### PR TITLE
Add remap to `coupler_put!`

### DIFF
--- a/test/CouplerState/cplstate_interface.jl
+++ b/test/CouplerState/cplstate_interface.jl
@@ -43,7 +43,7 @@ end
     coupler_add_field!(coupler, :test1, simA.data; write_sim = simA)
 
     map = Operators.LinearRemap(spaceB, spaceA)
-    coupler_add_map!(coupler, :simA_to_simB, map)
+    coupler_add_map!(coupler, map)
 
     @show coupler
 
@@ -51,16 +51,16 @@ end
         @test simA.data === coupler_get(coupler, :test1)
 
         # test remapping
-        @test map === ClimaCoupler.get_remap_operator(coupler, ClimaCoupler.name(simB), ClimaCoupler.name(simA))
-        @test ones(spaceB) ≈ coupler_get(coupler, :test1, simB)
+        @test map === ClimaCoupler.get_remap_operator(coupler, axes(simB.data), axes(simA.data))
+        @test ones(spaceB) ≈ coupler_get(coupler, :test1, axes(simB.data))
         target_field = zeros(spaceB)
-        coupler_get!(target_field, coupler, :test1, simB)
+        coupler_get!(target_field, coupler, :test1)
         @test ones(spaceB) ≈ target_field
 
         # key not in coupler dict
         @test_throws KeyError coupler_get(coupler, :idontexist)
-        @test_throws KeyError coupler_get(coupler, :idontexist, simB)
-        @test_throws KeyError coupler_get!(target_field, coupler, :idontexist, simB)
+        @test_throws KeyError coupler_get(coupler, :idontexist, axes(simB.data))
+        @test_throws KeyError coupler_get!(target_field, coupler, :idontexist)
     end
 
     @testset "coupler_put!" begin

--- a/test/CouplerState/cplstate_interface.jl
+++ b/test/CouplerState/cplstate_interface.jl
@@ -51,7 +51,7 @@ end
         @test simA.data === coupler_get(coupler, :test1)
 
         # test remapping
-        @test map === ClimaCoupler.get_remap_operator(coupler, axes(simB.data), axes(simA.data))
+        @test map === ClimaCoupler.coupler_get_map(coupler, axes(simB.data), axes(simA.data))
         @test ones(spaceB) ≈ coupler_get(coupler, :test1, axes(simB.data))
         target_field = zeros(spaceB)
         coupler_get!(target_field, coupler, :test1)
@@ -76,7 +76,5 @@ end
 
         # coupler_put! must be to a previously added field
         @test_throws KeyError coupler_put!(coupler, :idontexist, newdata, simA)
-        # incoming data must match dimensions/space of added field
-        @test_throws ErrorException coupler_put!(coupler, :test1, ones(spaceB), simA)
     end
 end


### PR DESCRIPTION
## Purpose and Content
This PR adds remapping to the `coupler_put!` calls and changes the way that the remap operators are stored/accessed in the coupler.

## Benefits and Risks
Having remapping at both the `put!` and `get` stages of the coupling enables the use of an exchange grid, should the user want one. This is optional, though also the standard in the wider coupling community. It's also nice to make `put!` and `get` more symmetric.

The way that maps are stored is also changed from keys with `simA_to_simB` naming convention to a key that is a tuple of the target and source spaces. This has some nice effects: 
- the naming system is abandoned and not necessary for the user to learn
- it is not necessary to store exchange grid names, which would otherwise be necessary for accessing maps during coupler_put!` calls
- it is much easier to build the maps automatically (see `coupler_add_field!` changes), likely making #67 easier to tackle.

In talking to @simonbyrne, a risk here is the time to hash spaces vs. names.

It should also be noted that a formal `IdentityRemap` operator is beneficial here and further simplifies some of the remap construction and coupler calls (since you can assume _every_ call has an associated map, even if it does nothing). [ClimaCore PR#793](https://github.com/CliMA/ClimaCore.jl/pull/793) adds this and should be treated as a dependency.

## Linked Issues
- Closes #65
- #67 

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [ ] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [ ] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [ ] All tests ran successfully on my local machine OR N/A.
- [ ] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.
