### PR TITLE
Add self count to FlameGraphDiff

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,10 +67,9 @@ steps:
       JULIA_MAX_NUM_PRECOMPILE_FILES: 50
 
   - wait
-  
+
   - group: "Unit Tests"
     steps:
-    
       - label: "MPI Regridder unit tests"
         key: "regridder_mpi_tests"
         command: "mpiexec julia --color=yes --project=test/ test/mpi_tests/regridder_mpi_tests.jl --run_name regridder_mpi"
@@ -94,6 +93,16 @@ steps:
           queue: central
           slurm_nodes: 3
           slurm_tasks_per_node: 1
+
+      - label: "Perf flame graph diff tests"
+        command: "julia --color=yes --project=perf/ perf/flame_test.jl --run_name flame_test"
+        timeout_in_minutes: 5
+        agents:
+          config: cpu
+          queue: central
+          slurm_nodes: 3
+          slurm_tasks_per_node: 1
+
 
   - group: "Integration Tests"
     steps:
@@ -120,6 +129,7 @@ steps:
         artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/default_modular_artifacts/total_energy*.png"
         env:
           FLAME_PLOT: ""
+          BUILD_HISTORY_HANDLE: ""
         agents:
           slurm_ntasks: 1
           slurm_mem_per_cpu: 16G
@@ -131,7 +141,7 @@ steps:
 
       - label: "Moist earth with slab surface - test: monin allsky sponge idealinsol infreq_dt_cpl"
         command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 21600 --dt 200secs --dt_rad 6hours --idealized_insolation true --mono_surface true --h_elem 4 --precip_model 0M --run_name target_params_in_slab_test1"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab_test1_artifacts/total_energy*.png"       
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab_test1_artifacts/total_energy*.png"
 
       - label: "Moist earth with slab surface - test: bulk allsky sponge realinsol infreq_dt_cpl"
         command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme bulk --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --run_name target_params_in_slab_test2"
@@ -141,10 +151,10 @@ steps:
         command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --run_name target_params_in_slab_test3"
         artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab_test3_artifacts/total_energy*.png"
 
-      # breaking: 
+      # breaking:
       # - label: "Moist earth with slab surface - monin allsky no_sponge idealinsol infreq_dt_cpl"
       #   command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge false --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 21600 --dt 200secs --dt_rad 6hours --idealized_insolation true --mono_surface true --h_elem 4 --precip_model 0M --run_name target_params_in_slab1"
-      #   artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab1_artifacts/total_energy*.png"       
+      #   artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab1_artifacts/total_energy*.png"
 
       - label: "AMIP"
         command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 10days --precip_model 0M --run_name coarse_single"
