### PR TITLE
Use relative module qualifiers for sibling modules

### DIFF
--- a/src/ConservationChecker.jl
+++ b/src/ConservationChecker.jl
@@ -16,7 +16,7 @@ using UnPack
 using Plots
 using ClimaAtmos: RRTMGPI
 using ClimaLSM
-using ClimaCoupler.Utilities: CoupledSimulation, swap_space!
+using ..Utilities: CoupledSimulation, swap_space!
 
 export AbstractCheck, EnergyConservationCheck, WaterConservationCheck, check_conservation!, plot_global_conservation
 

--- a/src/ConservationChecker.jl
+++ b/src/ConservationChecker.jl
@@ -64,7 +64,7 @@ check_conservation!(coupler_sim::CoupledSimulation, get_slab_energy, get_land_en
         get_land_energy,
         )
 
-computes the total energy, ``\\int \\rho e dV``, of the various components
+computes the total energy, ∫ ρe dV, of the various components
 of the coupled simulations, and updates `cc` with the values.
 
 TODO: move `get_slab_energy` and `get_land_energy` to their respective sims upon optimization refactor.
@@ -154,7 +154,7 @@ end
     get_land_energy,
     )
 
-computes the total water, ``\\int \\rho q_{tot} dV``, of the various components
+computes the total water, ∫ ρq_tot dV, of the various components
 of the coupled simulations, and updates `cc` with the values.
 
 Note: in the future this should not use `push!`.

--- a/src/Regridder.jl
+++ b/src/Regridder.jl
@@ -7,8 +7,8 @@ via ClimaCoreTempestRemap wrappers.
 """
 module Regridder
 
-using ClimaCoupler.Utilities
-using ClimaCoupler.TimeManager
+using ..Utilities
+using ..TimeManager
 using ClimaCore: Meshes, Domains, Topologies, Spaces, Fields, InputOutput
 using ClimaComms
 using NCDatasets


### PR DESCRIPTION
## Purpose 
This is a very quick and short PR (3 lines!) that addresses the possible conflicted version of sibling module namespaces.
 
Closes #222 
(Part of #205 )

## To-do
- [x] Use relative module qualifiers in `using` and `import` statements.

## Content
- [x] In `ConservationChecker.jl` and `Regridder.jl`, avoid specifying the parent module as `ClimaCoupler`, but use the `..` path.


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

- [x] I have read and checked the items on the review checklist.
