### PR TITLE
Fix paths for FlameGraphDiff on SLURM

### DIFF
--- a/perf/flame_diff.jl
+++ b/perf/flame_diff.jl
@@ -8,7 +8,7 @@ buildkite_cc_dir = "/groups/esm/slurm-buildkite/climacoupler-ci/"
 
 build_path = "/central/scratch/esm/slurm-buildkite/climacoupler-ci/$buildkite_bnumber/climacoupler-ci/perf/"
 cwd = pwd()
-@info "build_path is: $build_path; cwd is $cwd"
+@info "build_path is: $build_path"
 
 import Profile
 using Test
@@ -90,7 +90,7 @@ end
 
 # obtain the stacktree from the last saved file in `buildkite_cc_dir`
 ref_file = joinpath(buildkite_cc_dir, "$run_name.jld2")
-tracked_list = isfile(ref_file) ? load("$run_name.jld2") : Dict{String, Float64}()
+tracked_list = isfile(ref_file) ? load(ref_file) : Dict{String, Float64}()
 
 # compile coupling loop first
 step_coupler!(cs, n_samples)
@@ -116,6 +116,7 @@ flame_tree = profile_data.data["all"]
 my_dict = iterate_children(flame_tree)
 @info "This branch is: $buildkite_branch, commit $buildkite_commit"
 if buildkite_branch == "staging"
-    isfile(ref_file) ? mv(ref_file, "ref_file.$ref_file.$buildkite_commit") : nothing
+    isfile(ref_file) ?
+    mv(ref_file, joinpath(buildkite_cc_dir, "flame_diff_ref_file.$run_name.$buildkite_commit.jld2")) : nothing
     save(ref_file, my_dict) # reset ref_file upon staging
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Fix paths for saving reference files. Bug introduced in #238 (only apparent during merge, after staging). This is now tested for a dummy staging branch. 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [x] Fix and test the path bug. Files created as expected:
<img width="686" alt="Screen Shot 2023-02-04 at 7 43 31 AM" src="https://user-images.githubusercontent.com/38083334/216781336-48c7dc5a-ae5c-4554-a1eb-25108ad441c7.png">


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
