### PR TITLE
Report test 2

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -37,6 +37,11 @@ steps:
       - "julia --project=artifacts -e 'using Pkg; Pkg.status()'"
       - "julia --project=artifacts artifacts/download_artifacts.jl"
 
+      - echo "--- Instantiate perf env"
+      - "julia --project=perf/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project=perf/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project=perf/ -e 'using Pkg; Pkg.status()'"
+
     agents:
       slurm_cpus_per_task: 8
     env:
@@ -49,12 +54,117 @@ steps:
 
     steps:
 
-      - label: "AMIP"        
-        key: "mpi_amip_fine_long"
-        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl  --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad clearsky --microphy 0M --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150 --dt_rad 6hours --idealized_insolation true --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 100days --dt_save_to_sol 10days --mono_surface false --run_name current_amip_n32_longrun"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/current_amip_n32_longrun_artifacts/*"
+      - label: "Moist earth with slab surface - notmono + modular: bulk gray no_sponge idealinsol freq_dt_cpl"
+        key: "slabplanet"
+        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver_modular.jl --run_name default_modular_long --enable_threading true --coupled true --surface_scheme bulk  --moist equil --vert_diff true --rad gray --energy_check true --anim true --mode_name slabplanet --t_end 10days --dt_save_to_sol 1days --dt_cpl 200 --dt 200secs --mono_surface false --h_elem 4 --precip_model 0M"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/default_modular_long_artifacts/total_energy*.png"
+        env:
+          BUILD_HISTORY_HANDLE: ""
+        agents:
+          slurm_ntasks: 1
+          slurm_mem_per_cpu: 16G
+
+      - label: "MPI AMIP FINE: longrun"
+        key: "amip_longrun"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver_modular.jl --run_name target_amip_n64_longrun --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 180days --dt_save_to_sol 10days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n64_longrun_artifacts/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
+          BUILD_HISTORY_HANDLE: ""
+        agents:
+          slurm_ntasks: 64
+          slurm_mem_per_cpu: 16G
+
+      # MPI performance scaling (10 days)
+      - label: "MPI AMIP FINE: n64"
+        key: "mpi_amip_fine_n64"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --run_name target_amip_n64_shortrun --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n64_shortrun_artifacts/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+          BUILD_HISTORY_HANDLE: ""
+        agents:
+          slurm_ntasks: 64
+          slurm_mem_per_cpu: 16G
+          slurm_tasks_per_node: 8
+
+      - label: "MPI AMIP FINE: n32"
+        key: "mpi_amip_fine_n32"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --run_name target_amip_n32_shortrun --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n32_shortrun_artifacts/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+          BUILD_HISTORY_HANDLE: ""
         agents:
           slurm_ntasks: 32
+          slurm_mem_per_cpu: 16G
+          slurm_tasks_per_node: 8
 
