### PR TITLE
Interface changes pulled from #90

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,5 +46,5 @@ steps:
         artifact_paths: "sea_breeze/"
 
       - label: "Moist earth"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --energy_check=true --prescribed_sst=false --t_end=10000secs --dt_save_to_sol=200secs --dt_cpl=200"
+        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --energy_check=true --mode_name=aquaplanet --t_end=10000secs --dt_save_to_sol=200secs --dt_cpl=200"
         artifact_paths: "experiments/AMIP/moist_mpi_earth/total_energy*.png"

--- a/experiments/AMIP/moist_mpi_earth/cli_options.jl
+++ b/experiments/AMIP/moist_mpi_earth/cli_options.jl
@@ -14,10 +14,10 @@ function parse_commandline()
         help = "Boolean flag indicating whether to check energy conservation"
         arg_type = Bool
         default = false
-        "--prescribed_sst"
-        help = "Boolean flag indicating whether to run with a prescribed sea surface temperature"
-        arg_type = Bool
-        default = false
+        "--mode_name"
+        help = "Mode of coupled simulation. [`amip`, `aquaplanet`]"
+        arg_type = String
+        default = "aquaplanet"
         "--FLOAT_TYPE"
         help = "Float type"
         arg_type = String

--- a/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
@@ -11,11 +11,12 @@ using Dates
 
 include("cli_options.jl")
 (s, parsed_args) = parse_commandline()
+
 # Read in some parsed args
