### PR TITLE
Make `swap_spaces` not allocating and more GPU compatible

### DIFF
--- a/experiments/AMIP/moist_mpi_aquaplanet/coupler_driver.jl
+++ b/experiments/AMIP/moist_mpi_aquaplanet/coupler_driver.jl
@@ -14,7 +14,7 @@ include("coupler_utils/conservation_checker.jl")
 include("coupler_utils/regridder.jl")
 
 # initiate spatial and temporal info
-t_end = 2592000 # 100e2 
+t_end = 2592000 # 100e2
 tspan = (0, t_end)
 Δt_cpl = 2e2
 saveat = Δt_cpl * 1000
@@ -51,7 +51,7 @@ walltime = @elapsed for t in (tspan[1]:Δt_cpl:tspan[end])
     parent(atmos_sim.integrator.p.dif_flux_energy) .= FT(0)
     calculate_surface_fluxes_atmos_grid!(atmos_sim.integrator, T_S)
 
-    # run 
+    # run
     step!(atmos_sim.integrator, t - atmos_sim.integrator.t, true) # NOTE: use (t - integ_atm.t) here instead of Δt_cpl to avoid accumulating roundoff error in our timestepping.
 
     ## Slab

--- a/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_driver.jl
@@ -5,16 +5,16 @@ include("mpi/mpi_init.jl") # setup MPI context for distributed runs #hide
 #=
 ## Overview
 
-AMIP is a standard experimental protocol of the Program for Climate Model Diagnosis & Intercomparison (PCMDI). 
+AMIP is a standard experimental protocol of the Program for Climate Model Diagnosis & Intercomparison (PCMDI).
 It is used as a model benchmark for the atmospheric and land model components, while sea-surface temperatures (SST) and sea-ice concentration (SIC)
 are prescribed using time-interpolations between monthly observed data. We use standard data files with original sources:
-- SST and SIC: https://gdex.ucar.edu/dataset/158_asphilli.html 
+- SST and SIC: https://gdex.ucar.edu/dataset/158_asphilli.html
 - land-sea mask: https://www.ncl.ucar.edu/Applications/Data/#cdf
 
-For more information, see the PCMDI's specifications for [AMIP I](https://pcmdi.github.io/mips/amip/) and [AMIP II](https://pcmdi.github.io/mips/amip2/). 
+For more information, see the PCMDI's specifications for [AMIP I](https://pcmdi.github.io/mips/amip/) and [AMIP II](https://pcmdi.github.io/mips/amip2/).
 
-This driver contains two modes. The full `AMIP` mode and a `SlabPlanet` (all surfaces are thermal slabs) mode. Since `AMIP` is not a closed system, the 
-`SlabPlanet` mode is useful for checking conservation properties of the coupling. 
+This driver contains two modes. The full `AMIP` mode and a `SlabPlanet` (all surfaces are thermal slabs) mode. Since `AMIP` is not a closed system, the
+`SlabPlanet` mode is useful for checking conservation properties of the coupling.
 
 =#
 