+      - label: "MPI AMIP FINE: n8"
+        key: "mpi_amip_fine_n8"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --run_name target_amip_n8_shortrun --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n8_shortrun_artifacts/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+          BUILD_HISTORY_HANDLE: ""
+        agents:
+          slurm_ntasks: 8
+          slurm_mem_per_cpu: 16G
+          slurm_tasks_per_node: 8
+
+      - label: "MPI AMIP FINE: n2"
+        key: "mpi_amip_fine_n2"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --run_name target_amip_n2_shortrun --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n2_shortrun_artifacts/*"
+        env:
+          CLIMACORE_DISTRIBUTED: "MPI"
+          BUILD_HISTORY_HANDLE: ""
+        agents:
+          slurm_ntasks: 2
+          slurm_mem_per_cpu: 16G
+          slurm_tasks_per_node: 2
+
+      - label: "Unthreaded AMIP FINE" # also reported by longruns with a flame graph
+        key: "unthreaded_amip_fine"
+        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver_modular.jl --run_name target_amip_n1_shortrun --enable_threading false --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n1_shortrun_artifacts/*"
+        env:
+          BUILD_HISTORY_HANDLE: ""
+        agents:
+          slurm_mem_per_cpu: 16G
+
+      # Unthreaded flame graph report (NB: arguments passed from the ci pipeline.yml)
+      - label: ":rocket: performance: flame graph diff: perf_target_amip_n1_shortrun"
+        command: "julia --color=yes --project=perf perf/flame_diff.jl --run_name 4"
+        artifact_paths: "perf/output/perf_diff_target_amip_n1_shortrun/*"
+        agents:
+          slurm_mem: 20GB
+
+      - wait
+
+      # plot job performance history
+      - label: ":chart_with_downwards_trend: build history"
+        command:
+          - build_history staging # name of branch to plot
+        artifact_paths:
+          - "build_history.html"
+
+      - wait
+
+      - label: ":envelope: Slack report: build_history"
+        command:
+          - slack-upload -c "#coupler-report" -f build_history.html -m html -n build_history -x "Overall job performance"
+
+      - label: ":envelope: Slack report: Slabplanet"
+        command:
+          - slack-upload -c "#coupler-report" -f experiments/AMIP/moist_mpi_earth/output/slabplanet/default_modular_long_artifacts/total_energy_log_bucket.png -m png -n slab_coarse_log -x "Slabplanet energy conservation (log error)"
+          - slack-upload -c "#coupler-report" -f experiments/AMIP/moist_mpi_earth/output/slabplanet/default_modular_long_artifacts/total_energy_bucket.png -m png -n slab_coarse -x "Slabplanet energy conservation"
+
+      - label: ":envelope: Slack report: target AMIP"
+        command:
+          - slack-upload -c "#coupler-report" -f experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n64_longrun_artifacts/amip_paperplots.png -m png -n amip_fine -x "AMIP Longrun"
+
+      - label: ":envelope: Slack report: Flame Diff"
+        command:
+          - slack-upload -c "#coupler-report" -f perf/output/perf_diff_target_amip_n1_shortrun/flame_diff.html -m png -n amip_fine_flamegraphdiff -x "AMIP Longrun FlameGraphDiff"
+          - slack-upload -c "#coupler-report" -f perf/output/perf_diff_target_amip_n1_shortrun/flame_diff_self_count.html -m png -n amip_fine_flamegraphdiffself -x "AMIP Longrun FlameGraphDiffSelf"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -128,6 +128,16 @@ steps:
         command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver_modular.jl --run_name default_modular --enable_threading true --coupled true --surface_scheme bulk  --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface false --h_elem 4 --precip_model 0M"
         artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/default_modular_artifacts/total_energy*.png"
         env:
+          BUILD_HISTORY_HANDLE: ""
+        agents:
+          slurm_ntasks: 1
+          slurm_mem_per_cpu: 16G
+
+      - label: "Moist earth with slab surface (unthreaded) - notmono + modular: bulk gray no_sponge idealinsol freq_dt_cpl"
+        key: "modular_slabplanet_unthreaded"
+        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver_modular.jl --run_name default_modular_unthreaded --enable_threading true --coupled true --surface_scheme bulk  --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface false --h_elem 4 --precip_model 0M"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/default_modular_unthreaded_artifacts/total_energy*.png"
+        env:
           FLAME_PLOT: ""
           BUILD_HISTORY_HANDLE: ""
         agents:
@@ -183,21 +193,20 @@ steps:
         agents:
           slurm_ntasks: 2
 
-      - label: "MPI AMIP FINE"
-        key: "mpi_amip_fine"
-        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --run_name target_amip_n32_shortrun --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --idealized_insolation false --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 5days --dt_save_to_sol 10days --mono_surface false --precip_model 0M"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n32_shortrun_artifacts/*"
+      # short high-res performance test
+      - label: "Unthreaded AMIP FINE" # also reported by longruns with a flame graph
+        key: "unthreaded_amip_fine"
+        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver_modular.jl --run_name target_amip_n1_shortrun --enable_threading false --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 0.01days --dt_save_to_sol 1days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n1_shortrun_artifacts/*"
         env:
-          CLIMACORE_DISTRIBUTED: "MPI"
           BUILD_HISTORY_HANDLE: ""
         agents:
-          slurm_ntasks: 32
           slurm_mem_per_cpu: 16G
 
-      # performance tests
-      - label: ":rocket: flame graph and allocation tests: perf_default_modular"
+      # flame graphs + allocation tests
+      - label: ":rocket: flame graph and allocation tests: perf_default_modular_unthreaded"
         command: "julia --color=yes --project=perf perf/flame.jl --run_name 1"
-        artifact_paths: "perf/output/perf_default_modular/*"
+        artifact_paths: "perf/output/perf_default_modular_unthreaded/*"
         agents:
           slurm_mem: 20GB
 
@@ -207,15 +216,9 @@ steps:
         agents:
           slurm_mem: 20GB
 
-      - label: ":rocket: flame graph and allocation tests: perf_target_amip_n32_shortrun"
-        command: "julia --color=yes --project=perf perf/flame.jl --run_name 3"
-        artifact_paths: "perf/output/perf_target_amip_n32_shortrun/*"
-        agents:
-          slurm_mem: 20GB
-
-      - label: ":rocket: performance: flame graph diff: perf_default_modular"
+      - label: ":rocket: performance: flame graph diff: perf_default_modular_unthreaded"
         command: "julia --color=yes --project=perf perf/flame_diff.jl --run_name 1"
-        artifact_paths: "perf/output/perf_diff_default_modular/*"
+        artifact_paths: "perf/output/perf_diff_default_modular_unthreaded/*"
         agents:
           slurm_mem: 20GB
 

--- a/experiments/AMIP/moist_mpi_earth/user_plots/amip_visualizer.jl
+++ b/experiments/AMIP/moist_mpi_earth/user_plots/amip_visualizer.jl
@@ -9,8 +9,8 @@ include("plot_helper.jl")
         files_root = ".hdf5",
         fig_name = "amip_paperplots",
     )
-Coordinates the postprocessing and plotting of sample fields (specified in `post_spec`) 
-of the last monthly mean file. Any specific plot customization should be done here. 
+Coordinates the postprocessing and plotting of sample fields (specified in `post_spec`)
+of the last monthly mean file. Any specific plot customization should be done here.
 """
 function amip_paperplots(
     post_spec::NamedTuple,
@@ -32,6 +32,7 @@ function amip_paperplots(
 
         # postprocess
         post_data = postprocess(name, diag_data, getproperty(post_spec, name))
+        post_data.data[1] = sum(post_data.data) == 0 ? post_data.data[1] + eps() : post_data.data[1] # avoids InexactError
 
         # create individual plots
         p = plot(
@@ -61,7 +62,7 @@ end
 """
     read_latest_model_data(name::Symbol, filedir::String, root::String)
 
-Reads in a variable from a HDF5 file, as outputted by `ClimaCoupler.Dignostics`. 
+Reads in a variable from a HDF5 file, as outputted by `ClimaCoupler.Dignostics`.
 """
 function read_latest_model_data(name::Symbol, filedir::String, root::String)
 

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -13,10 +13,11 @@ include(joinpath(cc_dir, "experiments", "AMIP", "moist_mpi_earth", "cli_options.
 filename = joinpath(cc_dir, "experiments", "AMIP", "moist_mpi_earth", "coupler_driver_modular.jl")
 
 # selected runs for performance analysis and their expected allocations (based on previous runs)
-run_name_list = ["default_modular", "coarse_single_modular", "target_amip_n32_shortrun"]
+run_name_list =
+    ["default_modular_unthreaded", "coarse_single_modular", "target_amip_n32_shortrun", "target_amip_n1_shortrun"]
 run_name = run_name_list[parse(Int, ARGS[2])]
 allocs_limit = Dict()
-allocs_limit["perf_default_modular"] = 2685744
+allocs_limit["perf_default_modular_unthreaded"] = 2685744
 allocs_limit["perf_coarse_single_modular"] = 3864624
 allocs_limit["perf_target_amip_n32_shortrun"] = 172134848
 

--- a/perf/flame_diff.jl
+++ b/perf/flame_diff.jl
@@ -11,9 +11,11 @@ using JLD2
 buildkite_branch = ENV["BUILDKITE_BRANCH"]
 buildkite_commit = ENV["BUILDKITE_COMMIT"]
 buildkite_number = ENV["BUILDKITE_BUILD_NUMBER"]
+buildkite_build_path = ENV["BUILDKITE_BUILD_PATH"]
+buildkite_pipeline_slug = ENV["BUILDKITE_PIPELINE_SLUG"]
 buildkite_cc_dir = "/groups/esm/slurm-buildkite/climacoupler-ci/"
-scratch_cc_dir = "/central/scratch/esm/slurm-buildkite/climacoupler-ci/"
-build_path = "/central/scratch/esm/slurm-buildkite/climacoupler-ci/$buildkite_number/climacoupler-ci/perf/"
+scratch_cc_dir = joinpath(buildkite_build_path, buildkite_pipeline_slug)
+build_path = joinpath(buildkite_build_path, buildkite_pipeline_slug, buildkite_number, buildkite_pipeline_slug, "perf/")
 perf_run_no = ARGS[2]
 
 cwd = pwd()
@@ -26,7 +28,8 @@ include(joinpath(cc_dir, "experiments", "AMIP", "moist_mpi_earth", "cli_options.
 filename = joinpath(cc_dir, "experiments", "AMIP", "moist_mpi_earth", "coupler_driver_modular.jl")
 
 # selected runs for performance analysis and their expected allocations (based on previous runs)
-run_name_list = ["default_modular", "coarse_single_modular", "target_amip_n32_shortrun", "target_amip_n1_shortrun"]
+run_name_list =
+    ["default_modular_unthreaded", "coarse_single_modular", "target_amip_n32_shortrun", "target_amip_n1_shortrun"]
 run_name = run_name_list[parse(Int, perf_run_no)]
 
 # number of time steps used for profiling
@@ -74,7 +77,6 @@ else
     tracked_list = Dict{String, Float64}()
     @warn "FlameGraphDiff: No reference file: $ref_file found"
 end
-
 
 # compile coupling loop first
 step_coupler!(cs, n_samples)

--- a/perf/flame_test.jl
+++ b/perf/flame_test.jl
@@ -7,7 +7,6 @@ using JLD2
 
 if isinteractive()
     buildkite_cc_dir = build_path = "."
-    perf_run_no = "1"
 else
     buildkite_number = ENV["BUILDKITE_BUILD_NUMBER"]
     buildkite_cc_dir = "/groups/esm/slurm-buildkite/climacoupler-ci/"
@@ -88,7 +87,7 @@ end
     # load the dictionary of tracked counts from the reference file
     tracked_list = isfile(ref_file) ? load(ref_file) : Dict{String, Float64}()
 
-    test_func_name = "get_y.flame_test.jl.28"
+    test_func_name = "get_y.flame_test.jl.26"
 
     # test flame diff
     tracked_list["$test_func_name"] = 100  # reference value for node count with child sum


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds introduces automatic reporting to our slack channel: #coupler-reports. 

The report is composed of selected output from Buildkite CI experiments:

- [x] `build_history` graph
- [x] `flame_graphs` extended to show only the contributions of the node in question (minus its child contributions) with a Buildkite driver for an unthreaded AMIP run 
- [x] the AMIP target resolution 
- [x] slabplanet with conservation check

The repost will be generated weekly, using the `longruns` pipeline. 

(this follows on from #246 with a fresh rebase and closes #229 )

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
