### PR TITLE
update coupler_driver to use new ClimaLSM bucket model (WIP)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,7 +116,12 @@ steps:
       # breaking: 
       # - label: "Moist earth with slab surface - monin allsky no_sponge idealinsol infreq_dt_cpl"
       #   command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --microphy 0M --rayleigh_sponge false --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 21600 --dt 200secs --dt_rad 6hours --idealized_insolation true --mono_surface true --h_elem 4 --run_name target_params_in_slab1 --precip_model 0M"
-      #   artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab1_artifacts/total_energy*.png"       
+      #   artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab1_artifacts/total_energy*.png"
+      
+      - label: "Moist earth with slab surface - default: bulk gray no_sponge idealinsol freq_dt_cpl - bucket using BulkAlbedoFunction"
+        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true  --moist equil --vert_diff true --rad gray --microphy 0M --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface true --h_elem 4 --precip_model 0M --albedo_from_file false"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/run_artifacts/total_energy*.png"     
+
 
       - label: "AMIP"
         command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true  --moist equil --vert_diff true --rad gray --microphy 0M --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 10days --run_name coarse_single --precip_model 0M"

--- a/experiments/AMIP/moist_mpi_earth/Manifest.toml
+++ b/experiments/AMIP/moist_mpi_earth/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.2"
+julia_version = "1.8.1"
 manifest_format = "2.0"
-project_hash = "f2fc4f446f0d9872ae3e86d9183faa9636191e76"
+project_hash = "5aa8970f493c149bc70d9f4342277309556a32ea"
 
 [[deps.AMD]]
 deps = ["Libdl", "LinearAlgebra", "SparseArrays", "Test"]
@@ -246,8 +246,10 @@ uuid = "4ade58fe-a8da-486c-bd89-46df092ec0c7"
 version = "0.1.0"
 
 [[deps.ClimaLSM]]
-deps = ["CLIMAParameters", "ClimaCore", "DocStringExtensions", "IntervalSets", "StaticArrays", "SurfaceFluxes", "Thermodynamics", "UnPack"]
-git-tree-sha1 = "b6963416cfd1174c0703ae628b6647bbcdddd0bd"
+deps = ["ArtifactWrappers", "CLIMAParameters", "ClimaComms", "ClimaCore", "ClimaCoreTempestRemap", "Dates", "DocStringExtensions", "IntervalSets", "JLD2", "NCDatasets", "StaticArrays", "SurfaceFluxes", "Thermodynamics", "UnPack"]
+git-tree-sha1 = "2d6442081ef28ba9f8f4a3d73c8557ebe5311e8c"
+repo-rev = "albedo_from_file"
+repo-url = "https://github.com/CliMA/ClimaLSM.jl.git"
 uuid = "7884a58f-fab6-4fd0-82bb-ecfedb2d8430"
 version = "0.2.1"
 
@@ -643,9 +645,9 @@ version = "0.1.0"
 
 [[deps.Glib_jll]]
 deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "fb83fbe02fe57f2c068013aa94bcdf6760d3a7a7"
+git-tree-sha1 = "d3b3624125c1474292d0d8ed0f65554ac37ddb23"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.74.0+1"
+version = "2.74.0+2"
 
 [[deps.Glob]]
 git-tree-sha1 = "4df9f7e06108728ebf00a0a11edee4b29a482bb2"
