### PR TITLE
Force MPI tests to each use one node

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,8 +74,8 @@ steps:
         agents:
           config: cpu
           queue: central
-          slurm_nodes: 3
-          slurm_tasks_per_node: 1
+          slurm_nodes: 1
+          slurm_tasks_per_node: 3
 
 
   - group: "Integration Tests"
@@ -134,7 +134,8 @@ steps:
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
-          slurm_ntasks: 2
+          slurm_nodes: 1
+          slurm_tasks_per_node: 2
 
       - label: "MPI AMIP FINE"
         key: "mpi_amip_fine"
@@ -143,4 +144,5 @@ steps:
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
-          slurm_ntasks: 32
+          slurm_nodes: 1
+          slurm_tasks_per_node: 32


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Similar to [ClimaCore PR #1053](https://github.com/CliMA/ClimaCore.jl/pull/1053).
Restrict tests using MPI to run on one node each, with all tasks contained on that node.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
