### PR TITLE
Remove FT_dot

### DIFF
--- a/src/Regridder.jl
+++ b/src/Regridder.jl
@@ -19,7 +19,6 @@ using JLD2
 export write_to_hdf5,
     read_from_hdf5, dummmy_remap!, remap_field_cgll_to_rll, land_sea_mask, update_masks!, combine_surfaces!, binary_mask
 
-FT_dot(x) = FT.(x)
 nans_to_zero(v) = isnan(v) ? typeof(v)(0) : v
 
 """


### PR DESCRIPTION
## Purpose 

The purpose of this PR (a simple one-liner!) is to remove `FT_dot` since it was allocating and referencing an undefined variable. 

This is part of the clean-up/perf improvement work in #205 

Closes #252 

## Content
- Removes the `FT_dot` function.
 
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


- [x] I have read and checked the items on the review checklist.
