### PR TITLE
Increase slurm_mem allocation for MPI AMIP FINE test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -144,3 +144,4 @@ steps:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_ntasks: 32
+          slurm_mem: 80GB

--- a/experiments/AMIP/moist_mpi_earth_dynamical_sea_ice/coupler_utils/regridder.jl
+++ b/experiments/AMIP/moist_mpi_earth_dynamical_sea_ice/coupler_utils/regridder.jl
@@ -45,9 +45,9 @@ function ncreader_rll_to_cgll(
 )
     isdir(REGRID_DIR) ? nothing : mkpath(REGRID_DIR)
 
-    ds = NCDataset(datafile_rll)
-    nlat = ds.dim["lat"]
-    nlon = ds.dim["lon"]
+    nlat, nlon = NCDataset(datafile_rll) do ds
+        (ds.dim["lat"], ds.dim["lon"])
+    end
 
     meshfile_rll = joinpath(REGRID_DIR, "mesh_rll.g")
     rll_mesh(meshfile_rll; nlat = nlat, nlon = nlon)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
An initial solution to #192 


## Content
The `slurm_mem` allocation for the `MPI AMIP FINE` test is increased to 80GB. This is probably not the best long-term solution, but will be helpful for now to fix the coupler CI.

Update: also ensures NCDatasets are always closed after being opened, to prevent memory leaks.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