@@ -153,9 +163,10 @@ steps:
       - label: "AMIP - modular"
         key: "modular_amip"
         command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver_modular.jl --run_name coarse_single_modular --enable_threading true --coupled true  --surface_scheme bulk --moist equil --vert_diff true --rad gray --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 10days --precip_model 0M"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/coarse_single_artifacts/*"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/coarse_single_modular_artifacts/*"
         env:
           FLAME_PLOT: ""
+          BUILD_HISTORY_HANDLE: ""
         agents:
           slurm_ntasks: 1
           slurm_mem_per_cpu: 16G
@@ -178,7 +189,7 @@ steps:
         artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n32_shortrun_artifacts/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
-          FLAME_PLOT: ""
+          BUILD_HISTORY_HANDLE: ""
         agents:
           slurm_ntasks: 32
           slurm_mem_per_cpu: 16G
@@ -201,7 +212,7 @@ steps:
         artifact_paths: "perf/output/perf_target_amip_n32_shortrun/*"
         agents:
           slurm_mem: 20GB
-      
+
       - label: ":rocket: performance: flame graph diff: perf_default_modular"
         command: "julia --color=yes --project=perf perf/flame_diff.jl --run_name 1"
         artifact_paths: "perf/output/perf_diff_default_modular/*"
@@ -214,12 +225,6 @@ steps:
         agents:
           slurm_mem: 20GB
 
-      - label: ":rocket: performance: flame graph diff: perf_target_amip_n32_shortrun"
-        command: "julia --color=yes --project=perf perf/flame_diff.jl --run_name 3"
-        artifact_paths: "perf/output/perf_diff_target_amip_n32_shortrun/*"
-        agents:
-          slurm_mem: 20GB
-
       - wait
 
       # plot job performance history
@@ -228,4 +233,4 @@ steps:
           - build_history staging # name of branch to plot
         artifact_paths:
           - "build_history.html"
-      
+

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -1,17 +1,17 @@
 # Performance Analysis Tools
 
-`ClimaCoupler.jl` provides basic tools for analyzing performance: 
+`ClimaCoupler.jl` provides basic tools for analyzing performance:
 1. **Flame graphs**: the `perf/flame.jl` script is run by Buildkite to produce flame graphs using [ProfileCanvas.jl](https://github.com/pfitzseb/ProfileCanvas.jl) in the `perf/output/` directory.
-2. **Job walltime and allocation history**: use Buildkite to trigger the [`build_history`](https://github.com/CliMA/slurm-buildkite/blob/master/bin/build_history) script to output an interactive plot with the history of memory usage and time elapsed for each tracked job (default: current build and past builds of the `staging` branch over the past year). Use `key` to select which jobs to track. More documentation can be found in the [SLURM-Buildkite Wiki](https://github.com/CliMA/slurm-buildkite/wiki/Memory#plotting-memory-usage-over-time). 
+2. **Job walltime and allocation history**: use Buildkite to trigger the [`build_history`](https://github.com/CliMA/slurm-buildkite/blob/master/bin/build_history) script to output an interactive plot with the history of memory usage and time elapsed for each tracked job (default: current build and past builds of the `staging` branch over the past year). Use `key` to select which jobs to track. More documentation can be found in the [SLURM-Buildkite Wiki](https://github.com/CliMA/slurm-buildkite/wiki/Memory#plotting-memory-usage-over-time).
 
 ## Flame Graph Interpretation
-- use for single-process (un)threaded performance CPU profiling of individual stack traces. It provides a tree representation of a set of backtraces, showing the dependence and CPU cost of each function. 
+- use for single-process (un)threaded performance CPU profiling of individual stack traces. It provides a tree representation of a set of backtraces, showing the dependence and CPU cost of each function.
 - here is an example of a flame graph of ClimaCoupler's AMIP run, produced by Buildkite running the `perf/flame.jl` script:
 
 ![canvas](images/canvas_coupler.png)
 
-- each row along the y-axis represents a level of backtraces. In this case the lowermost level is at the top, and the top level represents what is directly being run on the CPU. The stacks in each level are sorted alphabetically (not chronologically, like flame _charts_). The column width is proportional to the presence in samples (related to allocations). The colors are grouped into runtime-dispatch, gc, compilation and default. The intensity is random. 
-- we also have a local beta version of flame graphs (in `perf/ProfileCanvasDiff.jl` and `perf/ProfileViewerDiff.js`), triggered by the `perf/flame_diff.jl` script, which plots the same flame graphs as above but with the color corresponding to whether the stack allocation has been reduced (blue) or increased (red) compared to the last staged runs. The color intensity is proportional to the fractional change, and black signifies untracked traces. 
+- each row along the y-axis represents a level of backtraces. In this case the lowermost level is at the top, and the top level represents what is directly being run on the CPU. The stacks in each level are sorted alphabetically (not chronologically, like flame _charts_). The column width is proportional to the presence in samples (related to allocations). The colors are grouped into runtime-dispatch, gc, compilation and default. The intensity is random.
+- we also have a local beta version of flame graphs (in `perf/ProfileCanvasDiff.jl` and `perf/ProfileViewerDiff.js`), triggered by the `perf/flame_diff.jl` script, which plots the same flame graphs as above but with the color corresponding to whether the stack allocation has been reduced (blue) or increased (red) compared to the last staged runs. The color intensity is proportional to the fractional change, and black signifies untracked traces. The default is to show the cumulative allocation (current function + all its children functions). By setting `self_count` to `true`, we can also count only the allocations of the current function itself, allowing us to isolate allocation changes within our software from changes in the upstream packages.
 
 ## References
 - [Description of flame graphs and their interpretation](https://github.com/CliMA/slurm-buildkite/wiki/Flame-Graphs)

--- a/perf/ProfileViewerDiff.js
+++ b/perf/ProfileViewerDiff.js
@@ -451,15 +451,15 @@ export class ProfileViewer {
     }
     // modifies the normal color by three stable random values drawn from a
     // PRNG seeded by the node hash
-    modifyNodeColorByHash(r, g, b, hash, range = 70) {
+    modifyNodeColorByHash(r, g, b, hash, range = 255) {
         const rng = this.mulberry32(hash);
         if (r === g && g === b) {
             r = g = b = Math.min(255, Math.max(0, r + (rng() - 0.5) * range));
         }
         else {
-            r = Math.min(255, Math.max(0, r + (rng() - 0.5) * range));
-            g = Math.min(255, Math.max(0, g + (rng() - 0.5) * range));
-            b = Math.min(255, Math.max(0, b + (rng() - 0.5) * range));
+            r = Math.min(range, Math.max(0, r + (rng() - 0.5) * range));
+            g = Math.min(range, Math.max(0, g + (rng() - 0.5) * range));
+            b = Math.min(range, Math.max(0, b + (rng() - 0.5) * range));
         }
         return {
             r,
@@ -510,16 +510,21 @@ export class ProfileViewer {
         // if (node.count > 0) {
         // better performance
         ;
-        if (node.count_change > 100) {
-            ({ r, g, b } = this.modifyNodeColorByCount(0, 0, 0, node.count_change ));
+        if (node.count_change / node.count > 100) {
+            ({ r, g, b } = this.modifyNodeColorByCount(0, 0, 0, node.count_change / node.count ));
         }
-        else if (node.count_change < 0) {
-            ({ r, g, b } = this.modifyNodeColorByCount(255, 255, 255, - node.count_change ));
-            r = 255;
+        else if (node.count_change/ node.count > 0) {
+            ({ r, g, b } = this.modifyNodeColorByCount(255, 255, 255, node.count_change / node.count ));
+            r = 255 - 20;
+            g = g - 20;
+            b = b - 20;
+
         }
         else {
-            ({ r, g, b } = this.modifyNodeColorByCount(255, 255, 255, node.count_change ));
-            b = 255;
+            ({ r, g, b } = this.modifyNodeColorByCount(255, 255, 255, - node.count_change / node.count ));
+            b = 255 - 20;
+            g = g - 20;
+            r = r - 20;
         }
 
         return {

--- a/perf/flame_diff.jl
+++ b/perf/flame_diff.jl
@@ -1,23 +1,23 @@
-# flame_diff.jl: provides allocation breakdown for individual backtraces for single-process unthredded runs 
+# flame_diff.jl: provides allocation breakdown for individual backtraces for single-process unthredded runs
 # and check for fractional change in allocation compared to the last staged run
-
-buildkite_branch = ENV["BUILDKITE_BRANCH"]
-buildkite_commit = ENV["BUILDKITE_COMMIT"]
-buildkite_bnumber = ENV["BUILDKITE_BUILD_NUMBER"]
-buildkite_cc_dir = "/groups/esm/slurm-buildkite/climacoupler-ci/"
-
-build_path = "/central/scratch/esm/slurm-buildkite/climacoupler-ci/$buildkite_bnumber/climacoupler-ci/perf/"
-cwd = pwd()
-@info "build_path is: $build_path"
 
 import Profile
 using Test
 import Base: view
 include("ProfileCanvasDiff.jl")
 import .ProfileCanvasDiff
+using JLD2
 
-Profile.clear_malloc_data()
-Profile.clear()
+buildkite_branch = ENV["BUILDKITE_BRANCH"]
+buildkite_commit = ENV["BUILDKITE_COMMIT"]
+buildkite_number = ENV["BUILDKITE_BUILD_NUMBER"]
+buildkite_cc_dir = "/groups/esm/slurm-buildkite/climacoupler-ci/"
+scratch_cc_dir = "/central/scratch/esm/slurm-buildkite/climacoupler-ci/"
+build_path = "/central/scratch/esm/slurm-buildkite/climacoupler-ci/$buildkite_number/climacoupler-ci/perf/"
+perf_run_no = ARGS[2]
+
+cwd = pwd()
+@info "build_path is: $build_path"
 
 cc_dir = joinpath(dirname(@__DIR__));
 include(joinpath(cc_dir, "experiments", "AMIP", "moist_mpi_earth", "cli_options.jl"));
@@ -26,13 +26,13 @@ include(joinpath(cc_dir, "experiments", "AMIP", "moist_mpi_earth", "cli_options.
 filename = joinpath(cc_dir, "experiments", "AMIP", "moist_mpi_earth", "coupler_driver_modular.jl")
 
 # selected runs for performance analysis and their expected allocations (based on previous runs)
-run_name_list = ["default_modular", "coarse_single_modular", "target_amip_n32_shortrun"]
-run_name = run_name_list[parse(Int, ARGS[2])]
+run_name_list = ["default_modular", "coarse_single_modular", "target_amip_n32_shortrun", "target_amip_n1_shortrun"]
+run_name = run_name_list[parse(Int, perf_run_no)]
 
 # number of time steps used for profiling
-const n_samples = 2
+n_samples = 2
 
-# flag to split coupler init from its solve 
+# flag to split coupler init from its solve
 ENV["CI_PERF_SKIP_COUPLED_RUN"] = true
 
 # pass in the correct arguments, overriding defaults with those specific to each run_name (in `pipeline.yaml`)
@@ -61,39 +61,25 @@ catch err
         rethrow(err.error)
     end
 end
-
 #####
 ##### Profiling
 #####
-"""
-    iterate_children(flame_tree, ct = 0, dict = Dict{String, Float64}())
-
-Iterate over all children of a stack tree and save their names ("\$func.\$file.\$line") and 
-corresponding count values in a Dict. 
-"""
-function iterate_children(flame_tree, ct = 0, dict = Dict{String, Float64}())
-    ct += 1
-    line = flame_tree.line
-    file = flame_tree.file
-    func = flame_tree.func
-    push!(dict, "$func.$file.$line" => flame_tree.count)
-
-    if isempty(flame_tree.children)
-        nothing
-    else
-        for sf in flame_tree.children
-            iterate_children(sf, ct, dict)
-        end
-    end
-    return dict
-end
 
 # obtain the stacktree from the last saved file in `buildkite_cc_dir`
 ref_file = joinpath(buildkite_cc_dir, "$run_name.jld2")
-tracked_list = isfile(ref_file) ? load(ref_file) : Dict{String, Float64}()
+
+if isfile(ref_file)
+    tracked_list = load(ref_file)
+else
+    tracked_list = Dict{String, Float64}()
+    @warn "FlameGraphDiff: No reference file: $ref_file found"
+end
+
 
 # compile coupling loop first
 step_coupler!(cs, n_samples)
+
+# clear compiler allocs
 Profile.clear_malloc_data()
 Profile.clear()
 
@@ -103,20 +89,30 @@ prof = Profile.@profile begin
 end
 
 # produce flamegraph with colors highlighting the allocation differences relative to the last saved run
-# profile_data 
+# profile_data
 if haskey(ENV, "BUILDKITE_COMMIT") || haskey(ENV, "BUILDKITE_BRANCH")
     output_dir = "perf/output/$run_name"
     mkpath(output_dir)
-    ProfileCanvasDiff.html_file(joinpath(output_dir, "flame_diff.html"), build_path = build_path)
+    ProfileCanvasDiff.html_file(
+        joinpath(output_dir, "flame_diff.html"),
+        build_path = build_path,
+        tracked_list = tracked_list,
+        self_count = false,
+    )
+    ProfileCanvasDiff.html_file(
+        joinpath(output_dir, "flame_diff_self_count.html"),
+        build_path = build_path,
+        tracked_list = tracked_list,
+        self_count = true,
+    )
 end
 
 # save (and reset) the stack tree if this is running on the `staging` branch
-profile_data = ProfileCanvasDiff.view(Profile.fetch(), tracked_list = tracked_list);
-flame_tree = profile_data.data["all"]
-my_dict = iterate_children(flame_tree)
 @info "This branch is: $buildkite_branch, commit $buildkite_commit"
+profile_data, new_tracked_list = ProfileCanvasDiff.view(Profile.fetch(), tracked_list = tracked_list, self_count = true);
 if buildkite_branch == "staging"
     isfile(ref_file) ?
-    mv(ref_file, joinpath(buildkite_cc_dir, "flame_diff_ref_file.$run_name.$buildkite_commit.jld2")) : nothing
-    save(ref_file, my_dict) # reset ref_file upon staging
+    mv(ref_file, joinpath(scratch_cc_dir, "flame_reference_file.$run_name.$buildkite_commit.jld2"), force = true) :
+    nothing
+    save(ref_file, new_tracked_list) # reset ref_file upon staging
 end

--- a/perf/flame_test.jl
+++ b/perf/flame_test.jl
@@ -1,0 +1,120 @@
+import Profile
+using Test
+import Base: view
+include("ProfileCanvasDiff.jl")
+import .ProfileCanvasDiff
+using JLD2
+
+if isinteractive()
+    buildkite_cc_dir = build_path = "."
+    perf_run_no = "1"
+else
+    buildkite_number = ENV["BUILDKITE_BUILD_NUMBER"]
+    buildkite_cc_dir = "/groups/esm/slurm-buildkite/climacoupler-ci/"
+    build_path = "/central/scratch/esm/slurm-buildkite/climacoupler-ci/$buildkite_number/climacoupler-ci/perf/"
+end
+
+output_dir = joinpath(buildkite_cc_dir, "test/")
+mkpath(output_dir)
+
+# dummy functions to analyze
+function cumsum_sqrt(x)
+    y = cumsum(x)
+    sqrt.(y)
+end
+
+function get_y(x)
+    f = collect(1:1:10000) .* x
+    cumsum(f)
+end
+
+function step_coupler!(n, y_all = [])
+    for i in collect(1:1:n)
+        y = get_y(i)
+        push!(y_all, y)
+    end
+    return y_all
+end
+
+# init
+step_coupler!(1)
+
+# clear compiler allocs
+Profile.clear_malloc_data()
+Profile.clear()
+
+# profile the coupling loop
+prof = Profile.@profile begin
+    step_coupler!(100)
+end
+
+# ref file
+ref_file = joinpath(output_dir, "reference.jld2")
+tracked_list = isfile(ref_file) ? load(ref_file) : Dict{String, Float64}()
+
+# save ref file
+profile_data, new_tracked_list = ProfileCanvasDiff.view(Profile.fetch(), tracked_list = tracked_list, self_count = true);
+
+save(ref_file, new_tracked_list) # reset ref_file upon staging
+
+
+"""
+    find_child(flame_tree, target_name; self_count = false)
+
+Helper function to find a particular flame tree node.
+"""
+function find_child(flame_tree, target_name; self_count = false)
+
+    line = flame_tree.line
+    file = flame_tree.file
+    func = flame_tree.func
+
+    node_name = "$func.$file.$line"
+    node_name = self_count ? "self_count_" * node_name : node_name
+
+    if node_name == target_name
+        global out = flame_tree
+    else
+        if !(isempty(flame_tree.children))
+            for sf in flame_tree.children
+                find_child(sf, target_name, self_count = self_count)
+            end
+        end
+    end
+    return @isdefined(out) ? out : nothing
+end
+
+@testset "flame diff tests" begin
+    # load the dictionary of tracked counts from the reference file
+    tracked_list = isfile(ref_file) ? load(ref_file) : Dict{String, Float64}()
+
+    test_func_name = "get_y.flame_test.jl.28"
+
+    # test flame diff
+    tracked_list["$test_func_name"] = 100  # reference value for node count with child sum
+    profile_data, new_tracked_list =
+        ProfileCanvasDiff.view(Profile.fetch(), tracked_list = tracked_list, self_count = false)
+    node = find_child(profile_data.data["all"], test_func_name, self_count = false)
+    @test node.count_change == node.count - 100
+
+    # test flame diff with self_count
+    tracked_list["self_count_$test_func_name"] = 50 # reference value for node count w/o child sum
+    profile_data, new_tracked_list =
+        ProfileCanvasDiff.view(Profile.fetch(), tracked_list = tracked_list, self_count = true)
+
+    node = find_child(profile_data.data["all"], test_func_name, self_count = false)
+    child_sum = sum(map(x -> x.count, node.children))
+    @test node.count_change == (node.count - child_sum) - 50
+
+    # html_file test
+    ProfileCanvasDiff.html_file(
+        joinpath(output_dir, "flame_diff.html"),
+        build_path = build_path,
+        tracked_list = tracked_list,
+        self_count = false,
+    )
+
+    @test isfile(joinpath(output_dir, "flame_diff.html"))
+    rm(output_dir; recursive = true, force = true)
+
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This allows counting and displaying the allocation changes of individual functions (independent of their child nodes). The need for this was identified whilst attempting to quantify local performance in #205. In the future, this will allow us to isolate allocation changes within our software from changes in the upstream models.

This is tagged as part of #229 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [x] separate allocation calculation into child and current function contributions. 
- [x] implement in FlameGraphDiff plots
- [x] add a ci test 
- [x] add in docs

## QA
- [x] check buildkite plots are created
- [x] check ci tests pass

## Note
- this is still in a temporary format/location, until we test/determine how this would be useful for the rest of the CliMA team. 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
