### PR TITLE
Add `coupler_push!` and `coupler_pull!` to Sea Breeze

### DIFF
--- a/experiments/ClimaCore/sea_breeze/atmos_rhs.jl
+++ b/experiments/ClimaCore/sea_breeze/atmos_rhs.jl
@@ -233,6 +233,19 @@ function AtmosSimulation(Y_init, t_start, dt, t_end, timestepper, p, saveat, cal
     return AtmosSimulation(atm_integ)
 end
 
+function ClimaCoupler.coupler_push!(coupler::ClimaCoupler.CouplerState, atmos::AtmosSimulation)
+    coupler_put!(coupler, :F_sfc, atmos.integrator.u.F_sfc, atmos)
+end
+
+function ClimaCoupler.coupler_pull!(atmos::AtmosSimulation, coupler::ClimaCoupler.CouplerState)
+    # pre: reset flux accumulator
+    atmos.integrator.u.F_sfc .= 0.0 # reset surface flux to be accumulated
+
+    T_sfc_ocean = coupler_get(coupler, :T_sfc_ocean, atmos)
+    T_sfc_land = coupler_get(coupler, :T_sfc_land, atmos)
+    atmos.integrator.p.T_sfc .= T_sfc_land .+ T_sfc_ocean
+end
+
 # init simulation
 function atm_init(; xmin = -500, xmax = 500, zmin = 0, zmax = 1000, npoly = 3, helem = 20, velem = 20, bc = nothing)
 

--- a/experiments/ClimaCore/sea_breeze/land_rhs.jl
+++ b/experiments/ClimaCore/sea_breeze/land_rhs.jl
@@ -37,6 +37,15 @@ function LandSimulation(Y_init, t_start, dt, t_end, timestepper, p, saveat, call
     return LandSimulation(lnd_integ)
 end
 
+function ClimaCoupler.coupler_push!(coupler::ClimaCoupler.CouplerState, land::LandSimulation)
+    coupler_put!(coupler, :T_sfc_land, land.integrator.u.T_sfc, land)
+end
+
+function ClimaCoupler.coupler_pull!(land::LandSimulation, coupler::ClimaCoupler.CouplerState)
+    coupler_get!(land.integrator.p.F_sfc, coupler, :F_sfc, land)
+    land.integrator.p.F_sfc ./= coupler.Δt_coupled
+end
+
 # init simulation
 function lnd_init(; xmin = -1000, xmax = 1000, helem = 20, npoly = 0)
 

--- a/experiments/ClimaCore/sea_breeze/ocean_rhs.jl
+++ b/experiments/ClimaCore/sea_breeze/ocean_rhs.jl
@@ -38,6 +38,15 @@ function OceanSimulation(Y_init, t_start, dt, t_end, timestepper, p, saveat, cal
     return OceanSimulation(ocn_integ)
 end
 
+function ClimaCoupler.coupler_push!(coupler::ClimaCoupler.CouplerState, ocean::OceanSimulation)
+    coupler_put!(coupler, :T_sfc_ocean, ocean.integrator.u.T_sfc, ocean)
+end
+
+function ClimaCoupler.coupler_pull!(ocean::OceanSimulation, coupler::ClimaCoupler.CouplerState)
+    coupler_get!(ocean.integrator.p.F_sfc, coupler, :F_sfc, ocean)
+    ocean.integrator.p.F_sfc ./= coupler.Δt_coupled
+end
+
 # init simulation
 function ocn_init(; xmin = -1000, xmax = 1000, helem = 20, npoly = 0)
 

--- a/experiments/ClimaCore/sea_breeze/run.jl
+++ b/experiments/ClimaCore/sea_breeze/run.jl
@@ -64,7 +64,7 @@ dss_callback = FunctionCallingCallback(dss_func, func_start = true)
 
 # timestepping
 t_start, t_end = (0.0, 1.0)
-cpl_Δt = 0.1
+Δt_coupled = 0.1
 saveat = 1e2
 atm_nsteps, ocn_nsteps, lnd_nsteps = (5, 1, 1)
 
@@ -104,19 +104,18 @@ lnd_F_sfc = Fields.zeros(lnd_domain)
 # init models
 atm_Y = Fields.FieldVector(Yc = atm_Y_default.Yc, ρw = atm_Y_default.ρw, F_sfc = atm_F_sfc)
 atm_p = (cpl_p = cpl_parameters, T_sfc = atm_T_sfc, bc = atm_bc)
-atmos = AtmosSimulation(atm_Y, t_start, cpl_Δt / atm_nsteps, t_end, SSPRK33(), atm_p, saveat, dss_callback)
+atmos = AtmosSimulation(atm_Y, t_start, Δt_coupled / atm_nsteps, t_end, SSPRK33(), atm_p, saveat, dss_callback)
 
 ocn_Y = Fields.FieldVector(T_sfc = ocn_Y_default.T_sfc)
 ocn_p = (cpl_parameters, F_sfc = ocn_F_sfc)
-ocean = OceanSimulation(ocn_Y, t_start, cpl_Δt / ocn_nsteps, t_end, SSPRK33(), ocn_p, saveat)
+ocean = OceanSimulation(ocn_Y, t_start, Δt_coupled / ocn_nsteps, t_end, SSPRK33(), ocn_p, saveat)
 
 lnd_Y = Fields.FieldVector(T_sfc = lnd_Y_default.T_sfc)
 lnd_p = (cpl_parameters, F_sfc = lnd_F_sfc)
-land = LandSimulation(lnd_Y, t_start, cpl_Δt / lnd_nsteps, t_end, SSPRK33(), lnd_p, saveat)
+land = LandSimulation(lnd_Y, t_start, Δt_coupled / lnd_nsteps, t_end, SSPRK33(), lnd_p, saveat)
 
 # coupled simulation
 struct AOLCoupledSimulation{
-    FT,
     A <: AtmosSimulation,
     O <: OceanSimulation,
     L <: LandSimulation,
@@ -130,12 +129,10 @@ struct AOLCoupledSimulation{
     land::L
     # Coupler storage
     coupler::C
-    # The coupled time step size
-    Δt::FT
 end
 
 # init coupler fields and maps
-coupler = CouplerState()
+coupler = CouplerState(Δt_coupled)
 coupler_add_field!(coupler, :T_sfc_ocean, ocean.integrator.u.T_sfc; write_sim = ocean)
 coupler_add_field!(coupler, :T_sfc_land, land.integrator.u.T_sfc; write_sim = land)
 coupler_add_field!(coupler, :F_sfc, atmos.integrator.u.F_sfc; write_sim = atmos)
@@ -143,9 +140,10 @@ for (name, map) in pairs(maps)
     coupler_add_map!(coupler, name, map)
 end
 
-sim = AOLCoupledSimulation(atmos, ocean, land, coupler, cpl_Δt)
+sim = AOLCoupledSimulation(atmos, ocean, land, coupler)
 
 # step for sims built on OrdinaryDiffEq
+# NOTE: use (t - integ_atm.t) here instead of Δt_cpl to avoid accumulating roundoff error in our timestepping.
 function step!(sim::ClimaCoupler.AbstractSimulation, t_stop)
     Δt = t_stop - sim.integrator.t
     step!(sim.integrator, Δt, true)
@@ -153,43 +151,24 @@ end
 
 function cpl_run(simulation::AOLCoupledSimulation)
     @info "Run model"
-    @unpack atmos, ocean, land, Δt = simulation
-    cpl_Δt = Δt
+    @unpack atmos, ocean, land, coupler = simulation
+    Δt_coupled = coupler.Δt_coupled
     # coupler stepping
-    for t in ((t_start + cpl_Δt):cpl_Δt:t_end)
-
+    for t in ((t_start + Δt_coupled):Δt_coupled:t_end)
         ## Atmos
-        # pre: reset flux accumulator
-        atmos.integrator.u.F_sfc .= 0.0 # reset surface flux to be accumulated
-        # don't want to alloc here..
-        T_sfc_ocean = coupler_get(coupler, :T_sfc_ocean, atmos)
-        T_sfc_land = coupler_get(coupler, :T_sfc_land, atmos)
-        atmos.integrator.p.T_sfc .= T_sfc_land .+ T_sfc_ocean
-
-        # run
-        # NOTE: use (t - integ_atm.t) here instead of Δt_cpl to avoid accumulating roundoff error in our timestepping.
+        coupler_pull!(atmos, coupler)
         step!(atmos, t)
-        coupler_put!(coupler, :F_sfc, atmos.integrator.u.F_sfc, atmos)
+        coupler_push!(coupler, atmos)
 
         ## Ocean
-        # pre: get accumulated flux from atmos
-        ocn_F_sfc = ocean.integrator.p.F_sfc
-        ocn_F_sfc .= coupler_get(coupler, :F_sfc, ocean) ./ cpl_Δt
-
-        # run
+        coupler_pull!(ocean, coupler)
         step!(ocean, t)
-        # post: send ocean surface temp to atmos
-        coupler_put!(coupler, :T_sfc_ocean, ocean.integrator.u.T_sfc, ocean)
+        coupler_push!(coupler, ocean)
 
         ## Land
-        # pre: get accumulated flux from atmos
-        lnd_F_sfc = land.integrator.p.F_sfc
-        lnd_F_sfc .= coupler_get(coupler, :F_sfc, land) ./ cpl_Δt
-
-        # run
+        coupler_pull!(land, coupler)
         step!(land, t)
-        # post: send land surface temp to atmos
-        coupler_put!(coupler, :T_sfc_land, land.integrator.u.T_sfc, land)
+        coupler_push!(coupler, land)
     end
     @info "Simulation Complete"
 end

--- a/src/CouplerState/coupler_state.jl
+++ b/src/CouplerState/coupler_state.jl
@@ -15,9 +15,13 @@ mutable struct CplFieldInfo{DT, MD}
     metadata::MD
 end
 
-mutable struct CouplerState{CF, RO}
+mutable struct CouplerState{FT, CF, RO}
+    # A dictionary of fields added to the coupler
     coupled_fields::CF
+    # A dictionary of remap operators between components
     remap_operators::RO
+    # The coupled timestep size
+    Δt_coupled::FT
 end
 
 _fields(coupler::CouplerState) = getfield(coupler, :coupled_fields)
@@ -32,8 +36,8 @@ etc... can be embeded in the intermdediate coupling layer.
 
 A field is exported by one component and imported by one or more other components.
 """
-function CouplerState()
-    return CouplerState(Dict{Symbol, CplFieldInfo}(), Dict{Symbol, Operators.LinearRemap}())
+function CouplerState(Δt_coupled)
+    return CouplerState(Dict{Symbol, CplFieldInfo}(), Dict{Symbol, Operators.LinearRemap}(), Δt_coupled)
 end
 
 """

--- a/test/CouplerState/cplstate_interface.jl
+++ b/test/CouplerState/cplstate_interface.jl
@@ -38,7 +38,7 @@ end
 
     simA = SimulationA(ones(spaceA))
     simB = SimulationB(zeros(spaceB))
-    coupler = CouplerState()
+    coupler = CouplerState(1.0)
 
     coupler_add_field!(coupler, :test1, simA.data; write_sim = simA)
 


### PR DESCRIPTION
## Purpose and Content
Adds `coupler_push!` and `coupler_pull!` methods for each component in the sea breeze demo. These methods wrap how each component interacts with the coupler (sending & receiving via `coupler_put` and `coupler_get`). 

This PR also moves the coupled time-step into the `CouplerState` struct so that it is accessible in the push/pull calls. 

## Benefits and Risks
Push/pull: A major benefit is the conciseness of the main driver loop - which now consists of only `coupler_push!`, `step!` and `coupler_pull!` calls. This means we can standardize the simulation run loop and develop a set of general coupled timesteppers that take some inputted component order. This may not be a high priority as custom coupled steppers and schemes will be useful.

Coupled timestep storage: As the coupled timestepping info becomes more well defined, this may need to be refined (e.g. a CoupledTimestepper struct that could pair with the `CouplerState` struct as a full `Coupler`). This will likely be determined by how accumulation is ultimately handled.

## Linked Issues
Part of #44 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
