### PR TITLE
upgrade climacore and climaatmos

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,4 +47,4 @@ steps:
 
       - label: "Moist earth"
         command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --energy_check=true --prescribed_sst=false --t_end=10000secs --dt_save_to_sol=200secs --dt_cpl=200"
-        artifact_paths: "moist_earth/"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/total_energy*.png"

--- a/experiments/AMIP/moist_mpi_earth/Manifest.toml
+++ b/experiments/AMIP/moist_mpi_earth/Manifest.toml
@@ -201,11 +201,9 @@ version = "0.1.3"
 
 [[deps.ClimaAtmos]]
 deps = ["ClimaCore", "ClimaCorePlots", "ClimaCoreVTK", "CloudMicrophysics", "DiffEqCallbacks", "Insolation", "IntervalSets", "JLD2", "LinearAlgebra", "OrdinaryDiffEq", "Pkg", "Printf", "StaticArrays", "Test", "Thermodynamics", "UnPack"]
-git-tree-sha1 = "9e04b2a0336b9861fd5b0af1455f9e3c795ab8ad"
-repo-rev = "7532e61eca8856e60ad91c719d3628a27c2c9b5d"
-repo-url = "https://github.com/CliMA/ClimaAtmos.jl.git"
+git-tree-sha1 = "1320c07f32a675fc4b83a81bf9d3c5add955f4df"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.1.0"
+version = "0.2.0"
 
 [[deps.ClimaComms]]
 deps = ["CUDA", "KernelAbstractions", "StaticArrays"]
@@ -220,10 +218,10 @@ uuid = "5f86816e-8b66-43b2-912e-75384f99de49"
 version = "0.3.2"
 
 [[deps.ClimaCore]]
-deps = ["Adapt", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DiffEqBase", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "InteractiveUtils", "IntervalSets", "LinearAlgebra", "RecursiveArrayTools", "RootSolvers", "Rotations", "SparseArrays", "Static", "StaticArrays", "Statistics", "UnPack"]
-git-tree-sha1 = "473da6d707d2f4efa92dc073ccbb170aa3750c9a"
+deps = ["Adapt", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DiffEqBase", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "InteractiveUtils", "IntervalSets", "LinearAlgebra", "RecursiveArrayTools", "RootSolvers", "Rotations", "SparseArrays", "Static", "StaticArrays", "Statistics", "UnPack"]
+git-tree-sha1 = "e73007e7dabe872d90819d7e0a0e78eedbeb2e53"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.10.5"
+version = "0.10.6"
 
 [[deps.ClimaCorePlots]]
 deps = ["ClimaCore", "RecipesBase", "StaticArrays", "TriplotBase"]
@@ -244,7 +242,7 @@ uuid = "c8b6d40d-e815-466f-95ae-c48aefa668fa"
 version = "0.7.1"
 
 [[deps.ClimaCoupler]]
-deps = ["PrettyTables", "SciMLBase"]
+deps = ["ClimaCore", "PrettyTables", "SciMLBase"]
 path = "../../.."
 uuid = "4ade58fe-a8da-486c-bd89-46df092ec0c7"
 version = "0.1.0"
@@ -707,6 +705,11 @@ deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Li
 git-tree-sha1 = "9b02998aba7bf074d14de89f9d37ca24a1a0b046"
 uuid = "78b55507-aeef-58d4-861c-77aaff3498b1"
 version = "0.21.0+0"
+
+[[deps.GilbertCurves]]
+git-tree-sha1 = "3e076ca96e34a47e98a46657b2bec2655a366d80"
+uuid = "88fa7841-ef32-4516-bb70-c6ec135699d9"
+version = "0.1.0"
 
 [[deps.Glib_jll]]
 deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE_jll", "Pkg", "Zlib_jll"]
@@ -1858,9 +1861,9 @@ version = "0.5.5"
 
 [[deps.WriteVTK]]
 deps = ["Base64", "CodecZlib", "FillArrays", "LightXML", "TranscodingStreams"]
-git-tree-sha1 = "bff2f6b5ff1e60d89ae2deba51500ce80014f8f6"
+git-tree-sha1 = "8c1e15c8c5b2b69648d2d5c89a1ede519199a0e6"
 uuid = "64499a7a-5c06-52f2-abe2-ccb03c286192"
-version = "1.14.2"
+version = "1.14.3"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]

--- a/experiments/AMIP/moist_mpi_earth/Project.toml
+++ b/experiments/AMIP/moist_mpi_earth/Project.toml
@@ -40,8 +40,5 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 TurbulenceConvection = "8e072fc4-01f8-44fb-b9dc-f9336c367e6b"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
-[compat]
-ClimaCore = "0.10.3"
-
 [extras]
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"

--- a/experiments/AMIP/moist_mpi_earth/cli_options.jl
+++ b/experiments/AMIP/moist_mpi_earth/cli_options.jl
@@ -168,6 +168,14 @@ function parse_commandline()
         help = "Viscous sponge coefficient"
         arg_type = Float64
         default = Float64(1e6)
+        "--apply_moisture_filter"
+        help = "Apply filter to moisture"
+        arg_type = Bool
+        default = false
+        "--disable_qt_hyperdiffusion"
+        help = "Disable the hyperdiffusion of specific humidity [`true`, `false` (default)] (TODO: reconcile this with ρe_tot or remove if instability fixed with limiters)"
+        arg_type = Bool
+        default = false
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
@@ -32,6 +32,11 @@ parsed_args["hyperdiff"] = true
 parsed_args["config"] = "sphere"
 parsed_args["moist"] = "equil"
 
+import ClimaCoupler
+pkg_dir = pkgdir(ClimaCoupler)
+coupler_output_dir = joinpath(pkg_dir, "experiments/AMIP/moist_mpi_earth")
+
+
 # Get the paths to the necessary data files - land sea mask, sst map, sea ice concentration
 include("artifacts.jl")
 
@@ -184,7 +189,12 @@ end
 
 @show "Postprocessing"
 if energy_check && !prescribed_sst
-    plot_global_energy(CS, coupler_sim, "total_energy_bucket.png", "total_energy_log_bucket.png")
+    plot_global_energy(
+        CS,
+        coupler_sim,
+        joinpath(coupler_output_dir, "total_energy_bucket.png"),
+        joinpath(coupler_output_dir, "total_energy_log_bucket.png"),
+    )
 end
 
 


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
Upgrade to latest CA release 0.2.0; requires latest CC 10.6
Also, fixed the buildkite run for the mpi earth so that the plots are saved correctly.

## Benefits and Risks
Remain up-to-date with CA.

