### PR TITLE
Fix gitignore for Manifest files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/Manifest.toml
 
 # Temporary
 *.DS_Store
@@ -27,7 +28,7 @@ docs/src/generated/
 !docs/src/images/*.png
 
 # Experiments
-!experiments/AMIP/*/Manifest.toml
+!experiments/AMIP/**/Manifest.toml
 
 # Data
 *.vtk


### PR DESCRIPTION
Re-adds `Manifest.toml` files to the .gitignore. 

Fixes the pattern syntax so that Manifests within the AMIP experiments directory are not ignored and can be checked in.

A reminder that in general, Manifests should not be checked in unless we are not using registered versions of dependencies. If this is the case and a Manifest is needed, please add a line to the gitignore with prefix "!" which negates the following pattern rather than deleting Manifest exclusion from gitignore all-together (line 1 of the gitignore). Learn more about gitignore [here](https://git-scm.com/docs/gitignore). You can also always force-add files to git tracking.