### PR TITLE
Address buildkite memory issues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -131,7 +131,6 @@ steps:
           BUILD_HISTORY_HANDLE: ""
         agents:
           slurm_ntasks: 1
-          slurm_mem_per_cpu: 16G
 
       - label: "Moist earth with slab surface (unthreaded) - notmono + modular: bulk gray no_sponge idealinsol freq_dt_cpl"
         key: "modular_slabplanet_unthreaded"
@@ -142,7 +141,6 @@ steps:
           BUILD_HISTORY_HANDLE: ""
         agents:
           slurm_ntasks: 1
-          slurm_mem_per_cpu: 16G
 
       # Note: this test fails when run with the more realistic albedo from file
       - label: "Moist earth with slab surface - target: monin allsky sponge realinsol infreq_dt_cpl - bucket using BulkAlbedoFunction"
@@ -179,11 +177,14 @@ steps:
           BUILD_HISTORY_HANDLE: ""
         agents:
           slurm_ntasks: 1
-          slurm_mem_per_cpu: 16G
+          slurm_mem: 20GB
 
       - label: "AMIP - modular, Float32 test" # Issue #271
         command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name coarse_single_modular_ft32 --enable_threading true --coupled true  --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check false --mode_name amip --anim true --t_end 10days --dt_save_to_sol 100days --dt_cpl 200 --dt 200secs --mono_surface true --h_elem 6 --dt_save_restart 10days --precip_model 0M"
         artifact_paths: "experiments/AMIP/modular/output/amip/coarse_single_modular_ft32_artifacts/*"
+        agents:
+          slurm_ntasks: 1
+          slurm_mem: 20GB
 
       - label: "sea_breeze"
         command: "julia --color=yes --project=experiments/ClimaCore/sea_breeze experiments/ClimaCore/sea_breeze/run.jl"
@@ -205,7 +206,7 @@ steps:
         env:
           BUILD_HISTORY_HANDLE: ""
         agents:
-          slurm_mem_per_cpu: 16G
+          slurm_mem: 20GB
 
       # flame graphs + allocation tests
       - label: ":rocket: flame graph and allocation tests: perf_default_modular_unthreaded"
@@ -240,4 +241,3 @@ steps:
           - build_history staging # name of branch to plot
         artifact_paths:
           - "build_history.html"
-


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Previously, we saw memory issues when running our `MPI AMIP FINE` test on buildkite (see #192). These issues have been resolved by memory usage changes addressed in ClimaCore PR [#1113](https://github.com/CliMA/ClimaCore.jl/pull/1113). Here, we remove the memory specifications we had added to work around this problem and replace them with the same memory limits enforced by [ClimaAtmos](https://github.com/CliMA/ClimaAtmos.jl/blob/main/.buildkite/pipeline.yml). In general, we should ensure that our buildkite driver is similar to that of ClimaAtmos.

Closes #192
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