@@ -41,7 +41,7 @@ you can run directly from the Julia REPL. The latter is recommended for debuggin
 with threading enabled:
 ```julia
 julia --project --threads 8
-``` 
+```
 =#
 
 #=
@@ -84,7 +84,7 @@ if isinteractive()
     parsed_args["albedo_from_file"] = true #hide
 end
 
-## read in some parsed command line arguments 
+## read in some parsed command line arguments
 mode_name = parsed_args["mode_name"]
 run_name = parsed_args["run_name"]
 energy_check = parsed_args["energy_check"]
@@ -140,9 +140,9 @@ include("atmos/atmos_init.jl")
 atmos_sim = atmos_init(FT, Y, integrator, params = params);
 
 #=
-We use a common `Space` for all global surfaces. This enables the MPI processes to operate on the same columns in both 
-the atmospheric and surface components, so exchanges are parallelized. Note this is only possible when the 
-atmosphere and surface are of the same horizontal resolution. 
+We use a common `Space` for all global surfaces. This enables the MPI processes to operate on the same columns in both
+the atmospheric and surface components, so exchanges are parallelized. Note this is only possible when the
+atmosphere and surface are of the same horizontal resolution.
 =#
 ## init a 2D bounary space at the surface
 boundary_space = atmos_sim.domain.face_space.horizontal_space
@@ -176,9 +176,9 @@ land_sim = bucket_init(
 #=
 ### Ocean and Sea Ice
 In the `AMIP` mode, all ocean properties are prescribed from a file, while sea-ice temperatures are calculated using observed
-SIC and assuming a 2m thickness of the ice. 
+SIC and assuming a 2m thickness of the ice.
 
-In the `SlabPlanet` mode, all ocean and sea ice are dynamical models, namely thermal slabs, with different parameters. 
+In the `SlabPlanet` mode, all ocean and sea ice are dynamical models, namely thermal slabs, with different parameters.
 =#
 
 @info mode_name
@@ -252,7 +252,7 @@ end
 #=
 ## Coupler Initialization
 The coupler needs to contain exchange information, manage the calendar and be able to access all component models. It can also optionally
-save online diagnostics. These are all initialized here and saved in a global `CouplerSimulation` struct, `cs`. 
+save online diagnostics. These are all initialized here and saved in a global `CouplerSimulation` struct, `cs`.
 =#
 
 ## coupler exchange fields
@@ -305,7 +305,7 @@ cs = CouplerSimulation{FT}(
 );
 
 #=
-## Initial States Exchange 
+## Initial States Exchange
 =#
 ## share states between models
 include("./push_pull.jl")
@@ -343,7 +343,7 @@ function solve_coupler!(cs, energy_check)
 
         cs.dates.date[1] = current_date(cs, t) # if not global, `date` is not updated.
 
-        ## print date on the first of month 
+        ## print date on the first of month
         @calendar_callback :(@show(cs.dates.date[1])) cs.dates.date[1] cs.dates.date1[1]
 
         if cs.mode.name == "amip"
@@ -434,8 +434,8 @@ end
 solve_coupler!(cs, energy_check);
 
 #=
-## Postprocessing 
-Currently all postprocessing is performed using the root process only. 
+## Postprocessing
+Currently all postprocessing is performed using the root process only.
 =#
 
 if ClimaComms.iamroot(comms_ctx)
@@ -518,7 +518,7 @@ if ClimaComms.iamroot(comms_ctx)
 end
 
 #=
-## Temporary Unit Tests 
+## Temporary Unit Tests
 To be moved to `test/`
 =#
 if !is_distributed && cs.mode.name == "amip"

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/bcfile_reader.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/bcfile_reader.jl
@@ -97,7 +97,7 @@ function bcfile_info_init(
 
 end
 
-no_scaling(x, _info) = swap_space!(x, axes(_info.land_mask))
+no_scaling(x, _info) = swap_space!(zeros(axes(_info.land_mask)), x)
 
 # IO - monthly
 """

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/conservation_checker.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/conservation_checker.jl
@@ -41,8 +41,9 @@ function check_conservation(cc::OnlineConservationCheck, coupler_sim)
         get_land_energy(land_sim, e_per_area_land)
     end
 
-    u_ocn = ocean_sim !== nothing ? swap_space!(ocean_sim.integrator.u.T_sfc, coupler_sim.boundary_space) : nothing
-    u_ice = ice_sim !== nothing ? swap_space!(ice_sim.integrator.u.T_sfc, coupler_sim.boundary_space) : nothing
+    u_ocn =
+        ocean_sim !== nothing ? swap_space!(zeros(coupler_sim.boundary_space), ocean_sim.integrator.u.T_sfc) : nothing
+    u_ice = ice_sim !== nothing ? swap_space!(zeros(coupler_sim.boundary_space), ice_sim.integrator.u.T_sfc) : nothing
 
     # global sums
     atmos_e = sum(u_atm)
@@ -101,7 +102,7 @@ function check_conservation(cc::OnlineConservationCheck, coupler_sim)
     push!(cc.ρe_tot_ocean, ocean_e)
 
     # save surface friction sink
-    push!(cc.friction_sink, sum((ke_dissipation(atmos_sim)) .* coupler_sim.Δt_cpl)) # ρ d ke_friction / dt 
+    push!(cc.friction_sink, sum((ke_dissipation(atmos_sim)) .* coupler_sim.Δt_cpl)) # ρ d ke_friction / dt
 
 end
 function ke_dissipation(sim)

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/flux_calculator.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/flux_calculator.jl
@@ -5,7 +5,7 @@ import ClimaAtmos: get_surface_fluxes!
 """
     set_ρ_sfc!(ρ_sfc, T_S, integrator)
 
-sets the value of the ρ_sfc field based on the temperature of the surface, 
+sets the value of the ρ_sfc field based on the temperature of the surface,
 the temperature of the atmosphere at the lowest level, and the heigh
 of the lowest level.
 """
@@ -13,7 +13,7 @@ function set_ρ_sfc!(ρ_sfc, T_S, integrator)
     ts = integrator.p.ᶜts
     thermo_params = CAP.thermodynamics_params(integrator.p.params)
     ts_int = Spaces.level(ts, 1)
-    parent(ρ_sfc) .= parent(ρ_sfc_at_point.(thermo_params, ts_int, swap_space!(T_S, axes(ts_int))))
+    parent(ρ_sfc) .= parent(ρ_sfc_at_point.(thermo_params, ts_int, swap_space!(zeros(axes(ts_int)), T_S)))
 end
 
 """
@@ -23,7 +23,7 @@ Computes the surface density at a point given the atmospheric state
 at the lowest level, the surface temperature, and the assumption of
 an ideal gas and hydrostatic balance.
 
-Required because the surface models do not compute air density as a 
+Required because the surface models do not compute air density as a
 variable.
 """
 function ρ_sfc_at_point(params, ts_int, T_sfc)
@@ -37,9 +37,9 @@ end
 """
     calculate_surface_fluxes_atmos_grid!(integrator)
 
-Calculates surface fluxes using adapter function `get_surface_fluxes!` 
-from ClimaAtmos that calls `SurfaceFluxes.jl`. The coupler updates in 
-atmos model cache fluxes at each coupling timestep. 
+Calculates surface fluxes using adapter function `get_surface_fluxes!`
+from ClimaAtmos that calls `SurfaceFluxes.jl`. The coupler updates in
+atmos model cache fluxes at each coupling timestep.
 
 - TODO: generalize interface for regridding and take land state out of atmos's integrator.p
 """

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/general_helper.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/general_helper.jl
@@ -20,9 +20,8 @@ end
 CouplerSimulation{FT}(args...) where {FT} = CouplerSimulation{FT, typeof.(args[1:5])...}(args...)
 float_type(::CouplerSimulation{FT}) where {FT} = FT
 
-function swap_space!(field, new_space)
-    field_out = zeros(new_space)
-    parent(field_out) .= parent(field)
+function swap_space!(field_out, field_in)
+    parent(field_out) .= parent(field_in)
     return field_out
 end
 

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/masker.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/masker.jl
@@ -23,7 +23,7 @@ function land_sea_mask(
     ClimaComms.barrier(comms_ctx)
     file_dates = load(joinpath(REGRID_DIR, outfile_root * "_times.jld2"), "times")
     mask = hdread_regridfile(comms_ctx, outfile_root, file_dates[1], varname)
-    mask = swap_space!(mask, boundary_space) # needed if we are reading from previous run
+    mask = swap_space!(zeros(boundary_space), mask) # needed if we are reading from previous run
     return mono ? mask : binary_mask.(mask, threshold = threshold)
 end
 

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/variable_definer.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/variable_definer.jl
@@ -12,16 +12,16 @@ get_var(cs, ::Val{:u}) = ClimaCore.Geometry.UVVector.(cs.model_sims.atmos_sim.in
 get_var(cs, ::Val{:q_tot}) =
     cs.model_sims.atmos_sim.integrator.u.c.ρq_tot ./ cs.model_sims.atmos_sim.integrator.u.c.ρ .* float_type(cs)(1000)
 
-get_var(cs, ::Val{:toa}) = swap_space!(toa_fluxes(cs), cs.boundary_space)
+get_var(cs, ::Val{:toa}) = swap_space!(zeros(cs.boundary_space), toa_fluxes(cs))
 
 get_var(cs, ::Val{:precipitation}) =
     .-swap_space!(
+        zeros(cs.boundary_space),
         cs.model_sims.atmos_sim.integrator.p.col_integrated_rain .+
         cs.model_sims.atmos_sim.integrator.p.col_integrated_snow,
-        cs.boundary_space,
     )
 
-get_var(cs, ::Val{:T_sfc}) = swap_space!(cs.fields.T_S, cs.boundary_space)
+get_var(cs, ::Val{:T_sfc}) = swap_space!(zeros(cs.boundary_space), cs.fields.T_S)
 
 # more complex calculations
 function zonal_wind(cs)

--- a/experiments/AMIP/moist_mpi_earth/slab_ice/slab_init.jl
+++ b/experiments/AMIP/moist_mpi_earth/slab_ice/slab_init.jl
@@ -8,7 +8,7 @@ struct IceSlabParameters{FT <: AbstractFloat}
     T_base::FT
     z0m::FT
     z0b::FT
-    T_freeze::FT # temperature at freezing point [K] 
+    T_freeze::FT # temperature at freezing point [K]
     k_ice::FT   # thermal conductivity of ice [W / m / K]
     α::FT # albedo
 end
@@ -38,7 +38,7 @@ end
 """
 ice_init(::Type{FT}; tspan, dt, saveat, space, ice_mask, stepper = Euler()) where {FT}
 
-Initializes the `DiffEq` problem, and creates a Simulation-type object containing the necessary information for `step!` in the coupling loop. 
+Initializes the `DiffEq` problem, and creates a Simulation-type object containing the necessary information for `step!` in the coupling loop.
 """
 function ice_init(::Type{FT}; tspan, saveat, dt, space, ice_mask, stepper = Euler()) where {FT}
 
@@ -66,17 +66,16 @@ end
 
 # file-specific
 """
-    clean_sic(SIC, _info) 
-Ensures that the space of the SIC struct matches that of the mask, and converts the units from area % to area fraction. 
+    clean_sic(SIC, _info)
+Ensures that the space of the SIC struct matches that of the mask, and converts the units from area % to area fraction.
 """
+clean_sic(SIC, _info) = swap_space!(zeros(axes(_info.land_mask)), SIC) ./ float_type_bcf(_info)(100.0)
 
-clean_sic(SIC, _info) = swap_space!(SIC, axes(_info.land_mask)) ./ float_type_bcf(_info)(100.0)
-
-# setting that SIC < 0.5 os counted as ocean if binary remapping of landsea mask. 
+# setting that SIC < 0.5 os counted as ocean if binary remapping of landsea mask.
 get_ice_mask(h_ice::FT, mono, threshold = 0.5) where {FT} = mono ? h_ice : binary_mask.(h_ice, threshold = threshold)
 
 """
-apply_mask(mask, condition, yes, no, value = 0.5) 
+apply_mask(mask, condition, yes, no, value = 0.5)
 - apply mask mased on a threshold value in the mask
 """
 apply_mask(mask, condition, yes, no, value) = condition(mask, value) ? yes : no

--- a/experiments/AMIP/moist_mpi_earth/slab_ocean/slab_init.jl
+++ b/experiments/AMIP/moist_mpi_earth/slab_ocean/slab_init.jl
@@ -48,7 +48,7 @@ end
 """
     ocean_init(::Type{FT}; tspan, dt, saveat, space, land_mask, stepper = Euler()) where {FT}
 
-Initializes the `DiffEq` problem, and creates a Simulation-type object containing the necessary information for `step!` in the coupling loop. 
+Initializes the `DiffEq` problem, and creates a Simulation-type object containing the necessary information for `step!` in the coupling loop.
 """
 function ocean_init(::Type{FT}; tspan, dt, saveat, space, ocean_mask, stepper = Euler()) where {FT}
 
@@ -69,7 +69,7 @@ end
 
 # file specific
 """
-    clean_sst(SST::FT, _info) 
+    clean_sst(SST::FT, _info)
 Ensures that the space of the SST struct matches that of the mask, and converts the units to Kelvin (N.B.: this is dataset specific)
 """
-clean_sst(SST, _info) = (swap_space!(SST, axes(_info.land_mask)) .+ float_type_bcf(_info)(273.15))
+clean_sst(SST, _info) = (swap_space!(zeros(axes(_info.land_mask)), SST) .+ float_type_bcf(_info)(273.15))

--- a/experiments/AMIP/moist_mpi_earth/user_diagnostics.jl
+++ b/experiments/AMIP/moist_mpi_earth/user_diagnostics.jl
@@ -60,7 +60,7 @@ function get_var(cs::CoupledSimulation, ::Val{:toa})
     )
 
     radiation_sources = @. -(LWd_TOA + SWd_TOA - LWu_TOA - SWu_TOA)
-    swap_space!(radiation_sources, cs.boundary_space)
+    swap_space!(zeros(cs.boundary_space), radiation_sources)
 end
 
 """
@@ -70,9 +70,9 @@ Precipitation (m m⁻²).
 """
 get_var(cs::CoupledSimulation, ::Val{:precipitation}) =
     .-swap_space!(
+        zeros(cs.boundary_space),
         cs.model_sims.atmos_sim.integrator.p.col_integrated_rain .+
         cs.model_sims.atmos_sim.integrator.p.col_integrated_snow,
-        cs.boundary_space,
     )
 
 # coupler diagnotics
@@ -81,6 +81,6 @@ get_var(cs::CoupledSimulation, ::Val{:precipitation}) =
 
 Combined surface temperature (K).
 """
-get_var(cs::CoupledSimulation, ::Val{:T_sfc}) = swap_space!(cs.fields.T_S, cs.boundary_space)
+get_var(cs::CoupledSimulation, ::Val{:T_sfc}) = swap_space!(zeros(cs.boundary_space), cs.fields.T_S)
 
 # land diagnotics

--- a/experiments/AMIP/moist_mpi_earth_dynamical_sea_ice/coupler_driver.jl
+++ b/experiments/AMIP/moist_mpi_earth_dynamical_sea_ice/coupler_driver.jl
@@ -49,7 +49,7 @@ include("slab_ocean/slab_init.jl")
 prescribed_sst = false
 if prescribed_sst == true
     SST = ncreader_rll_to_cgll_from_space(FT, "data/sst.nc", "SST", boundary_space)  # a sample SST field from https://gdex.ucar.edu/dataset/158_asphilli.html
-    SST = swap_space!(SST, axes(mask)) .* (abs.(mask .- 1)) .+ FT(273.15) # TODO: avoids the "space not the same instance" error
+    SST = swap_space!(zeros(axes(mask)), SST) .* (abs.(mask .- 1)) .+ FT(273.15) # TODO: avoids the "space not the same instance" error
     ocean_params = OceanSlabParameters(FT(20), FT(1500.0), FT(800.0), FT(280.0), FT(1e-3), FT(1e-5))
 else
     slab_ocean_sim = slab_ocean_init(FT, tspan, dt = Δt_cpl, space = boundary_space, saveat = saveat, mask = mask)
@@ -60,7 +60,7 @@ prescribed_sic = false
 if prescribed_sic == true
     # sample SST field
     SIC = ncreader_rll_to_cgll_from_space(FT, "data/sic.nc", "SEAICE", boundary_space)
-    SIC = swap_space!(SIC, axes(mask)) .* (abs.(mask .- 1))
+    SIC = swap_space!(zeros(axes(mask)), SIC) .* (abs.(mask .- 1))
     slab_ice_sim = slab_ice_init(
         FT,
         tspan,
@@ -179,7 +179,7 @@ walltime = @elapsed for t in (tspan[1]:Δt_cpl:tspan[end])
 
     atmos_sim.integrator.p.rrtmgp_model.surface_temperature .= field2array(T_S) # supplied to atmos for radiation
 
-    # run 
+    # run
     step!(atmos_sim.integrator, t - atmos_sim.integrator.t, true) # NOTE: instead of Δt_cpl, to avoid accumulating roundoff error
 
     #clip TODO: this is bad!! > limiters

--- a/experiments/AMIP/moist_mpi_earth_dynamical_sea_ice/coupler_utils/flux_calculator.jl
+++ b/experiments/AMIP/moist_mpi_earth_dynamical_sea_ice/coupler_utils/flux_calculator.jl
@@ -20,10 +20,10 @@ function calculate_surface_fluxes_atmos_grid!(integrator, info_sfc)
             Geometry.UVVector.(Spaces.level(Y.c.uₕ, 1)),
             Spaces.level(Fields.coordinate_field(Y.c).z, 1),
             FT(0), # TODO: get actual value of z_sfc
-            swap_space!(T_sfc, axes(Spaces.level(Y.c, 1))), # remove when same instance issue is resolved
+            swap_space!(zeros(axes(Spaces.level(Y.c, 1))), T_sfc), # remove when same instance issue is resolved
             params,
-            swap_space!(z0m, axes(Spaces.level(Y.c, 1))), # TODO: get these roughness lengths from land
-            swap_space!(z0b, axes(Spaces.level(Y.c, 1))),
+            swap_space!(zeros(axes(Spaces.level(Y.c, 1))), z0m), # TODO: get these roughness lengths from land
+            swap_space!(zeros(axes(Spaces.level(Y.c, 1))), z0b),
             Cd,
             Ch,
         )
@@ -32,23 +32,23 @@ function calculate_surface_fluxes_atmos_grid!(integrator, info_sfc)
     if :ρe in propertynames(Y.c)
 
         flux_energy = ones(axes(dif_flux_energy))
-        parent(flux_energy) .= parent(tsf.shf .+ tsf.lhf .* swap_space!(abs.(ice_mask .- FT(1)), axes(tsf.shf)))  # only SHF above sea ice
-        @. dif_flux_energy = Geometry.WVector(flux_energy) #Geometry.WVector.(swap_space!(tsf.shf .+ tsf.lhf, axes(dif_flux_energy)) )
+        parent(flux_energy) .= parent(tsf.shf .+ tsf.lhf .* swap_space!(zeros(axes(tsf.shf)), abs.(ice_mask .- FT(1))))  # only SHF above sea ice
+        @. dif_flux_energy = Geometry.WVector(flux_energy) #Geometry.WVector.(swap_space!(zeros(axes(dif_flux_energy)), tsf.shf .+ tsf.lhf) )
     end
 
     # Moisture mass flux
     if :ρq_tot in propertynames(Y.c)
         flux_mass = ones(axes(dif_flux_ρq_tot))
-        parent(flux_mass) .= parent(tsf.E .* swap_space!(abs.(ice_mask .- FT(1)), axes(tsf.E)))
+        parent(flux_mass) .= parent(tsf.E .* swap_space!(zeros(axes(tsf.E)), abs.(ice_mask .- FT(1))))
         @. dif_flux_ρq_tot = Geometry.WVector(flux_mass) # no E above sea ice
     end
 
     # Momentum flux
-    u_space = axes(tsf.ρτxz) # TODO: delete when "space not the same instance" error is dealt with 
+    u_space = axes(tsf.ρτxz) # TODO: delete when "space not the same instance" error is dealt with
     normal = Geometry.WVector.(ones(u_space)) # TODO: this will need to change for topography
-    ρ_1 = Fields.Field(Fields.field_values(Fields.level(Y.c.ρ, 1)), u_space) # TODO: delete when "space not the same instance" error is dealt with 
+    ρ_1 = Fields.Field(Fields.field_values(Fields.level(Y.c.ρ, 1)), u_space) # TODO: delete when "space not the same instance" error is dealt with
     if :uₕ in propertynames(Y.c)
-        parent(dif_flux_uₕ) .=  # TODO: remove parent when "space not the same instance" error is dealt with 
+        parent(dif_flux_uₕ) .=  # TODO: remove parent when "space not the same instance" error is dealt with
             parent(
                 Geometry.Contravariant3Vector.(normal) .⊗
                 Geometry.Covariant12Vector.(Geometry.UVVector.(tsf.ρτxz ./ ρ_1, tsf.ρτyz ./ ρ_1)),
@@ -63,10 +63,10 @@ function calculate_surface_fluxes_atmos_grid!(integrator, info_sfc)
             Geometry.UVVector.(Spaces.level(Y.c.uₕ, 1)),
             Spaces.level(Fields.coordinate_field(Y.c).z, 1),
             FT(0), # TODO: get actual value of z_sfc
-            swap_space!(T_sfc .+ ΔT_sfc, axes(Spaces.level(Y.c, 1))), # remove when same instance issue is resolved
+            swap_space!(zeros(axes(Spaces.level(Y.c, 1))), T_sfc .+ ΔT_sfc), # remove when same instance issue is resolved
             params,
-            swap_space!(z0m, axes(Spaces.level(Y.c, 1))), # TODO: get these roughness lengths from land
-            swap_space!(z0b, axes(Spaces.level(Y.c, 1))),
+            swap_space!(zeros(axes(Spaces.level(Y.c, 1))), z0m), # TODO: get these roughness lengths from land
+            swap_space!(zeros(axes(Spaces.level(Y.c, 1))), z0b),
             Cd,
             Ch,
         )

--- a/experiments/AMIP/moist_mpi_earth_dynamical_sea_ice/coupler_utils/general_helper.jl
+++ b/experiments/AMIP/moist_mpi_earth_dynamical_sea_ice/coupler_utils/general_helper.jl
@@ -13,9 +13,8 @@ float_type(::CouplerSimulation{FT}) where {FT} = FT
 
 get_u(sim, t) = Geometry.UVVector.(sim.integrator.sol.u[t].c.uₕ).components.data.:1
 
-function swap_space!(field, new_space)
-    field_out = zeros(new_space)
-    parent(field_out) .= parent(field)
+function swap_space!(field_out, field_in)
+    parent(field_out) .= parent(field_in)
     return field_out
 end
 

--- a/experiments/AMIP/moist_mpi_earth_dynamical_sea_ice/coupler_utils/viz_explorer.jl
+++ b/experiments/AMIP/moist_mpi_earth_dynamical_sea_ice/coupler_utils/viz_explorer.jl
@@ -80,7 +80,7 @@ function plot_anim(atmos_sim, slab_sim, slab_ocean_sim, slab_ice_sim) # TODO: us
             u = slab_ice_sim.integrator.sol.u[t_i]
             t = t_i / 24 / 60 / 60
             Plots.plot(
-                u.h_ice .* swap_space!(abs.(mask .- FT(1)), axes(u.h_ice)),
+                u.h_ice .* swap_space!(zeros(axes(u.h_ice)), abs.(mask .- FT(1))),
                 clims = (0, 0.35),
                 title = ("day: $t"),
             )#.- Fields.level(sol_atm.u[1].c.ρt_tot,1),  clims = (-5000, 50000) )

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -16,8 +16,8 @@ filename = joinpath(cc_dir, "experiments", "AMIP", "moist_mpi_earth", "coupler_d
 run_name_list = ["default_modular", "coarse_single_modular", "target_amip_n32_shortrun"]
 run_name = run_name_list[parse(Int, ARGS[2])]
 allocs_limit = Dict()
-allocs_limit["perf_default_modular"] = 2685440
-allocs_limit["perf_coarse_single_modular"] = 3864320
+allocs_limit["perf_default_modular"] = 2685744
+allocs_limit["perf_coarse_single_modular"] = 3864624
 allocs_limit["perf_target_amip_n32_shortrun"] = 172134848
 
 # number of time steps used for profiling

--- a/src/BCReader.jl
+++ b/src/BCReader.jl
@@ -66,7 +66,7 @@ Remap the values of a `field` onto the space of the
 - `bcf_info`: [BCFileInfo] contains a land_mask to remap onto the space of.
 """
 no_scaling(field::Fields.Field, bcf_info::BCFileInfo{FT}) where {FT} =
-    Utilities.swap_space!(field, axes(bcf_info.land_mask))
+    Utilities.swap_space!(zeros(axes(bcf_info.land_mask)), field)
 
 """
     bcfile_info_init(

--- a/src/ConservationChecker.jl
+++ b/src/ConservationChecker.jl
@@ -107,7 +107,7 @@ function check_conservation!(
         )
 
         coupler_sim.fields.F_R_TOA .-=
-            swap_space!(LWd_TOA .+ SWd_TOA .- LWu_TOA .- SWu_TOA, boundary_space) .* coupler_sim.Δt_cpl
+            swap_space!(zeros(boundary_space), LWd_TOA .+ SWd_TOA .- LWu_TOA .- SWu_TOA) .* coupler_sim.Δt_cpl
         radiation_sources_accum = sum(coupler_sim.fields.F_R_TOA) # accumulated radiation sources + sinks [J]
         push!(cc.toa_net_source, radiation_sources_accum)
     else
@@ -186,7 +186,7 @@ function check_conservation!(
     end
 
     # save sea ice
-    coupler_sim.fields.P_net .-= swap_space!(surface_water_gain_from_rates(coupler_sim), boundary_space) # accumulated surface water gain
+    coupler_sim.fields.P_net .-= swap_space!(zeros(boundary_space), surface_water_gain_from_rates(coupler_sim)) # accumulated surface water gain
     if ice_sim !== nothing
         push!(cc.ρq_tot_seaice, sum(coupler_sim.fields.P_net .* surface_masks.ice)) # kg (∫ P_net dV)
     else

--- a/src/Regridder.jl
+++ b/src/Regridder.jl
@@ -387,7 +387,7 @@ function land_sea_mask(
     ClimaComms.barrier(comms_ctx)
     file_dates = JLD2.load(joinpath(REGRID_DIR, outfile_root * "_times.jld2"), "times")
     mask = read_from_hdf5(REGRID_DIR, outfile_root, file_dates[1], varname, comms_ctx)
-    mask = swap_space!(mask, boundary_space) # needed if we are reading from previous run
+    mask = swap_space!(zeros(boundary_space), mask) # needed if we are reading from previous run
     return mono ? mask : binary_mask.(mask, threshold = threshold)
 end
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -61,17 +61,16 @@ Return the floating point type backing `T`: `T` can either be an object or a typ
 float_type(::CoupledSimulation{FT}) where {FT} = FT
 
 """
-    swap_space!(field::Fields.Field, new_space)
+    swap_space!(field_out::Fields.Field, field_in::Fields.Field)
 
 Remap the values of a field onto a new space.
 
 # Arguments
-- `field`: [Fields.Field] to be remapped to new space.
-- `new_space`: [Spaces.Space] to remap `field` to.
+- `field_in`: [Fields.Field] to be remapped to new space.
+- `field_out`: [Fields.Field] to remap `field_in` to.
 """
-function swap_space!(field::Fields.Field, new_space)
-    field_out = zeros(new_space)
-    parent(field_out) .= parent(field)
+function swap_space!(field_out, field_in::Fields.Field)
+    parent(field_out) .= parent(field_in)
     return field_out
 end
 

--- a/test/bcreader_tests.jl
+++ b/test/bcreader_tests.jl
@@ -1,4 +1,4 @@
-#= 
+#=
     Unit tests for ClimaCoupler BCReader module
 =#
 
@@ -130,7 +130,7 @@ for FT in (Float32, Float64)
             Nq = 4
             domain = Domains.SphereDomain(radius)
             mesh = Meshes.EquiangularCubedSphere(domain, 4)
-            topology = Topologies.Topology2D(mesh)
+            topology = Topologies.DistributedTopology2D(comms_ctx, mesh, Topologies.spacefillingcurve(mesh))
             quad = Spaces.Quadratures.GLL{Nq}()
             boundary_space_t = Spaces.SpectralElementSpace2D(topology, quad)
 

--- a/test/regridder_tests.jl
+++ b/test/regridder_tests.jl
@@ -1,4 +1,4 @@
-#= 
+#=
     Unit tests for ClimaCoupler Regridder module
 =#
 

--- a/test/utilities_tests.jl
+++ b/test/utilities_tests.jl
@@ -29,10 +29,12 @@ for FT in (Float32, Float64)
 
     @testset "test swap_space!" begin
         space1 = TestHelper.create_space(FT, R = FT(6371e3))
-        space2 = TestHelper.create_space(FT, R = FT(6371e3) / 2)
+        space2 = TestHelper.create_space(FT, R = FT(6371e3))
 
         field1 = ones(space1)
-        field2 = Utilities.swap_space!(field1, space2)
+        field2 = ones(space2)
+
+        field2 = Utilities.swap_space!(field2, field1)
 
         @test parent(field1) == parent(field2)
         @test axes(field2) == space2


### PR DESCRIPTION
## Purpose 
The purspose of this PR is to improve `swap_space` so that it is not allocating and to make it GPU compatible.  

Closes #248 

## To-do
- [x] ~~Remove internal call to ClimaCore `parent`~~ This cannot be done internally in the function (see error: `ERROR: LoadError: syntax: Global method definition around .... needs to be placed at the top level, or use "eval".` because of the global method table). So it needs to be worked around wherever it's used.
- [x] Make it `@inline`?

## Content
We remove the internal usage of ClimaCore `parent` by using ClimaCore's `Fields.allow_mismatched_diagonalized_spaces()` function as a temporary workaround, in the absence of a better ClimaCore's interface 

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


- [x] I have read and checked the items on the review checklist.
