### PR TITLE
Remove TC1 from docs examples.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,24 +7,24 @@ const OUTPUT_DIR = joinpath(@__DIR__, "src/generated")
 
 # tutorials & experiments
 # - generate tutorial files
-tutorial_dir = joinpath(EXPERIMENTS_DIR, "ClimaCore/tc1_heat-diffusion-with-slab/")
-tutorial_name = "run.jl"
-Pkg.activate(tutorial_dir)
-Pkg.instantiate()
-include(joinpath(tutorial_dir, tutorial_name))
-Literate.markdown(joinpath(tutorial_dir, tutorial_name), OUTPUT_DIR; execute = true, documenter = false)
+# tutorial_dir = joinpath(EXPERIMENTS_DIR, "ClimaCore/tc1_heat-diffusion-with-slab/")
+# tutorial_name = "run.jl"
+# Pkg.activate(tutorial_dir)
+# Pkg.instantiate()
+# include(joinpath(tutorial_dir, tutorial_name))
+# Literate.markdown(joinpath(tutorial_dir, tutorial_name), OUTPUT_DIR; execute = true, documenter = false)
 
 # - move tutorial files to docs/src
-IMAGE_DIR = joinpath(tutorial_dir, "images/")
-files = readdir(IMAGE_DIR)
-png_files = filter(endswith(".png"), files)
-for file in png_files
-    mkpath(joinpath(OUTPUT_DIR, "images/"))
-    cp(joinpath(IMAGE_DIR, file), joinpath(OUTPUT_DIR, "images/", file), force = true)
-end
+# IMAGE_DIR = joinpath(tutorial_dir, "images/")
+# files = readdir(IMAGE_DIR)
+# png_files = filter(endswith(".png"), files)
+# for file in png_files
+#     mkpath(joinpath(OUTPUT_DIR, "images/"))
+#     cp(joinpath(IMAGE_DIR, file), joinpath(OUTPUT_DIR, "images/", file), force = true)
+# end
 
 # pages layout
-experiment_pages = ["generated/run.md"]
+experiment_pages = []
 interface_pages = ["couplerstate.md", "timestepping.md"]
 
 pages = Any["Home" => "index.md", "Examples" => experiment_pages, "Coupler Interface" => interface_pages]


### PR DESCRIPTION
## Purpose and Content
Removes tc1 (heat equation + slab) from the docs as it now breaks. It should be replaced by the sea breeze which is cleaner, uses ClimaCoupler, and is checked by buildkite.

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
