### PR TITLE
Daily interpolation from monthly data (v2)

### DIFF
--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/calendar_timer.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/calendar_timer.jl
@@ -33,7 +33,7 @@ Evaluate `ex` when `model_date` is on/after `callback_date` and do nothing other
 """
 macro calendar_callback(ex::Expr, model_date::Union{Symbol, Expr}, callback_date::Union{Symbol, Expr})
     quote
-        if Dates.days($model_date - $callback_date) < FT(0)
+        if ($model_date - $callback_date).value < FT(0)
             nothing
         else
             eval($ex)


### PR DESCRIPTION
# PULL REQUEST
- Update from #91

## Purpose and Content
Adds capability to interpolate linearly between two monthly `Fields`. The demo uses prerequisite PRs outlined in #88 to obtain monthly data. 

## Benefits and Risks
- benefit: last piece for enabling specifying temporarily varying boundary conditions from a file.
- risk: performance slow-down - check are in place (see below)

## Linked Issues
- SDI: #74 
- Design: #88

## Dependent PRs
- no not merge before  #87 ,  #89 and #90

## Performance of the final solution 
- time loop only over added infrastructure of #88 : adding 0.24s per simulation day at `dt = 200s`

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [x] Documentation has been added/updated OR N/A.