### PR TITLE
Separate regridding from file reader

### DIFF
--- a/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
@@ -83,9 +83,9 @@ end
 
 if prescribed_sst
     println("No ocean sim - do not expect energy conservation")
-    SST =
-        ncreader_rll_to_cgll_from_space(FT, time_slice_ncfile(sst_data), "SST", boundary_space, outfile = "sst_cgll.nc")  # a sample SST field
-
+    weightfile, datafile_cgll, regrid_space =
+        ncreader_rll_to_cgll_from_space(sst_data, "SST", boundary_space, outfile = "sst_cgll.nc")
+    SST = ncreader_cgll_sparse_to_field(datafile_cgll, "SST", weightfile, (Int(1),), regrid_space)[1]
     SST = swap_space!(SST, axes(mask)) .* (abs.(mask .- 1)) .+ FT(273.15)
 
     ocean_params = OceanSlabParameters(FT(20), FT(1500.0), FT(800.0), FT(280.0), FT(1e-3), FT(1e-5), FT(0.06))
@@ -98,9 +98,9 @@ else
 end
 
 # Currently, we only support a slab ice model with fixed area and depth.
-
-SIC =
-    ncreader_rll_to_cgll_from_space(FT, time_slice_ncfile(sic_data), "SEAICE", boundary_space, outfile = "sic_cgll.nc")
+weightfile, datafile_cgll, regrid_space =
+    ncreader_rll_to_cgll_from_space(sic_data, "SEAICE", boundary_space, outfile = "sic_cgll.nc")
+SIC = ncreader_cgll_sparse_to_field(datafile_cgll, "SEAICE", weightfile, (Int(1),), regrid_space)[1]
 SIC = swap_space!(SIC, axes(mask)) .* (abs.(mask .- 1))
 ice_mask = get_ice_mask.(SIC .- FT(25), FT) # here 25% and lower is considered ice free
 

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/masker.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/masker.jl
@@ -1,9 +1,7 @@
-function LandSeaMask(FT, infile, varname, h_space; outfile = "land_sea_cgll.nc", threshold = 0.7)
-    R = h_space.topology.mesh.domain.radius
-    ne = h_space.topology.mesh.ne
-    Nq = Spaces.Quadratures.polynomial_degree(h_space.quadrature_style) + 1
-
-    mask = ncreader_rll_to_cgll(FT, infile, varname, ne = ne, R = R, Nq = Nq, outfile = outfile)
+function LandSeaMask(FT, infile, varname, boundary_space; outfile = "land_sea_cgll.nc", threshold = 0.7)
+    weightfile, datafile_cgll, regrid_space =
+        ncreader_rll_to_cgll_from_space(infile, varname, boundary_space, outfile = outfile)
+    mask = ncreader_cgll_sparse_to_field(datafile_cgll, varname, weightfile, (Int(1),), regrid_space)[1]
     mask = clean_mask.(FT, mask, threshold)
 end
 


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

This PR re-organises the regridding `coupler_utils`, so that regridding is separate from reading the regridded output from `TempestRemap`. 

- note that mesh generation with the space-filling curve breaks the regridding order required in `TempestRemap`. This was fixed with specifying a `regrid_space` using the previous method of mesh generation. However, this should be generalized in the future.  

## Benefits and Risks
- benefit: this will enable a monthly callback for temporal interpolation 
- risk: few more lines to the interface (though this will be removed by the following PR)

## Linked Issues
- SDI: #74 
- Design: #88

## Dependent PRs
- [x] do not merge before  #87 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
