### PR TITLE
Enable broadcasting with mismatched spaces.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,5 +5,6 @@ version = "0.1.0"
 
 [deps]
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"

--- a/src/ClimaCoupler.jl
+++ b/src/ClimaCoupler.jl
@@ -5,6 +5,18 @@ Coupling module sufficient for initial atmos-ocean-land coupled simulation.
 """
 module ClimaCoupler
 
+using ClimaCore
+import ClimaCore: Fields, Operators
+import Logging
+
+# Disable errors from broadcasting with mismatched spaces
+Fields.allow_mismatched_diagonalized_spaces() = true
+Operators.allow_mismatched_fd_spaces() = true
+
+function __init__()
+    Logging.disable_logging(Logging.Warn) # disable warnings (for broadcasting with mismatched spaces)
+end
+
 include("CoupledSimulations/clock.jl")
 include("CoupledSimulations/coupled_simulation.jl")
 include("CouplerState/coupler_state.jl")

--- a/test/general_tests.jl
+++ b/test/general_tests.jl
@@ -1,0 +1,31 @@
+using Test
+using ClimaCoupler
+import ClimaCore: Fields, Domains, Topologies, Meshes, Spaces, Geometry
+using IntervalSets
+
+function spectral_space_2D(; n1 = 1, n2 = 1, Nij = 4)
+    domain = Domains.RectangleDomain(
+        Geometry.XPoint(-1.0) .. Geometry.XPoint(1.0),
+        Geometry.YPoint(-1.0) .. Geometry.YPoint(1.0),
+        x1periodic = false,
+        x2periodic = false,
+        x1boundary = (:east, :west),
+        x2boundary = (:south, :north),
+    )
+    mesh = Meshes.RectilinearMesh(domain, n1, n2)
+    grid_topology = Topologies.Topology2D(mesh)
+
+    quad = Spaces.Quadratures.GLL{Nij}()
+    space = Spaces.SpectralElementSpace2D(grid_topology, quad)
+    return space
+end
+
+@testset "Enable Mismatched Space Broadcasting" begin
+    space1 = spectral_space_2D()
+    space2 = spectral_space_2D()
+    field1 = ones(space1)
+    field2 = 2 .* ones(space2)
+    @test Fields.is_diagonalized_spaces(typeof(space1), typeof(space2))
+    @test_nowarn field1 .= field2
+    @test parent(field1) == parent(field2)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+include("general_tests.jl")
 include("CoupledSimulations/clock.jl")
 include("CouplerState/cplstate_interface.jl")
 # include("CoupledSimulations/cplsolver.jl")


### PR DESCRIPTION
## Purpose and Content
Turns off broadcasting errors that stem from mismatched spaces using the tools from [ClimaCore#640](https://github.com/CliMA/ClimaCore.jl/pull/640#issuecomment-1139209023).

## Benefits and Risks
This is necessary to couple components without using `parent`. Will allow #60 to be addressed. Current risks surround warning suppression - to prevent a warnings from being printed each broadcast, warnings and below are disabled in the logger. A more target approach would be more useful to only hide warnings stemming from broadcasting with mismatched spaces.

## Linked Issues
- Closes #79 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
