### PR TITLE
Fix and test coupler show

### DIFF
--- a/src/CouplerState/coupler_state.jl
+++ b/src/CouplerState/coupler_state.jl
@@ -170,5 +170,7 @@ function Base.show(io::IO, coupler::CouplerState)
         entry = coupler.CplStateBlob[k]
         data[i,:] = [k entry.units entry.datetime entry.gridinfo.gridtype]
     end
-    pretty_table(data, ["Field Name" "Units" "Field Time (Y-m-d H:M:S)" "Grid Type"])
+    header = (["Field Name", "Units", "Field Time", "Grid Type"],
+                ["", "", "Y-m-d H:M:S", ""])
+    pretty_table(data, header = header)
 end

--- a/test/CouplerState/cplstate_interface.jl
+++ b/test/CouplerState/cplstate_interface.jl
@@ -13,6 +13,8 @@ using CouplerMachine, Dates, Unitful
     coupler_add_field!(coupler, :test2, data, nothing, date, u"km/hr")
     coupler_add_field!(coupler, :test3, data, nothing, date, u"°C")
 
+    @show coupler
+
     @testset "coupler_get" begin
         @test data === coupler_get(coupler, :test1, nothing, date, u"kg")
         # unit conversion


### PR DESCRIPTION
Adds `Base.show` for `CouplerState` to the test suite and updates to use non-deprecated `pretty_table` call.