### PR TITLE
Use ClimaTimeSteppers

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,7 +46,7 @@ steps:
         artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet_artifacts/total_energy*.png"
 
       - label: "AMIP"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --energy_check=false --mode_name=amip --anim=true --t_end=32days --dt_save_to_sol=1days --dt_cpl=200 --mono_surface=false --h_elem=6"
+        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --energy_check=false --mode_name=amip --anim=true --t_end=32days --dt_save_to_sol=1days --dt_cpl=400 --mono_surface=false --h_elem=6"
         artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip_artifacts/*"
 
       - label: "sea_breeze"

--- a/experiments/AMIP/moist_mpi_earth/Manifest.toml
+++ b/experiments/AMIP/moist_mpi_earth/Manifest.toml
@@ -264,8 +264,8 @@ version = "0.1.0"
 
 [[deps.ClimaTimeSteppers]]
 deps = ["CUDA", "DataStructures", "DiffEqBase", "DiffEqCallbacks", "KernelAbstractions", "LinearAlgebra", "MPI", "SciMLBase", "StaticArrays"]
-git-tree-sha1 = "c7bf608690ae2a0a2424a864f457fd18c698f143"
-repo-rev = "a698feab4899a0586607633be6735557aac05182"
+git-tree-sha1 = "583a08c20f75286806759796317d956be39751a4"
+repo-rev = "main"
 repo-url = "https://github.com/CliMA/ClimaTimeSteppers.jl.git"
 uuid = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 version = "0.2.4"
@@ -474,9 +474,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[deps.Distributions]]
 deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
-git-tree-sha1 = "0d7d213133d948c56e8c2d9f4eab0293491d8e4a"
+git-tree-sha1 = "04db820ebcfc1e053bd8cbb8d8bccf0ff3ead3f7"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.75"
+version = "0.25.76"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
@@ -593,9 +593,9 @@ version = "2.15.0"
 
 [[deps.FiniteDifferences]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Printf", "Random", "Richardson", "SparseArrays", "StaticArrays"]
-git-tree-sha1 = "0ee1275eb003b6fc7325cb14301665d1072abda1"
+git-tree-sha1 = "9788a26511ad46afd12197955c2b984d5faf83c8"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.24"
+version = "0.12.25"
 
 [[deps.FixedPointNumbers]]
 deps = ["Statistics"]
@@ -767,9 +767,9 @@ version = "1.12.2+2"
 
 [[deps.HTTP]]
 deps = ["Base64", "CodecZlib", "Dates", "IniFile", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
-git-tree-sha1 = "4abede886fcba15cd5fd041fef776b230d004cee"
+git-tree-sha1 = "e8c58d5f03b9d9eb9ed7067a2f34c7c371ab130b"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "1.4.0"
+version = "1.4.1"
 
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg"]
@@ -1244,9 +1244,9 @@ version = "0.3.22"
 
 [[deps.OffsetArrays]]
 deps = ["Adapt"]
-git-tree-sha1 = "1ea784113a6aa054c5ebd95945fa5e52c2f378e7"
+git-tree-sha1 = "f71d8950b724e9ff6110fc948dff5a329f901d64"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.7"
+version = "1.12.8"
 
 [[deps.Ogg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1290,9 +1290,9 @@ version = "1.2.1"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "e60321e3f2616584ff98f0a4f18d98ae6f89bbb3"
+git-tree-sha1 = "a94dc0169bffbf7e5250fb7e1efb1a85b09105c7"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "1.1.17+0"
+version = "1.1.18+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -1382,9 +1382,9 @@ version = "0.2.1"
 
 [[deps.PlotThemes]]
 deps = ["PlotUtils", "Statistics"]
-git-tree-sha1 = "8162b2f8547bc23876edd0c5181b27702ae58dce"
+git-tree-sha1 = "1f03a2d339f42dca4a4da149c7e15e9b896ad899"
 uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
-version = "3.0.0"
+version = "3.1.0"
 
 [[deps.PlotUtils]]
 deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "SnoopPrecompile", "Statistics"]
@@ -1772,9 +1772,9 @@ version = "1.0.1"
 
 [[deps.Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "OrderedCollections", "TableTraits", "Test"]
-git-tree-sha1 = "2d7164f7b8a066bcfa6224e67736ce0eb54aef5b"
+git-tree-sha1 = "c79322d36826aa2f4fd8ecfa96ddb47b174ac78d"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.9.0"
+version = "1.10.0"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]

--- a/experiments/AMIP/moist_mpi_earth/cli_options.jl
+++ b/experiments/AMIP/moist_mpi_earth/cli_options.jl
@@ -6,7 +6,7 @@ function parse_commandline()
         "--dt_cpl"
         help = " Coupling time step in seconds"
         arg_type = Int
-        default = 200
+        default = 400
         "--anim"
         help = "Boolean flag indicating whether to make animations"
         arg_type = Bool
@@ -130,7 +130,7 @@ function parse_commandline()
         "--ode_algo"
         help = "ODE algorithm [`ARS343` (default), `IMKG343a`, `ODE.Euler`, `ODE.IMEXEuler`, `ODE.Rosenbrock23`, etc.]"
         arg_type = String
-        default = "ODE.Rosenbrock23"
+        default = "ARS343"
         "--max_newton_iters"
         help = "Maximum number of Newton's method iterations (only for ODE algorithms that use Newton's method)"
         arg_type = Int

--- a/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
@@ -199,6 +199,9 @@ cs = CouplerSimulation(
 # share states between models
 include("./push_pull.jl")
 atmos_pull!(cs)
+if parsed_args["ode_algo"] == "ARS343"
+    step!(atmos_sim.integrator, Δt_cpl, true) # this is necessary to set values to the unitialized cache. In `ODE.jl` this is done as part of `reinit!``
+end
 atmos_push!(cs)
 land_pull!(cs)
 
@@ -216,7 +219,7 @@ end
 
 # coupling loop
 function solve_coupler!(cs, energy_check)
-    @show "Starting coupling loop"
+    @info "Starting coupling loop"
 
     @unpack model_sims, Δt_cpl, tspan = cs
     @unpack atmos_sim, land_sim, ocean_sim, ice_sim = model_sims


### PR DESCRIPTION
Collaborators: @szy21 @valeriabarra 

This is fixes a problem with initialization across component models. With ClimaTImeSteppers, not all cached variables are initialized before doing `step!` (this was not the case with `ODE.jl`). 

Ideally this shouldn't be needed in the final version, so whether we want to keep this for the time being or come up with a better solution now is a matter of discussion / people's availability. @dennisYatunin what are your thoughts? 

NB: The timestep for ARS343 was increased to 400s for the AMIP Buildkite setup. With 200s we got numerical instability after 5 days (@szy21 has seen this before in Tempest, and commented that this is not necessarily surprising since larger timestep adds more impliict dissipation). 