-prescribed_sst = parsed_args["prescribed_sst"]
+mode_name = parsed_args["mode_name"]
 energy_check = parsed_args["energy_check"]
 const FT = parsed_args["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
-land_sim = "bucket"
+land_sim_name = "bucket"
 t_end = FT(time_to_seconds(parsed_args["t_end"]))
 tspan = (0, t_end)
 Δt_cpl = FT(parsed_args["dt_cpl"])
@@ -62,7 +63,6 @@ atmos_sim = atmos_init(FT, Y, integrator, params = params);
 boundary_space = ClimaCore.Fields.level(atmos_sim.domain.face_space, half) # global surface grid
 
 # init land-sea mask
-
 mask = LandSeaMask(FT, mask_data, "LSMASK", boundary_space)
 mask = swap_space!(mask, boundary_space) # needed if we are reading from previous run
 
@@ -74,147 +74,153 @@ include("slab/slab_init.jl")
 include("slab_ocean/slab_init.jl")
 include("slab_ice/slab_init.jl")
 
-if land_sim == "slab"
-    slab_sim = slab_init(FT; tspan, dt = Δt_cpl, space = boundary_space, saveat = saveat, mask = mask)
+if land_sim_name == "slab"
+    land_sim = slab_init(FT; tspan, dt = Δt_cpl, space = boundary_space, saveat = saveat, mask = mask)
 end
-if land_sim == "bucket"
-    slab_sim = bucket_init(FT, FT.(tspan); dt = FT(Δt_cpl), space = boundary_space, saveat = FT(saveat))
+if land_sim_name == "bucket"
+    land_sim = bucket_init(FT, FT.(tspan); dt = FT(Δt_cpl), space = boundary_space, saveat = FT(saveat))
 end
 
-if prescribed_sst
+if mode_name == "amip"
     println("No ocean sim - do not expect energy conservation")
+
+    # ocean
     weightfile, datafile_cgll, regrid_space =
         ncreader_rll_to_cgll_from_space(sst_data, "SST", boundary_space, outfile = "sst_cgll.nc")
-    SST = ncreader_cgll_sparse_to_field(datafile_cgll, "SST", weightfile, (Int(1),), regrid_space)[1]
-    SST = swap_space!(SST, axes(mask)) .* (abs.(mask .- 1)) .+ FT(273.15)
+    SST_init = ncreader_cgll_sparse_to_field(datafile_cgll, "SST", weightfile, (Int(1),), regrid_space)[1]
+    SST_init = swap_space!(SST_init, axes(mask)) .* (abs.(mask .- 1)) .+ FT(273.15)
 
     ocean_params = OceanSlabParameters(FT(20), FT(1500.0), FT(800.0), FT(280.0), FT(1e-3), FT(1e-5), FT(0.06))
-    slab_ocean_sim = nothing
+    ocean_sim = (; integrator = (; u = (; T_sfc = SST_init), p = (; params = ocean_params)))
+    mode_specifics = (; name = mode_name)
+
+    # sea ice
+    # (Currently, we only support a slab ice model with fixed area and depth.)
+    weightfile, datafile_cgll, regrid_space =
+        ncreader_rll_to_cgll_from_space(sic_data, "SEAICE", boundary_space, outfile = "sic_cgll.nc")
+    SIC = ncreader_cgll_sparse_to_field(datafile_cgll, "SEAICE", weightfile, (Int(1),), regrid_space)[1]
+    SIC = swap_space!(SIC, axes(mask)) .* (abs.(mask .- 1))
+    ice_mask = get_ice_mask.(SIC .- FT(25), FT) # here 25% and lower is considered ice free
+
+    ice_sim = ice_init(FT; tspan = tspan, dt = Δt_cpl, space = boundary_space, saveat = saveat, ice_mask = ice_mask)
+
 else
-    slab_ocean_sim =
-        slab_ocean_init(FT; tspan = tspan, dt = Δt_cpl, space = boundary_space, saveat = saveat, mask = mask)
-    SST = nothing
-    ocean_params = nothing
+    # ocean
+    ocean_sim = ocean_init(FT; tspan = tspan, dt = Δt_cpl, space = boundary_space, saveat = saveat, mask = mask)
+
+    # sea ice
+    ice_sim = (;
+        integrator = (;
+            u = (; T_sfc = ClimaCore.Fields.zeros(boundary_space)),
+            p = (; params = ocean_sim.params, Ya = (; ice_mask = ClimaCore.Fields.zeros(boundary_space))),
+        )
+    )
+    mode_specifics = (; name = mode_name)
 end
 
-# Currently, we only support a slab ice model with fixed area and depth.
-weightfile, datafile_cgll, regrid_space =
-    ncreader_rll_to_cgll_from_space(sic_data, "SEAICE", boundary_space, outfile = "sic_cgll.nc")
-SIC = ncreader_cgll_sparse_to_field(datafile_cgll, "SEAICE", weightfile, (Int(1),), regrid_space)[1]
-SIC = swap_space!(SIC, axes(mask)) .* (abs.(mask .- 1))
-ice_mask = get_ice_mask.(SIC .- FT(25), FT) # here 25% and lower is considered ice free
-
-slab_ice_sim =
-    slab_ice_init(FT; tspan = tspan, dt = Δt_cpl, space = boundary_space, saveat = saveat, ice_mask = ice_mask)
-
-
 # init coupler
-coupler_sim = CouplerSimulation(FT(Δt_cpl), integrator.t, boundary_space, FT, mask)
+coupler_field_names = (:T_S, :z0m_S, :z0b_S, :ρ_sfc, :q_sfc, :albedo, :F_A, :F_E, :F_R, :P_liq)
+coupler_fields =
+    NamedTuple{coupler_field_names}(ntuple(i -> ClimaCore.Fields.zeros(boundary_space), length(coupler_field_names)))
+model_sims = (atm = atmos_sim, ice = ice_sim, lnd = land_sim, ocn = ocean_sim)
+dates = (; date = [date], date0 = [date0], date1 = [date1])
+
+coupler_sim = CouplerSimulation(
+    FT(Δt_cpl),
+    integrator.t,
+    dates,
+    boundary_space,
+    FT,
+    mask,
+    coupler_fields,
+    model_sims,
+    mode_specifics,
+    parsed_args,
+);
+
 include("./push_pull.jl")
 
 # init conservation info collector
-atmos_pull!(
-    atmos_sim,
-    slab_ice_sim,
-    slab_sim,
-    slab_ocean_sim,
-    boundary_space,
-    prescribed_sst,
-    z0m_S,
-    z0b_S,
-    T_S,
-    ρ_sfc,
-    q_sfc,
-    ocean_params,
-    SST,
-    mask,
-)
-
-atmos_push!(atmos_sim, boundary_space, F_A, F_R, F_E, P_liq, parsed_args)
-land_pull!(slab_sim, F_A, F_R, F_E, P_liq, ρ_sfc)
-ice_pull!(slab_ice_sim, F_A, F_R)
-if !prescribed_sst
-    ocean_pull!(slab_ocean_sim, F_A, F_R)
-    reinit!(slab_ocean_sim.integrator)
-end
-
+atmos_pull!(coupler_sim)
+atmos_push!(coupler_sim)
+land_pull!(coupler_sim)
 reinit!(atmos_sim.integrator)
-reinit!(slab_sim.integrator)
-reinit!(slab_ice_sim.integrator)
-if !is_distributed && energy_check && !prescribed_sst
-    CS = OnlineConservationCheck([], [], [], [], [], [])
-    check_conservation(CS, coupler_sim, atmos_sim, slab_sim, slab_ocean_sim, slab_ice_sim)
+reinit!(land_sim.integrator)
+
+mode_name == "amip" ? (ice_pull!(coupler_sim), reinit!(ice_sim.integrator)) :
+(ocean_pull!(coupler_sim), reinit!(ocean_sim.integrator))
+
+if !is_distributed && energy_check && mode_name == "aquaplanet"
+    conservation_check = OnlineConservationCheck([], [], [], [], [], [])
+    check_conservation(conservation_check, coupler_sim, atmos_sim, land_sim, ocean_sim, ice_sim) # TODO: check this still works for aquaplanet after AMIP
 end
 
 # coupling loop
 @show "Starting coupling loop"
 
+# step in time
 walltime = @elapsed for t in ((tspan[1] + Δt_cpl):Δt_cpl:tspan[end])
+    cs = coupler_sim
 
     date = current_date(t)
 
     @calendar_callback :(@show(date), date1 += Dates.Month(1)) date date1
 
     ## Atmos
-    atmos_pull!(
-        atmos_sim,
-        slab_ice_sim,
-        slab_sim,
-        slab_ocean_sim,
-        boundary_space,
-        prescribed_sst,
-        z0m_S,
-        z0b_S,
-        T_S,
-        ρ_sfc,
-        q_sfc,
-        ocean_params,
-        SST,
-        mask,
-    )
+    atmos_pull!(cs)
     step!(atmos_sim.integrator, t - atmos_sim.integrator.t, true) # NOTE: instead of Δt_cpl, to avoid accumulating roundoff error
 
-    atmos_push!(atmos_sim, boundary_space, F_A, F_R, F_E, P_liq, parsed_args)
+    atmos_push!(cs)
 
     ## Slab land
-    land_pull!(slab_sim, F_A, F_R, F_E, P_liq, ρ_sfc)
-    step!(slab_sim.integrator, t - slab_sim.integrator.t, true)
+    land_pull!(cs)
+    step!(land_sim.integrator, t - land_sim.integrator.t, true)
 
     ## Slab ocean
-    if !prescribed_sst
-        ocean_pull!(slab_ocean_sim, F_A, F_R)
-        step!(slab_ocean_sim.integrator, t - slab_ocean_sim.integrator.t, true)
+    if cs.mode.name == "aquaplanet"
+        ocean_pull!(cs)
+        step!(ocean_sim.integrator, t - ocean_sim.integrator.t, true)
     end
 
     ## Slab ice
-    ice_pull!(slab_ice_sim, F_A, F_R)
-    step!(slab_ice_sim.integrator, t - slab_ice_sim.integrator.t, true)
+    if cs.mode.name == "amip"
+        ice_pull!(cs)
+        step!(ice_sim.integrator, t - ice_sim.integrator.t, true)
+    end
 
     ## Compute energy
-    if !is_distributed && energy_check && !prescribed_sst
-        check_conservation(CS, coupler_sim, atmos_sim, slab_sim, slab_ocean_sim, slab_ice_sim)
+    if !is_distributed && energy_check && cs.mode.name == "aquaplanet"
+        check_conservation(conservation_check, cs, atmos_sim, land_sim, ocean_sim, ice_sim)
     end
+
 end
 
 @show walltime
 
 @show "Postprocessing"
-if energy_check && !prescribed_sst
+if energy_check && coupler_sim.mode.name == "aquaplanet"
     plot_global_energy(
-        CS,
+        conservation_check,
         coupler_sim,
         joinpath(coupler_output_dir, "total_energy_bucket.png"),
         joinpath(coupler_output_dir, "total_energy_log_bucket.png"),
     )
 end
 
-
-@show P_liq
+@show coupler_sim.fields.P_liq
 # # animations
-if (land_sim == "bucket") && parsed_args["anim"]
+if (land_sim_name == "bucket") && parsed_args["anim"]
     #make it so this works with slab land?
     include("coupler_utils/viz_explorer.jl")
-    plot_anim(atmos_sim, slab_sim, slab_ocean_sim, slab_ice_sim, mask, prescribed_sst, SST)
+    plot_anim(
+        coupler_sim.model_sims.atm,
+        coupler_sim.model_sims.lnd,
+        coupler_sim.model_sims.ocn,
+        coupler_sim.model_sims.ice,
+        coupler_sim.mask,
+        coupler_sim.mode.name,
+        coupler_sim.fields.T_S,
+    )
 end
 
 # Cleanup temporary files

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/conservation_checker.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/conservation_checker.jl
@@ -35,7 +35,7 @@ of the coupled simulations, and updates cs with the values.
 Note: in the future this should not use ``push!``.
 """
 function check_conservation(
-    cs::OnlineConservationCheck,
+    cc::OnlineConservationCheck,
     coupler_sim,
     atmos_sim,
     land_sim = nothing,
@@ -51,7 +51,7 @@ function check_conservation(
     Δz_bot = FT(0.5) * (z[2, 1, 1, 1, 1] - z[1, 1, 1, 1, 1])
 
     u_atm = atmos_sim.integrator.u.c.ρe_tot
-    T_land = land_sim !== nothing ? get_land_temp(slab_sim) : nothing
+    T_land = land_sim !== nothing ? get_land_temp(land_sim) : nothing
     u_lnd = land_sim !== nothing ? swap_space!(T_land, coupler_sim.boundary_space) : nothing
     u_ocn = ocean_sim !== nothing ? swap_space!(ocean_sim.integrator.u.T_sfc, coupler_sim.boundary_space) : nothing
     u_ice = seaice_sim !== nothing ? swap_space!(seaice_sim.integrator.u.T_sfc, coupler_sim.boundary_space) : nothing
@@ -79,14 +79,14 @@ function check_conservation(
 
         radiation_sources = -sum(SWd_TOA .- LWu_TOA .- SWu_TOA) ./ Δz_top
         radiation_sources_accum =
-            size(cs.toa_net_source)[1] > 0 ? cs.toa_net_source[end] + radiation_sources .* coupler_sim.Δt :
+            size(cc.toa_net_source)[1] > 0 ? cc.toa_net_source[end] + radiation_sources .* coupler_sim.Δt :
             radiation_sources .* coupler_sim.Δt# accumulated radiation sources + sinks
-        push!(cs.toa_net_source, radiation_sources_accum)
+        push!(cc.toa_net_source, radiation_sources_accum)
     end
 
 
     # Save atmos
-    push!(cs.ρe_tot_atmos, atmos_e)
+    push!(cc.ρe_tot_atmos, atmos_e)
 
     # Surface masks
     univ_mask = parent(coupler_sim.mask) .- parent(seaice_sim.integrator.p.Ya.ice_mask .* FT(2))
@@ -97,11 +97,11 @@ function check_conservation(
     # Save land
     parent(u_lnd) .= land_mask.(parent(u_lnd), univ_mask)
     land_e = land_sim !== nothing ? sum(get_land_energy(land_sim, u_lnd)) ./ Δz_bot : FT(0)
-    push!(cs.ρe_tot_land, land_e)
+    push!(cc.ρe_tot_land, land_e)
 
     parent(u_ice) .= ice_mask.(parent(u_ice), univ_mask)
     seaice_e = seaice_sim !== nothing ? sum(get_slab_energy(seaice_sim, u_ice)) ./ Δz_bot : FT(0)
-    push!(cs.ρe_tot_seaice, seaice_e)
+    push!(cc.ρe_tot_seaice, seaice_e)
 
     if ocean_sim != nothing
         parent(u_ocn) .= ocean_mask.(parent(u_ocn), univ_mask)
@@ -110,7 +110,7 @@ function check_conservation(
         ocean_e = FT(0)
     end
 
-    push!(cs.ρe_tot_ocean, ocean_e)
+    push!(cc.ρe_tot_ocean, ocean_e)
 
 
 end
@@ -140,11 +140,11 @@ function plot_global_energy(CS, coupler_sim, figname1 = "total_energy.png", fign
     diff_ρe_tot_slab_ocean = (CS.ρe_tot_ocean .- CS.ρe_tot_ocean[1])
 
     times_days = times ./ (24 * 60 * 60)
-    Plots.plot(times_days, diff_ρe_tot_atmos, label = "atmos")
-    Plots.plot!(times_days, diff_ρe_tot_slab, label = "land")
-    Plots.plot!(times_days, diff_ρe_tot_slab_seaice, label = "seaice")
-    Plots.plot!(times_days, diff_toa_net_source, label = "toa")
-    Plots.plot!(times_days, diff_ρe_tot_slab_ocean, label = "ocean")
+    Plots.plot(times_days, diff_ρe_tot_atmos[1:length(times_days)], label = "atmos")
+    Plots.plot!(times_days, diff_ρe_tot_slab[1:length(times_days)], label = "land")
+    Plots.plot!(times_days, diff_ρe_tot_slab_seaice[1:length(times_days)], label = "seaice")
+    Plots.plot!(times_days, diff_toa_net_source[1:length(times_days)], label = "toa")
+    Plots.plot!(times_days, diff_ρe_tot_slab_ocean[1:length(times_days)], label = "ocean")
 
     tot = CS.ρe_tot_atmos .+ CS.ρe_tot_ocean .+ CS.ρe_tot_land .+ CS.ρe_tot_seaice .+ CS.toa_net_source
 

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/general_helper.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/general_helper.jl
@@ -1,14 +1,18 @@
 # most of these functions are temporary helpers until upstream issues are resolved
 
 # TODO: unify with coupler interface
-struct CouplerSimulation{I, F, B, T, M}
+struct CouplerSimulation{I, F, D, B, T, M, P}
     Δt::I
     t::F
+    dates::D
     boundary_space::B
     FT::T
     mask::M
+    fields::NamedTuple
+    model_sims::NamedTuple
+    mode::NamedTuple
+    parsed_args::P
 end
-
 
 function swap_space!(field, new_space)
     field_out = zeros(new_space)

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/viz_explorer.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/viz_explorer.jl
@@ -1,6 +1,6 @@
 using ClimaCorePlots
 
-function plot_anim(atmos_sim, slab_sim, slab_ocean_sim, slab_ice_sim, land_sea_mask, prescribed_sst, SST)
+function plot_anim(atmos_sim, slab_sim, slab_ocean_sim, slab_ice_sim, land_sea_mask, mode_name, SST)
     sol_atm = atmos_sim.integrator.sol
 
     anim = Plots.@animate for u in sol_atm.u
@@ -44,7 +44,7 @@ function plot_anim(atmos_sim, slab_sim, slab_ocean_sim, slab_ice_sim, land_sea_m
     FT = eltype(land_sea_mask)
     univ_mask = parent(land_sea_mask) .- parent(slab_ice_sim.integrator.p.Ya.ice_mask .* FT(2))
 
-    if !prescribed_sst
+    if mode_name == "aquaplanet"
         sol_slab_ocean = slab_ocean_sim.integrator.sol
 
         anim = Plots.@animate for (bucketu, oceanu, iceu) in zip(sol_slab.u, sol_slab_ocean.u, sol_slab_ice.u)
@@ -54,7 +54,7 @@ function plot_anim(atmos_sim, slab_sim, slab_ocean_sim, slab_ice_sim, land_sea_m
 
             Plots.plot(T_S)
         end
-    else
+    elseif mode_name == "amip"
         anim = Plots.@animate for (bucketu, iceu) in zip(sol_slab.u, sol_slab_ice.u)
             parent(combined_field) .=
                 combine_surface.(FT, univ_mask, parent(bucketu.bucket.T_sfc), parent(SST), parent(iceu.T_sfc))

--- a/experiments/AMIP/moist_mpi_earth/push_pull.jl
+++ b/experiments/AMIP/moist_mpi_earth/push_pull.jl
@@ -1,180 +1,152 @@
-T_S = ClimaCore.Fields.zeros(boundary_space) # temperature
-z0m_S = ClimaCore.Fields.zeros(boundary_space)
-z0b_S = ClimaCore.Fields.zeros(boundary_space)
-ρ_sfc = ClimaCore.Fields.zeros(boundary_space)
-q_sfc = ClimaCore.Fields.zeros(boundary_space)
-albedo = ClimaCore.Fields.zeros(boundary_space)
-
-F_A = ClimaCore.Fields.zeros(boundary_space) # aerodynamic turbulent fluxes
-F_E = ClimaCore.Fields.zeros(boundary_space) # aerodynamic turbulent fluxes
-F_R = ClimaCore.Fields.zeros(boundary_space) # radiative fluxes
-P_liq = ClimaCore.Fields.zeros(boundary_space) # m/s precip
 """
-   atmos_push!(atmos_sim, boundary_space, F_A, F_R, F_E, P_liq, parsed_args)
-
+   atmos_push!(cs)
 updates F_A, F_R, P_liq, and F_E in place based on values used in the atmos_sim for the current step.
 """
-function atmos_push!(atmos_sim, boundary_space, F_A, F_R, F_E, P_liq, parsed_args)
-    F_A .= ClimaCore.Fields.zeros(boundary_space)
-    dummmy_remap!(F_A, atmos_sim.integrator.p.dif_flux_energy)
-    F_E .= ClimaCore.Fields.zeros(boundary_space)
-    dummmy_remap!(F_E, atmos_sim.integrator.p.dif_flux_ρq_tot)
-    P_liq .= ClimaCore.Fields.zeros(boundary_space)
-    dummmy_remap!(P_liq, atmos_sim.integrator.p.col_integrated_precip)
-    F_R .= ClimaCore.Fields.zeros(boundary_space)
-    parsed_args["rad"] == "gray" ? dummmy_remap!(F_R, level(atmos_sim.integrator.p.ᶠradiation_flux, half)) : nothing
+function atmos_push!(cs)
+    atmos_sim = cs.model_sims.atm
+    csf = cs.fields
+    dummmy_remap!(csf.F_A, atmos_sim.integrator.p.dif_flux_energy)
+    dummmy_remap!(csf.F_E, atmos_sim.integrator.p.dif_flux_ρq_tot)
+    dummmy_remap!(csf.P_liq, atmos_sim.integrator.p.col_integrated_precip)
+    cs.parsed_args["rad"] == "gray" ? dummmy_remap!(csf.F_R, level(atmos_sim.integrator.p.ᶠradiation_flux, half)) :
+    nothing
 end
 
 """
-   land_pull!(slab_sim::SlabSimulation, F_A, F_R, _...)
-
+   land_pull!(cs)
 Updates the slab_sim cache state in place with the current values of F_A and F_R.
 """
-function land_pull!(slab_sim::SlabSimulation, F_A, F_R, _...)
-    @. slab_sim.integrator.p.F_aero = F_A
-    @. slab_sim.integrator.p.F_rad = F_R
+function land_pull!(cs)
+    slab_sim = cs.model_sims.lnd
+    csf = cs.fields
+    @. slab_sim.integrator.p.F_aero = csf.F_A
+    @. slab_sim.integrator.p.F_rad = csf.F_R
 end
 
 """
-   land_pull!(slab_sim::BucketSimulation, F_A, F_R, F_E, P_liq, ρ_sfc)
-
+   land_pull!(cs)
 Updates the slab_sim cache state in place with the current values of F_A, F_R, F_E, P_liq, and ρ_sfc.
-
 The surface air density is computed using the atmospheric state at the first level and making ideal gas
 and hydrostatic balance assumptions. The land model does not compute the surface air density so this is
 a reasonable stand-in.
 """
-function land_pull!(slab_sim::BucketSimulation, F_A, F_R, F_E, P_liq, ρ_sfc)
-    FT = eltype(F_A)
-    @. slab_sim.integrator.p.bucket.ρ_sfc = ρ_sfc
-    @. slab_sim.integrator.p.bucket.SHF = F_A
+function land_pull!(cs)
+    slab_sim = cs.model_sims.lnd
+    csf = cs.fields
+    FT = cs.FT
+    @. slab_sim.integrator.p.bucket.ρ_sfc = csf.ρ_sfc
+    @. slab_sim.integrator.p.bucket.SHF = csf.F_A
     @. slab_sim.integrator.p.bucket.LHF = FT(0.0)
     ρ_liq = (LSMP.ρ_cloud_liq(slab_sim.params.earth_param_set))
-    @. slab_sim.integrator.p.bucket.E = F_E / ρ_liq
-    @. slab_sim.integrator.p.bucket.R_n = F_R
-    @. slab_sim.integrator.p.bucket.P_liq = FT(-1.0) .* P_liq # land expects this to be positive
+    @. slab_sim.integrator.p.bucket.E = csf.F_E / ρ_liq
+    @. slab_sim.integrator.p.bucket.R_n = csf.F_R
+    @. slab_sim.integrator.p.bucket.P_liq = FT(-1.0) .* csf.P_liq # land expects this to be positive
 end
 
 """
-   ocean_pull!(slab_ocean_sim, F_A, F_R)
-
-Updates the slab_ocean_sim cache state in place with the current values of F_A and F_R.
-
+   ocean_pull!(cs)
+Updates the ocean_sim cache state in place with the current values of F_A and F_R.
 The ocean model does not require moisture fluxes at the surface, so F_E is not returned.
 """
-function ocean_pull!(slab_ocean_sim, F_A, F_R)
-    @. slab_ocean_sim.integrator.p.F_aero = F_A
-    @. slab_ocean_sim.integrator.p.F_rad = F_R
+function ocean_pull!(cs)
+    ocean_sim = cs.model_sims.ocn
+    csf = cs.fields
+    @. ocean_sim.integrator.p.F_aero = csf.F_A
+    @. ocean_sim.integrator.p.F_rad = csf.F_R
 end
 
 """
-   ice_pull!(slab_ice_sim, F_A, F_R)
-
-Updates the slab_ice_sim cache state in place with the current values of F_A and F_R.
-
+   ice_pull!(cs)
+Updates the ice_sim cache state in place with the current values of F_A and F_R.
 In the current version, the sea ice has a prescribed thickness, and we assume that it is not
 sublimating. That contribution has been zeroed out in the atmos fluxes.
 """
-function ice_pull!(slab_ice_sim, F_A, F_R)
-    @. slab_ice_sim.integrator.p.Ya.F_aero = F_A
-    @. slab_ice_sim.integrator.p.Ya.F_rad = F_R
+function ice_pull!(cs)
+    ice_sim = cs.model_sims.ice
+    csf = cs.fields
+    @. ice_sim.integrator.p.Ya.F_aero = csf.F_A
+    @. ice_sim.integrator.p.Ya.F_rad = csf.F_R
 end
 
 """
-   atmos_pull!(atmos_sim,
-               slab_ice_sim,
-               slab_sim,
-               slab_ocean_sim,
-               boundary_space,
-               prescribed_sst,
-               z0m_S,
-               z0b_S,
-               T_S,
-               ρ_sfc,
-               q_sfc,
-               ocean_params,
-               SST,
-               land_sea_mask
-              )
+   atmos_pull!(cs)
+              
 Creates the surface fields for temperature, roughness length, albedo, and specific humidity; computes
 turbulent surface fluxes; updates the atmosphere boundary flux cache variables in place; updates the
 RRTMGP cache variables in place.
 """
-function atmos_pull!(
-    atmos_sim,
-    slab_ice_sim,
-    slab_sim,
-    slab_ocean_sim,
-    boundary_space,
-    prescribed_sst,
-    z0m_S,
-    z0b_S,
-    T_S,
-    ρ_sfc,
-    q_sfc,
-    ocean_params,
-    SST,
-    land_sea_mask,
-)
+function atmos_pull!(cs)
+
+    atmos_sim = cs.model_sims.atm
+    slab_sim = cs.model_sims.lnd
+    ocean_sim = cs.model_sims.ocn
+    ice_sim = cs.model_sims.ice
+
+    csf = cs.fields
+    T_sfc_cpl = csf.T_S
+    z0m_cpl = csf.z0m_S
+    z0b_cpl = csf.z0b_S
+    ρ_sfc_cpl = csf.ρ_sfc
+    q_sfc_cpl = csf.q_sfc
+    albedo_sfc_cpl = csf.albedo
+
     thermo_params = CAP.thermodynamics_params(atmos_sim.integrator.p.params)
 
-    univ_mask = parent(land_sea_mask) .- parent(slab_ice_sim.integrator.p.Ya.ice_mask .* FT(2))
     T_land = get_land_temp(slab_sim)
     z0m_land, z0b_land = get_land_roughness(slab_sim)
+    T_ocean = ocean_sim.integrator.u.T_sfc
+    z0m_ocean = ocean_sim.integrator.p.params.z0m
+    z0b_ocean = ocean_sim.integrator.p.params.z0b
+    α_ocean = ocean_sim.integrator.p.params.α
+    T_ice = ice_sim.integrator.u.T_sfc
+    ice_mask = ice_sim.integrator.p.Ya.ice_mask
+    z0m_ice = ice_sim.integrator.p.params.z0m
+    z0b_ice = ice_sim.integrator.p.params.z0b
+
+    land_mask = cs.mask
+
+    # mask of all models (1 = land, 0 = ocean, -2 = sea ice)
+    univ_mask = parent(land_mask) .- parent(ice_mask .* FT(2))
+
+    # combine models' surfaces onlo one coupler field 
+    # surface temperature
     combined_field = zeros(boundary_space)
-    if prescribed_sst
-        T_ocean = SST
-        z0m_ocean = ocean_params.z0m
-        z0b_ocean = ocean_params.z0b
-        α_ocean = ocean_params.α
-    else
-        T_ocean = slab_ocean_sim.integrator.u.T_sfc
-        z0m_ocean = slab_ocean_sim.integrator.p.params.z0m
-        z0b_ocean = slab_ocean_sim.integrator.p.params.z0b
-        α_ocean = slab_ocean_sim.integrator.p.params.α
-    end
+    parent(combined_field) .= combine_surface.(FT, univ_mask, parent(T_land), parent(T_ocean), parent(T_ice))
+    dummmy_remap!(T_sfc_cpl, combined_field)
 
-    parent(combined_field) .=
-        combine_surface.(FT, univ_mask, parent(T_land), parent(T_ocean), parent(slab_ice_sim.integrator.u.T_sfc))
-    dummmy_remap!(T_S, combined_field)
+    # roughness length for momentum
+    parent(combined_field) .= combine_surface.(FT, univ_mask, z0m_land, z0m_ocean, z0m_ice)
+    dummmy_remap!(z0m_cpl, combined_field)
 
-    parent(combined_field) .=
-        combine_surface.(FT, univ_mask, z0m_land, z0m_ocean, slab_ice_sim.integrator.p.Ya.params.z0m)
-    dummmy_remap!(z0m_S, combined_field)
+    # roughness length for tracers
+    parent(combined_field) .= combine_surface.(FT, univ_mask, z0b_land, z0b_ocean, z0b_ice)
+    dummmy_remap!(z0b_cpl, combined_field)
 
-    parent(combined_field) .=
-        combine_surface.(FT, univ_mask, z0b_land, z0b_ocean, slab_ice_sim.integrator.p.Ya.params.z0b)
-    dummmy_remap!(z0b_S, combined_field)
+    # calculate atmospheric surface density 
+    set_ρ_sfc!(ρ_sfc_cpl, T_sfc_cpl, atmos_sim.integrator)
 
-    set_ρ_sfc!(ρ_sfc, T_S, atmos_sim.integrator)
-    # Now compute ocean and sea ice q_sat
-    ocean_q_sfc = TD.q_vap_saturation_generic.(thermo_params, T_ocean, ρ_sfc, TD.Liquid())
-    sea_ice_q_sfc = TD.q_vap_saturation_generic.(thermo_params, slab_ice_sim.integrator.u.T_sfc, ρ_sfc, TD.Ice())
-    land_q_sfc = get_land_q(slab_sim, atmos_sim, T_land, ρ_sfc)
-    # Pull q_sfc from land, and set q_sfc on surface with it and the above computed values.
+    # surface specific humidity
+    ocean_q_sfc = TD.q_vap_saturation_generic.(thermo_params, T_ocean, ρ_sfc_cpl, TD.Liquid())
+    sea_ice_q_sfc = TD.q_vap_saturation_generic.(thermo_params, T_ice, ρ_sfc_cpl, TD.Ice())
+    land_q_sfc = get_land_q(slab_sim, atmos_sim, T_land, ρ_sfc_cpl)
     parent(combined_field) .=
         combine_surface.(FT, univ_mask, parent(land_q_sfc), parent(ocean_q_sfc), parent(sea_ice_q_sfc))
-    dummmy_remap!(q_sfc, combined_field)
-    α_land = land_albedo(slab_sim)
+    dummmy_remap!(q_sfc_cpl, combined_field)
 
-    α_ice = slab_ice_sim.params.α
+    # albedo
+    α_land = land_albedo(slab_sim)
+    α_ice = ice_sim.integrator.p.params.α
     parent(combined_field) .= combine_surface.(FT, univ_mask, α_land, α_ocean, α_ice)
-    dummmy_remap!(albedo, combined_field)
+    dummmy_remap!(albedo_sfc_cpl, combined_field)
     atmos_sim.integrator.p.rrtmgp_model.diffuse_sw_surface_albedo .=
-        reshape(RRTMGPI.field2array(albedo), 1, length(parent(albedo)))
+        reshape(RRTMGPI.field2array(albedo_sfc_cpl), 1, length(parent(albedo_sfc_cpl)))
     atmos_sim.integrator.p.rrtmgp_model.direct_sw_surface_albedo .=
-        reshape(RRTMGPI.field2array(albedo), 1, length(parent(albedo)))
+        reshape(RRTMGPI.field2array(albedo_sfc_cpl), 1, length(parent(albedo_sfc_cpl)))
 
     # calculate turbulent fluxes on atmos grid and save in atmos cache
-    info_sfc = (;
-        T_sfc = T_S,
-        ρ_sfc = ρ_sfc,
-        q_sfc = q_sfc,
-        z0m = z0m_S,
-        z0b = z0b_S,
-        ice_mask = slab_ice_sim.integrator.p.Ya.ice_mask,
-    )
+    info_sfc =
+        (; T_sfc = T_sfc_cpl, ρ_sfc = ρ_sfc_cpl, q_sfc = q_sfc_cpl, z0m = z0m_cpl, z0b = z0b_cpl, ice_mask = ice_mask)
     calculate_surface_fluxes_atmos_grid!(atmos_sim.integrator, info_sfc)
 
-    atmos_sim.integrator.p.rrtmgp_model.surface_temperature .= RRTMGPI.field2array(T_S)
+    atmos_sim.integrator.p.rrtmgp_model.surface_temperature .= RRTMGPI.field2array(T_sfc_cpl)
 end

--- a/experiments/AMIP/moist_mpi_earth/slab/slab_utils.jl
+++ b/experiments/AMIP/moist_mpi_earth/slab/slab_utils.jl
@@ -15,4 +15,5 @@ end
 
 Returns the volumetric internal energy of the slab.
 """
-get_slab_energy(slab_sim, T_sfc) = slab_sim.params.ρ .* slab_sim.params.c .* T_sfc .* slab_sim.params.h
+get_slab_energy(slab_sim, T_sfc) =
+    slab_sim.integrator.p.params.ρ .* slab_sim.integrator.p.params.c .* T_sfc .* slab_sim.integrator.p.params.h

--- a/experiments/AMIP/moist_mpi_earth/slab_ice/slab_init.jl
+++ b/experiments/AMIP/moist_mpi_earth/slab_ice/slab_init.jl
@@ -25,7 +25,7 @@ function ice_rhs!(du, u, p, t)
     Y = u
     FT = eltype(dY)
 
-    params = p.Ya.params
+    params = p.params
     F_aero = p.Ya.F_aero
     F_rad = p.Ya.F_rad
     ice_mask = p.Ya.ice_mask
@@ -35,7 +35,7 @@ function ice_rhs!(du, u, p, t)
     parent(dY.T_sfc) .= apply_mask.(parent(ice_mask), >, parent(rhs), FT(0))
 end
 
-function slab_ice_init(::Type{FT}; tspan, saveat, dt, space, ice_mask, stepper = Euler()) where {FT}
+function ice_init(::Type{FT}; tspan, saveat, dt, space, ice_mask, stepper = Euler()) where {FT}
 
     params = IceSlabParameters(
         FT(2),
@@ -50,14 +50,9 @@ function slab_ice_init(::Type{FT}; tspan, saveat, dt, space, ice_mask, stepper =
     )
 
     Y = slab_ice_space_init(FT, space, params)
-    Ya = (;
-        params = params,
-        F_aero = ClimaCore.Fields.zeros(space),
-        F_rad = ClimaCore.Fields.zeros(space),
-        ice_mask = ice_mask,
-    )
+    Ya = (; F_aero = ClimaCore.Fields.zeros(space), F_rad = ClimaCore.Fields.zeros(space), ice_mask = ice_mask)
 
-    problem = OrdinaryDiffEq.ODEProblem(ice_rhs!, Y, tspan, (; Ya = Ya))
+    problem = OrdinaryDiffEq.ODEProblem(ice_rhs!, Y, tspan, (; Ya = Ya, params = params))
     integrator = OrdinaryDiffEq.init(problem, stepper, dt = dt, saveat = saveat)
 
 

--- a/experiments/AMIP/moist_mpi_earth/slab_ocean/slab_init.jl
+++ b/experiments/AMIP/moist_mpi_earth/slab_ocean/slab_init.jl
@@ -44,7 +44,7 @@ function slab_ocean_rhs!(dY, Y, Ya, t)
     parent(dY.T_sfc) .= apply_mask.(parent(mask), <, parent(rhs), FT(0.5))
 end
 
-function slab_ocean_init(::Type{FT}; tspan, dt, saveat, space, mask, stepper = Euler()) where {FT}
+function ocean_init(::Type{FT}; tspan, dt, saveat, space, mask, stepper = Euler()) where {FT}
 
     params = OceanSlabParameters(FT(20), FT(1500.0), FT(800.0), FT(280.0), FT(1e-3), FT(1e-5), FT(0.06))
 


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content
This PR introduces interface changes which are used in PR #90 . They are split from the main PR to make reviewing of the functionality easier. The changes here include:
- reducing arguments in `push!` and `pull` functions by introducing a `CouplerSimulation` struct
- unifying names of, and information contained within,  model sims. This reduces the number of `if.. else..` statements when running with prescribed or modeled SSTs.
- include `SST` and `SIC` in their respective sims

While these interface changes are not part of the final coupler interface design, they facilitate the development and running of the models from the coupler in the intermediate term, and will be used in the first AMIP showcase. 

## Benefits and Risks
- b: less code, more structured
- r: interface changes are not the priority (only minimal changes introduced here)

## Linked Issues
see #90 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.
