### PR TITLE
BCReader: use generic struct properties

### DIFF
--- a/src/BCReader.jl
+++ b/src/BCReader.jl
@@ -36,7 +36,7 @@ Stores information specific to each boundary condition from a file and each vari
 - segment_length::Vector{Int}     # length of each month segment (used in the daily interpolation)
 - interpolate_daily::Bool         # switch to trigger daily interpolation
 """
-struct BCFileInfo{FT <: Real, B, X, S, V, D, C, O, M}
+struct BCFileInfo{FT <: Real, B, X, S, V, D, C, O, M, VI}
     bcfile_dir::B
     comms_ctx::X
     hd_outfile_root::S
@@ -45,13 +45,13 @@ struct BCFileInfo{FT <: Real, B, X, S, V, D, C, O, M}
     monthly_fields::C
     scaling_function::O
     land_mask::M
-    segment_idx::Vector{Int}
-    segment_idx0::Vector{Int}
-    segment_length::Vector{Int}
+    segment_idx::VI
+    segment_idx0::VI
+    segment_length::VI
     interpolate_daily::Bool
 end
 
-BCFileInfo{FT}(args...) where {FT} = BCFileInfo{FT, typeof.(args[1:8])...}(args...)
+BCFileInfo{FT}(args...) where {FT} = BCFileInfo{FT, typeof.(args[1:9])...}(args...)
 
 float_type_bcf(::BCFileInfo{FT}) where {FT} = FT
 


### PR DESCRIPTION
## Purpose 
This PR is a follow-up of #227 . It improves type safety and compiler optimization by removing abstract types in the BCReader struct.

Closes #250 


## Content
It improves type safety and compiler optimization by removing abstract types in the BCReader struct.


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


- [x] I have read and checked the items on the review checklist.
