### PR TITLE
Throw warnings when zeroing NaNs

### DIFF
--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/masker.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/masker.jl
@@ -30,7 +30,7 @@ end
 """
     update_masks!(cs)
 
-Updates dynamically changing masks. 
+Updates dynamically changing masks.
 """
 function update_masks!(cs)
 
@@ -52,7 +52,7 @@ end
 """
     binary_mask(var::FT; threshold = 0.5)
 
-Converts a number to 1 or 0 of the same type, based on a threashold. 
+Converts a number to 1 or 0 of the same type, based on a threashold.
 """
 
 binary_mask(var::FT; threshold = 0.5) where {FT} = (var - FT(threshold)) > FT(0) ? FT(1) : FT(0)
@@ -64,18 +64,23 @@ Sums Field objects in `fields` weighted by the respective masks.
 """
 function combine_surfaces!(combined_field::Fields.Field, masks::NamedTuple, fields::NamedTuple)
     combined_field .= eltype(combined_field)(0)
+    warn_nans = false
     for surface_name in propertynames(fields) # could use dot here?
-        field_no_nans = nans_to_zero.(getproperty(fields, surface_name))  # TODO: performance analysis / alternatives
-        combined_field .+= getproperty(masks, surface_name) .* field_no_nans
+        if any(x -> isnan(x), getproperty(fields, surface_name))
+            warn_nans = true
+        end
+        combined_field .+= getproperty(masks, surface_name) .* nans_to_zero.(getproperty(fields, surface_name))
     end
-
+    warn_nans && @warn "NaNs were detected and converted to zeros."
 end
-nans_to_zero(v) = isnan(v) ? FT(0) : v
+
+#= Converts NaNs to zeros of the same type. =#
+nans_to_zero(v) = isnan(v) ? typeof(v)(0) : v
 
 """
     update_masks!(cs)
 
-Updates dynamically changing masks. 
+Updates dynamically changing masks.
 """
 function update_masks!(cs)
 
@@ -97,7 +102,7 @@ end
 
 """
     time_slice_ncfile(sic_data, time_idx = 1)
-- slices a dataset at time index `time_idx` and saves it under `sic_data_slice`. Used for more efficient regridding of mask, SST and SIC files. 
+- slices a dataset at time index `time_idx` and saves it under `sic_data_slice`. Used for more efficient regridding of mask, SST and SIC files.
 """
 function time_slice_ncfile(sic_data, time_idx = 1)
     sic_data_slice = sic_data[1:(end - 3)] * "_one_time.nc"

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -1,4 +1,4 @@
-# flame.jl: provides allocation breakdown for individual backtraces for single-process unthredded runs 
+# flame.jl: provides allocation breakdown for individual backtraces for single-process unthredded runs
 # and check for overall allocation limits based on previous runs
 # copied and modified from `ClimaAtmos/perf`
 
@@ -16,14 +16,14 @@ filename = joinpath(cc_dir, "experiments", "AMIP", "moist_mpi_earth", "coupler_d
 run_name_list = ["default_modular", "coarse_single_modular", "target_amip_n32_shortrun"]
 run_name = run_name_list[parse(Int, ARGS[2])]
 allocs_limit = Dict()
-allocs_limit["perf_default_modular"] = 6639776
-allocs_limit["perf_coarse_single_modular"] = 6639776
-allocs_limit["perf_target_amip_n32_shortrun"] = 428396688
+allocs_limit["perf_default_modular"] = 2685440
+allocs_limit["perf_coarse_single_modular"] = 3864320
+allocs_limit["perf_target_amip_n32_shortrun"] = 172134848
 
 # number of time steps used for profiling
 const n_samples = 2
 
-# flag to split coupler init from its solve 
+# flag to split coupler init from its solve
 ENV["CI_PERF_SKIP_COUPLED_RUN"] = true
 
 # pass in the correct arguments, overriding defaults with those specific to each run_name (in `pipeline.yaml`)


### PR DESCRIPTION
## Purpose 
The purpose of this PR is to improve the `nans_to_zero` function so that it throws a warning to the user. 

Closes #254 

## Content
- [x] Added docstring
- [x] Added a warning for the user
- [x] Removed a duplicate definition in `experiments/AMIP/moist_mpi_earth/coupler_utils/masker.jl`


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

- [x] I have read and checked the items on the review checklist.