@@ -934,9 +936,9 @@ version = "1.42.0+0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+git-tree-sha1 = "c7cb1f5d892775ba13767a87c7ada0b980ea0a71"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.1+1"
+version = "1.16.1+2"
 
 [[deps.Libmount_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1596,7 +1598,7 @@ version = "1.10.0"
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-version = "1.10.1"
+version = "1.10.0"
 
 [[deps.TaylorSeries]]
 deps = ["InteractiveUtils", "LinearAlgebra", "Markdown", "Requires", "SparseArrays"]

--- a/experiments/AMIP/moist_mpi_earth/Project.toml
+++ b/experiments/AMIP/moist_mpi_earth/Project.toml
@@ -47,3 +47,6 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [extras]
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
+
+[compat]
+ClimaAtmos = "0.7.0"

--- a/experiments/AMIP/moist_mpi_earth/bucket/bucket_init.jl
+++ b/experiments/AMIP/moist_mpi_earth/bucket/bucket_init.jl
@@ -16,8 +16,7 @@ import ClimaLSM.Bucket:
     snow_precipitation,
     # TODO add MapInfo constructor to ClimaLSM so fewer internals exposed
     cesm2_land_albedo_dataset_path
-import ClimaLSM.Regridder:
-    MapInfo
+import ClimaLSM.Regridder: MapInfo
 
 using ClimaLSM: make_ode_function, initialize, obtain_surface_space, make_set_initial_aux_state
 
@@ -166,7 +165,7 @@ function bucket_init(
         end
         albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc)
     end
-    
+
     σS_c = FT(0.2)
     W_f = FT(0.5)
     d_soil = FT(3.5) # soil depth

--- a/experiments/AMIP/moist_mpi_earth/bucket/bucket_utils.jl
+++ b/experiments/AMIP/moist_mpi_earth/bucket/bucket_utils.jl
@@ -51,7 +51,13 @@ a method for the bucket model
 when used as the land model.
 """
 function land_albedo(slab_sim::BucketSimulation)
-    α_land = surface_albedo.(slab_sim.integrator.p.bucket.α_sfc, slab_sim.params.albedo.α_snow, slab_sim.integrator.u.bucket.σS, slab_sim.params.σS_c)
+    α_land =
+        surface_albedo.(
+            slab_sim.integrator.p.bucket.α_sfc,
+            slab_sim.params.albedo.α_snow,
+            slab_sim.integrator.u.bucket.σS,
+            slab_sim.params.σS_c,
+        )
     return parent(α_land)
 end
 

--- a/experiments/AMIP/moist_mpi_earth/bucket/bucket_utils.jl
+++ b/experiments/AMIP/moist_mpi_earth/bucket/bucket_utils.jl
@@ -51,8 +51,7 @@ a method for the bucket model
 when used as the land model.
 """
 function land_albedo(slab_sim::BucketSimulation)
-    coords = ClimaCore.Fields.coordinate_field(axes(slab_sim.integrator.u.bucket.σS))
-    α_land = surface_albedo.(Ref(slab_sim.params.albedo), coords, slab_sim.integrator.u.bucket.σS, slab_sim.params.σS_c)
+    α_land = surface_albedo.(slab_sim.integrator.p.bucket.α_sfc, slab_sim.params.albedo.α_snow, slab_sim.integrator.u.bucket.σS, slab_sim.params.σS_c)
     return parent(α_land)
 end
 

--- a/experiments/AMIP/moist_mpi_earth/cli_options.jl
+++ b/experiments/AMIP/moist_mpi_earth/cli_options.jl
@@ -281,6 +281,10 @@ function parse_commandline()
         help = "Apply parameterization for convective gravity wave forcing on horizontal mean flow"
         arg_type = Bool
         default = false
+        "--albedo_from_file"
+        help = "Access land surface albedo information from data file"
+        arg_type = Bool
+        default = true
     end
     parsed_args = ArgParse.parse_args(ARGS, s)
     return (s, parsed_args)

--- a/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
@@ -151,8 +151,15 @@ include("slab_ice/slab_init.jl")
 ### Land
 We use `ClimaLSM.jl`'s bucket model.
 =#
-land_sim =
-    bucket_init(FT, FT.(tspan), parsed_args["config"], parsed_args["albedo_from_file"]; dt = FT(Δt_cpl), space = boundary_space, saveat = FT(saveat))
+land_sim = bucket_init(
+    FT,
+    FT.(tspan),
+    parsed_args["config"],
+    parsed_args["albedo_from_file"];
+    dt = FT(Δt_cpl),
+    space = boundary_space,
+    saveat = FT(saveat),
+)
 
 #=
 ### Ocean and Sea Ice

--- a/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
@@ -152,7 +152,7 @@ include("slab_ice/slab_init.jl")
 We use `ClimaLSM.jl`'s bucket model.
 =#
 land_sim =
-    bucket_init(FT, FT.(tspan), parsed_args["config"]; dt = FT(Δt_cpl), space = boundary_space, saveat = FT(saveat))
+    bucket_init(FT, FT.(tspan), parsed_args["config"], parsed_args["albedo_from_file"]; dt = FT(Δt_cpl), space = boundary_space, saveat = FT(saveat))
 
 #=
 ### Ocean and Sea Ice


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
Update: replaced by #197 
## Purpose 
ClimaLSM [PR #125](https://github.com/CliMA/ClimaLSM.jl/pull/125) updates the bucket model to read in surface albedo from a datafile. The coupler driver needs to be updated to use this and test coupled runs with both types of albedo.

## To-do
[x] Update coupler_driver.jl to use new bucket model interface
[x] Test BulkAlbedoFunction, BulkAlbedoMap without MPI
[ ] Test BulkAlbedoFunction, BulkAlbedoMap with MPI


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
