### PR TITLE
update modular driver to use BCReader module

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -133,6 +133,10 @@ steps:
         command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true  --moist equil --vert_diff true --rad gray --microphy 0M --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 10days --run_name coarse_single --precip_model 0M"
         artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/coarse_single_artifacts/*"
 
+      - label: "AMIP - modular"
+        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver_modular.jl --enable_threading true --coupled true  --moist equil --vert_diff true --rad gray --microphy 0M --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 10days --run_name coarse_single_modular --precip_model 0M"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/coarse_single_artifacts/*"
+
       - label: "sea_breeze"
         command: "julia --color=yes --project=experiments/ClimaCore/sea_breeze experiments/ClimaCore/sea_breeze/run.jl"
         artifact_paths: "sea_breeze/"
@@ -155,4 +159,4 @@ steps:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:
           slurm_ntasks: 32
-          slurm_mem: 80GB
+          slurm_mem_per_cpu: 16G

--- a/Project.toml
+++ b/Project.toml
@@ -17,11 +17,12 @@ OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+TempestRemap_jll = "8573a8c5-1df0-515e-a024-abad257ee284"
 TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-ClimaComms = "0.3"
+ClimaComms = "=0.3.2"
 ClimaCore = "0.10"
 ClimaCoreTempestRemap = "0.3"
 DocStringExtensions = "0.8, 0.9"

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -8,6 +8,6 @@ modules in the coupler.
 
 ```@docs
 ClimaCoupler.Utilities.CouplerSimulation
-ClimaCoupler.Utilities.heaviside
+ClimaCoupler.Utilities.float_type
 ClimaCoupler.Utilities.swap_space!
 ```

--- a/experiments/AMIP/moist_mpi_earth/Manifest.toml
+++ b/experiments/AMIP/moist_mpi_earth/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.2"
+julia_version = "1.8.3"
 manifest_format = "2.0"
 project_hash = "f2fc4f446f0d9872ae3e86d9183faa9636191e76"
 
@@ -174,7 +174,7 @@ uuid = "052768ef-5323-5732-b1bb-66c8b64840ba"
 version = "3.12.0"
 
 [[deps.Cairo_jll]]
-deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
+deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
 git-tree-sha1 = "4b859a208b2397a7a623a03449e4636bdb17bcf2"
 uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
 version = "1.16.1+1"
@@ -240,7 +240,7 @@ uuid = "c8b6d40d-e815-466f-95ae-c48aefa668fa"
 version = "0.7.1"
 
 [[deps.ClimaCoupler]]
-deps = ["ClimaAtmos", "ClimaComms", "ClimaCore", "ClimaCoreTempestRemap", "ClimaLSM", "Dates", "DocStringExtensions", "JLD2", "NCDatasets", "OrdinaryDiffEq", "Plots", "PrettyTables", "SciMLBase", "TerminalLoggers", "UnPack"]
+deps = ["ClimaAtmos", "ClimaComms", "ClimaCore", "ClimaCoreTempestRemap", "ClimaLSM", "Dates", "DocStringExtensions", "JLD2", "NCDatasets", "OrdinaryDiffEq", "Plots", "PrettyTables", "SciMLBase", "TempestRemap_jll", "TerminalLoggers", "UnPack"]
 path = "../../.."
 uuid = "4ade58fe-a8da-486c-bd89-46df092ec0c7"
 version = "0.1.0"
@@ -643,9 +643,9 @@ version = "0.1.0"
 
 [[deps.Glib_jll]]
 deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "fb83fbe02fe57f2c068013aa94bcdf6760d3a7a7"
+git-tree-sha1 = "d3b3624125c1474292d0d8ed0f65554ac37ddb23"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.74.0+1"
+version = "2.74.0+2"
 
 [[deps.Glob]]
 git-tree-sha1 = "4df9f7e06108728ebf00a0a11edee4b29a482bb2"
@@ -934,9 +934,9 @@ version = "1.42.0+0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+git-tree-sha1 = "c7cb1f5d892775ba13767a87c7ada0b980ea0a71"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.1+1"
+version = "1.16.1+2"
 
 [[deps.Libmount_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1606,9 +1606,9 @@ version = "0.10.13"
 
 [[deps.TempestRemap_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "NetCDF_jll", "OpenBLAS32_jll", "Pkg"]
-git-tree-sha1 = "27e81d7684e47875688952432d178d7f45130482"
+git-tree-sha1 = "88c3818a492ad1a94b1aa440b01eab5d133209ff"
 uuid = "8573a8c5-1df0-515e-a024-abad257ee284"
-version = "2.1.6+0"
+version = "2.1.6+1"
 
 [[deps.TensorCore]]
 deps = ["LinearAlgebra"]

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/bcfile_reader.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/bcfile_reader.jl
@@ -36,7 +36,7 @@ end
 
 BCFileInfo{FT}(args...) where {FT} = BCFileInfo{FT, typeof.(args[1:7])...}(args...)
 
-float_type(::BCFileInfo{FT}) where {FT} = FT
+float_type_bcf(::BCFileInfo{FT}) where {FT} = FT
 
 """
     bcfile_info_init(FT, comms_ctx, datafile_rll, varname, boundary_space; interpolate_daily = false, segment_idx0 = [Int(1)], scaling_function = false)
@@ -107,7 +107,7 @@ Extracts boundary condition data from regridded (to model grid) NetCDF files (wh
 """
 function update_midmonth_data!(date, bcf_info)
     # monthly count
-    FT = float_type(bcf_info)
+    FT = float_type_bcf(bcf_info)
     all_dates = bcf_info.all_dates
     midmonth_idx = bcf_info.segment_idx[1]
     midmonth_idx0 = bcf_info.segment_idx0[1]

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/general_helper.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/general_helper.jl
@@ -18,7 +18,7 @@ struct CouplerSimulation{FT, C, S, D, B, P}
 end
 
 CouplerSimulation{FT}(args...) where {FT} = CouplerSimulation{FT, typeof.(args[1:5])...}(args...)
-float_type(::CouplerSimulation{FT}) where {FT} = FT
+float_type_cs(::CouplerSimulation{FT}) where {FT} = FT
 
 function swap_space!(field, new_space)
     field_out = zeros(new_space)

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/offline_postprocessor.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/offline_postprocessor.jl
@@ -1,5 +1,6 @@
 
 using Statistics
+using ClimaCoupler.Regridder: remap_field_cgll_to_rll
 
 # data types for postprocessing
 abstract type PostProcessedData end

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/variable_definer.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/variable_definer.jl
@@ -10,7 +10,7 @@ get_var(cs, ::Val{:T}) = air_temperature(cs)
 get_var(cs, ::Val{:u}) = ClimaCore.Geometry.UVVector.(cs.model_sims.atmos_sim.integrator.u.c.uₕ).components.data.:1
 
 get_var(cs, ::Val{:q_tot}) =
-    cs.model_sims.atmos_sim.integrator.u.c.ρq_tot ./ cs.model_sims.atmos_sim.integrator.u.c.ρ .* float_type(cs)(1000)
+    cs.model_sims.atmos_sim.integrator.u.c.ρq_tot ./ cs.model_sims.atmos_sim.integrator.u.c.ρ .* float_type_cs(cs)(1000)
 
 get_var(cs, ::Val{:toa}) = swap_space!(toa_fluxes(cs), cs.boundary_space)
 

--- a/experiments/AMIP/moist_mpi_earth/push_pull.jl
+++ b/experiments/AMIP/moist_mpi_earth/push_pull.jl
@@ -21,7 +21,7 @@ and hydrostatic balance assumptions. The land model does not compute the surface
 a reasonable stand-in.
 """
 function land_pull!(cs)
-    FT = float_type(cs)
+    FT = float_type_cs(cs)
     land_sim = cs.model_sims.land_sim
     csf = cs.fields
     land_mask = cs.surface_masks.land
@@ -59,7 +59,7 @@ In the current version, the sea ice has a prescribed thickness, and we assume th
 sublimating. That contribution has been zeroed out in the atmos fluxes.
 """
 function ice_pull!(cs)
-    FT = float_type(cs)
+    FT = float_type_cs(cs)
     ice_sim = cs.model_sims.ice_sim
     csf = cs.fields
     ice_mask = cs.surface_masks.ice

--- a/experiments/AMIP/moist_mpi_earth/slab_ice/slab_init.jl
+++ b/experiments/AMIP/moist_mpi_earth/slab_ice/slab_init.jl
@@ -70,7 +70,7 @@ end
 Ensures that the space of the SIC struct matches that of the mask, and converts the units from area % to area fraction. 
 """
 
-clean_sic(SIC, _info) = swap_space!(SIC, axes(_info.land_mask)) ./ float_type(_info)(100.0)
+clean_sic(SIC, _info) = swap_space!(SIC, axes(_info.land_mask)) ./ float_type_bcf(_info)(100.0)
 
 # setting that SIC < 0.5 os counted as ocean if binary remapping of landsea mask. 
 get_ice_mask(h_ice::FT, mono, threshold = 0.5) where {FT} = mono ? h_ice : binary_mask.(h_ice, threshold = threshold)

--- a/experiments/AMIP/moist_mpi_earth/slab_ocean/slab_init.jl
+++ b/experiments/AMIP/moist_mpi_earth/slab_ocean/slab_init.jl
@@ -72,4 +72,4 @@ end
     clean_sst(SST::FT, _info) 
 Ensures that the space of the SST struct matches that of the mask, and converts the units to Kelvin (N.B.: this is dataset specific)
 """
-clean_sst(SST, _info) = (swap_space!(SST, axes(_info.land_mask)) .+ float_type(_info)(273.15))
+clean_sst(SST, _info) = (swap_space!(SST, axes(_info.land_mask)) .+ float_type_bcf(_info)(273.15))

--- a/src/BCReader.jl
+++ b/src/BCReader.jl
@@ -13,7 +13,8 @@ using ClimaComms
 using Dates
 using JLD2
 
-export BCFileInfo, bcfile_info_init, update_midmonth_data!, next_date_in_file, interpolate_midmonth_to_daily
+export BCFileInfo,
+    float_type_bcf, bcfile_info_init, update_midmonth_data!, next_date_in_file, interpolate_midmonth_to_daily
 
 
 """
@@ -52,7 +53,7 @@ end
 
 BCFileInfo{FT}(args...) where {FT} = BCFileInfo{FT, typeof.(args[1:8])...}(args...)
 
-float_type(::BCFileInfo{FT}) where {FT} = FT
+float_type_bcf(::BCFileInfo{FT}) where {FT} = FT
 
 """
     no_scaling(field, bcf_info)
@@ -180,7 +181,7 @@ The times for which data is extracted depends on the specifications in the
 function update_midmonth_data!(date, bcf_info::BCFileInfo)
     # monthly count
     (; bcfile_dir, comms_ctx, hd_outfile_root, varname, all_dates, scaling_function) = bcf_info
-    FT = float_type(bcf_info)
+    FT = float_type_bcf(bcf_info)
     midmonth_idx = bcf_info.segment_idx[1]
     midmonth_idx0 = bcf_info.segment_idx0[1]
 

--- a/src/Regridder.jl
+++ b/src/Regridder.jl
@@ -16,7 +16,7 @@ using Dates
 using JLD2
 
 export write_to_hdf5,
-    read_from_hdf5, dummmy_remap!, remap_field_cgll_to_rll, land_sea_mask, update_masks!, combine_surfaces!
+    read_from_hdf5, dummmy_remap!, remap_field_cgll_to_rll, land_sea_mask, update_masks!, combine_surfaces!, binary_mask
 
 FT_dot(x) = FT.(x)
 nans_to_zero(v) = isnan(v) ? typeof(v)(0) : v

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -8,13 +8,14 @@ module Utilities
 
 using ClimaCore: Fields, Spaces
 
-export CoupledSimulation, float_type, heaviside, swap_space!, create_space
+export CoupledSimulation, float_type_cs, swap_space!
 
 
 """
 Stores information needed to run a simulation with the coupler. 
 """
-struct CoupledSimulation{FT, S, D, B, FV, P, E}
+struct CoupledSimulation{FT, X, S, D, B, FV, P, E}
+    comms_ctx::X
     tspan::S
     dates::D
     boundary_space::B
@@ -30,20 +31,8 @@ struct CoupledSimulation{FT, S, D, B, FV, P, E}
     monthly_2d_diags::NamedTuple
 end
 
-CoupledSimulation{FT}(args...) where {FT} = CoupledSimulation{FT, typeof.(args[1:6])...}(args...)
-float_type(::CoupledSimulation{FT}) where {FT} = FT
-
-"""
-    heaviside(var)
-
-Implements the heaviside step function multiplied by `var`, returning 0 for negative inputs
-or the input value itself for non-negative inputs.
-
-# Arguments
-- `var`: [Integer or Float] value to apply heaviside to.
-"""
-
-heaviside(var) = var < 0 ? 0 : var
+CoupledSimulation{FT}(args...) where {FT} = CoupledSimulation{FT, typeof.(args[1:7])...}(args...)
+float_type_cs(::CoupledSimulation{FT}) where {FT} = FT
 
 """
     swap_space!(field::Fields.Field, new_space)

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -64,6 +64,7 @@ function coupler_sim_from_file(
     FT = eltype(land_mask)
 
     Utilities.CoupledSimulation{FT}(
+        ClimaComms.SingletonCommsContext(),
         tspan,
         dates,
         boundary_space,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,7 @@ end
 @safetestset "BCReader tests" begin
     include("bcreader_tests.jl")
 end
+@safetestset "Utilities tests" begin
+    include("utilities_tests.jl")
+end
 # include("CoupledSimulations/cplsolver.jl")

--- a/test/utilities_tests.jl
+++ b/test/utilities_tests.jl
@@ -1,0 +1,40 @@
+#= 
+    Unit tests for ClimaCoupler Utilities module
+=#
+
+using Test
+using ClimaCoupler: Utilities, TestHelper
+using ClimaCore: Fields
+
+for FT in (Float32, Float64)
+    @testset "test float_type_cs for FT=$FT" begin
+        cs = Utilities.CoupledSimulation(
+            nothing, # comms_ctx
+            nothing, # tspan
+            nothing, # dates
+            nothing, # boundary_space
+            nothing, # fields
+            nothing, # parsed_args
+            nothing, # conservation_checks
+            FT(200), # t
+            FT(1 * 24 * 3600), # Δt_cpl
+            (;), # surface_masks
+            (;), # model_sims
+            (;), # mode
+            (;), # monthly_3d_diags
+            (;), # monthly_2d_diags
+        )
+        @test Utilities.float_type_cs(cs) == FT
+    end
+
+    @testset "test swap_space!" begin
+        space1 = TestHelper.create_space(FT, R = FT(6371e3))
+        space2 = TestHelper.create_space(FT, R = FT(6371e3) / 2)
+
+        field1 = ones(space1)
+        field2 = Utilities.swap_space!(field1, space2)
+
+        @test parent(field1) == parent(field2)
+        @test axes(field2) == space2
+    end
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The BCReader module was implemented by #175. Now the modular driver `coupler_driver_modular.jl` needs to be updated to use this instead of including `coupler_utils/bcfile_reader.jl`.


## To-do
- [x] Replace `include` line with import of BCReader module
- [x] Update calls of functions from BCReader


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
