### PR TITLE
Make comms_ctx a required arg

### DIFF
--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/bcfile_reader.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/bcfile_reader.jl
@@ -166,7 +166,7 @@ next_date_in_file(bcfile_info) = bcfile_info.all_dates[bcfile_info.segment_idx[1
 """
     interpolate_midmonth_to_daily(date, bcf_info)
 
-Interpolates linearly between two `Fields` in the `bcf_info` struct, or returns the first Field if interpolation is switched off. 
+Interpolates linearly between two `Fields` in the `bcf_info` struct, or returns the first Field if interpolation is switched off.
 """
 function interpolate_midmonth_to_daily(date, bcf_info)
 
@@ -190,7 +190,7 @@ end
 """
     interpol(f1::FT, f2::FT, Δt_tt1::FT, Δt_t2t1::FT) where {FT}
 
-Performs linear interpolation of `f` at time `t` within a segment `Δt_t2t1 = (t2 - t1)`, of fields `f1` and `f2`, with `t2 > t1`. 
+Performs linear interpolation of `f` at time `t` within a segment `Δt_t2t1 = (t2 - t1)`, of fields `f1` and `f2`, with `t2 > t1`.
 
 `Δt_tt1 = (t - t1)`
 `f(t1) = f1`

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/masker.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/masker.jl
@@ -30,7 +30,7 @@ end
 """
     update_masks!(cs)
 
-Updates dynamically changing masks. 
+Updates dynamically changing masks.
 """
 function update_masks!(cs)
 
@@ -52,7 +52,7 @@ end
 """
     binary_mask(var::FT; threshold = 0.5)
 
-Converts a number to 1 or 0 of the same type, based on a threashold. 
+Converts a number to 1 or 0 of the same type, based on a threashold.
 """
 
 binary_mask(var::FT; threshold = 0.5) where {FT} = (var - FT(threshold)) > FT(0) ? FT(1) : FT(0)
@@ -75,7 +75,7 @@ nans_to_zero(v) = isnan(v) ? FT(0) : v
 """
     update_masks!(cs)
 
-Updates dynamically changing masks. 
+Updates dynamically changing masks.
 """
 function update_masks!(cs)
 
@@ -97,7 +97,7 @@ end
 
 """
     time_slice_ncfile(sic_data, time_idx = 1)
-- slices a dataset at time index `time_idx` and saves it under `sic_data_slice`. Used for more efficient regridding of mask, SST and SIC files. 
+- slices a dataset at time index `time_idx` and saves it under `sic_data_slice`. Used for more efficient regridding of mask, SST and SIC files.
 """
 function time_slice_ncfile(sic_data, time_idx = 1)
     sic_data_slice = sic_data[1:(end - 3)] * "_one_time.nc"

--- a/experiments/AMIP/moist_mpi_earth/coupler_utils/regridder.jl
+++ b/experiments/AMIP/moist_mpi_earth/coupler_utils/regridder.jl
@@ -14,8 +14,8 @@ ClimaComms.barrier(comms_ctx)
 """
     reshape_cgll_sparse_to_field!(field::Fields.Field, in_array::Array, R)
 
-Reshapes a sparse vector array (raw output of the TempestRemap) to a Field object. 
-Redundant nodes are populated using `dss` operations. 
+Reshapes a sparse vector array (raw output of the TempestRemap) to a Field object.
+Redundant nodes are populated using `dss` operations.
 """
 function reshape_cgll_sparse_to_field!(field::Fields.Field, in_array::Array, R)
     field_array = parent(field)
@@ -38,13 +38,12 @@ function reshape_cgll_sparse_to_field!(field::Fields.Field, in_array::Array, R)
 end
 
 """
-hdwrite_regridfile_rll_to_cgll(comms_ctx, datafile_rll, varname, space; hd_outfile_root = "data_cgll", mono = false)
+    hdwrite_regridfile_rll_to_cgll(comms_ctx, datafile_rll, varname, space; hd_outfile_root = "data_cgll", mono = false)
 
-Reads and regrids data of the `varname` variable from an input NetCDF file and saves it as another NetCDF file using Tempest Remap. 
+Reads and regrids data of the `varname` variable from an input NetCDF file and saves it as another NetCDF file using Tempest Remap.
 The input NetCDF file needs to be `Exodus` formatted, and can contain time-dependent data. The output NetCDF file
-is then read back, the output arrays converted into Fields and saved as HDF5 files (one per time slice). This function should 
-be called by the root process. The regridded HDF5 output is readable by multiple MPI processes. 
-
+is then read back, the output arrays converted into Fields and saved as HDF5 files (one per time slice). This function should
+be called by the root process. The regridded HDF5 output is readable by multiple MPI processes.
 """
 function hdwrite_regridfile_rll_to_cgll(
     comms_ctx,
@@ -78,7 +77,7 @@ function hdwrite_regridfile_rll_to_cgll(
         # write lat-lon mesh
         rll_mesh(meshfile_rll; nlat = nlat, nlon = nlon)
 
-        # write cgll mesh, overlap mesh and weight file 
+        # write cgll mesh, overlap mesh and weight file
         write_exodus(meshfile_cgll, topology)
         overlap_mesh(meshfile_overlap, meshfile_rll, meshfile_cgll)
 


### PR DESCRIPTION
## Purpose 
We want to make `comms_ctx` a required argument (not optional) to avoid possible conflicts.

Closes #256 

## Content
- [x] Removes the default value for the `comms_ctx` argument.
- [x] Uses the old default argument inside the `hdwrite_regridfile_rll_to_cgll` function.
- [x] Updates docstrings


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [x] I have read and checked the items on the review checklist.
