### PR TITLE
Rename masks to fractions

### DIFF
--- a/docs/src/regridder.md
+++ b/docs/src/regridder.md
@@ -15,8 +15,8 @@ ClimaCoupler.Regridder.write_to_hdf5
 ClimaCoupler.Regridder.read_from_hdf5
 ClimaCoupler.Regridder.dummmy_remap!
 ClimaCoupler.Regridder.remap_field_cgll_to_rll
-ClimaCoupler.Regridder.land_sea_mask
-ClimaCoupler.Regridder.update_masks!
+ClimaCoupler.Regridder.land_fraction
+ClimaCoupler.Regridder.update_surface_fractions!
 ClimaCoupler.Regridder.combine_surfaces!
 ```
 

--- a/experiments/AMIP/modular/components/ocean/slab_seaice_init.jl
+++ b/experiments/AMIP/modular/components/ocean/slab_seaice_init.jl
@@ -77,8 +77,8 @@ end
     clean_sic(SIC, _info)
 Ensures that the space of the SIC struct matches that of the mask, and converts the units from area % to area fraction.
 """
-clean_sic(SIC, _info) = swap_space!(zeros(axes(_info.land_mask)), SIC) ./ float_type_bcf(_info)(100.0)
+clean_sic(SIC, _info) = swap_space!(zeros(axes(_info.land_fraction)), SIC) ./ float_type_bcf(_info)(100.0)
 
-# setting that SIC < 0.5 os counted as ocean if binary remapping of landsea mask.
+# setting that SIC < 0.5 is counted as ocean if binary remapping.
 get_ice_fraction(h_ice::FT, mono::Bool, threshold = 0.5) where {FT} =
     mono ? h_ice : Regridder.binary_mask(h_ice, threshold = FT(threshold))

--- a/experiments/AMIP/modular/components/slab_init.jl
+++ b/experiments/AMIP/modular/components/slab_init.jl
@@ -56,10 +56,10 @@ end
 Computes the rhs of the slab model.
 """
 function slab_rhs!(dY, Y, cache, t)
-    p, F_aero, F_rad, land_mask = cache
+    p, F_aero, F_rad = cache
     FT = eltype(Y.T_sfc)
     rhs = @. -(F_aero + F_rad) / (p.h * p.ρ * p.c)
-    parent(dY.T_sfc) .= parent(rhs) # apply_mask.(FT, parent(land_mask), parent(rhs))
+    parent(dY.T_sfc) .= parent(rhs)
 end
 
 """
@@ -67,7 +67,7 @@ end
 
 Initializes the slab simulation.
 """
-function slab_init(::Type{FT}; tspan, dt, saveat, space, land_mask, stepper = Euler()) where {FT}
+function slab_init(::Type{FT}; tspan, dt, saveat, space, land_fraction, stepper = Euler()) where {FT}
 
     params = ThermalSlabParameters(FT(1), FT(1500.0), FT(800.0), FT(1e-3), FT(1e-5), FT(0.2))
     T_init = FT(315)
@@ -76,7 +76,7 @@ function slab_init(::Type{FT}; tspan, dt, saveat, space, land_mask, stepper = Eu
         params = params,
         F_aero = ClimaCore.Fields.zeros(space),
         F_rad = ClimaCore.Fields.zeros(space),
-        land_mask = land_mask,
+        land_fraction = land_fraction,
     )
     problem = OrdinaryDiffEq.ODEProblem(slab_rhs!, Y, tspan, cache)
     integrator = OrdinaryDiffEq.init(problem, stepper, dt = dt, saveat = saveat)

--- a/experiments/AMIP/modular/user_io/viz_explorer.jl
+++ b/experiments/AMIP/modular/user_io/viz_explorer.jl
@@ -39,7 +39,7 @@ function plot_anim(cs, out_dir = ".")
             land_T_sfc = get_land_temp_from_state(cs.model_sims.land_sim, bucketu)
             combine_surfaces!(
                 combined_field,
-                cs.surface_masks,
+                cs.surface_fractions,
                 (; land = land_T_sfc, ocean = oceanu.T_sfc, ice = FT(0)),
             )
             Plots.plot(combined_field)
@@ -49,7 +49,11 @@ function plot_anim(cs, out_dir = ".")
         sol_slab_ice = slab_ice_sim.integrator.sol
         anim = Plots.@animate for (bucketu, iceu) in zip(sol_slab.u, sol_slab_ice.u)
             land_T_sfc = get_land_temp_from_state(cs.model_sims.land_sim, bucketu)
-            combine_surfaces!(combined_field, cs.surface_masks, (; land = land_T_sfc, ocean = SST, ice = iceu.T_sfc))
+            combine_surfaces!(
+                combined_field,
+                cs.surface_fractions,
+                (; land = land_T_sfc, ocean = SST, ice = iceu.T_sfc),
+            )
             Plots.plot(combined_field)
         end
     end
@@ -57,14 +61,14 @@ function plot_anim(cs, out_dir = ".")
 
     combined_field = zeros(boundary_space)
     anim = Plots.@animate for bucketu in sol_slab.u
-        combine_surfaces!(combined_field, cs.surface_masks, (; land = bucketu.bucket.W, ocean = 0.0, ice = 0.0))
+        combine_surfaces!(combined_field, cs.surface_fractions, (; land = bucketu.bucket.W, ocean = 0.0, ice = 0.0))
         Plots.plot(combined_field)
     end
     Plots.mp4(anim, joinpath(out_dir, "bucket_W.mp4"), fps = 10)
 
     combined_field = zeros(boundary_space)
     anim = Plots.@animate for bucketu in sol_slab.u
-        combine_surfaces!(combined_field, cs.surface_masks, (; land = bucketu.bucket.σS, ocean = 0.0, ice = 0.0))
+        combine_surfaces!(combined_field, cs.surface_fractions, (; land = bucketu.bucket.σS, ocean = 0.0, ice = 0.0))
         Plots.plot(combined_field)
     end
     Plots.mp4(anim, joinpath(out_dir, "bucket_snow.mp4"), fps = 10)

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -45,7 +45,7 @@ struct CoupledSimulation{
     tspan::TS
     t::TI
     Δt_cpl::DTI
-    surface_masks::NTSM
+    surface_fractions::NTSM
     model_sims::NTMS
     mode::NTM
     diagnostics::Tuple

--- a/test/bcreader_tests.jl
+++ b/test/bcreader_tests.jl
@@ -39,7 +39,7 @@ for FT in (Float32, Float64)
             dummy_dates,                        # all_dates
             nothing,                            # monthly_fields
             nothing,                            # scaling_function
-            nothing,                            # land_mask
+            nothing,                            # land_fraction
             deepcopy(segment_idx0),             # segment_idx
             segment_idx0,                       # segment_idx0
             Int[],                              # segment_length
@@ -87,7 +87,7 @@ for FT in (Float32, Float64)
             dummy_dates,                        # all_dates
             monthly_fields,                     # monthly_fields
             nothing,                            # scaling_function
-            nothing,                            # land_mask
+            nothing,                            # land_fraction
             deepcopy(segment_idx0),             # segment_idx
             segment_idx0,                       # segment_idx0
             segment_length,                     # segment_length
@@ -106,7 +106,7 @@ for FT in (Float32, Float64)
             dummy_dates,                        # all_dates
             monthly_fields,                     # monthly_fields
             nothing,                            # scaling_function
-            nothing,                            # land_mask
+            nothing,                            # land_fraction
             deepcopy(segment_idx0),             # segment_idx
             segment_idx0,                       # segment_idx0
             segment_length,                     # segment_length
@@ -134,8 +134,8 @@ for FT in (Float32, Float64)
             quad = Spaces.Quadratures.GLL{Nq}()
             boundary_space_t = Spaces.SpectralElementSpace2D(topology, quad)
 
-            land_mask_t = Fields.zeros(boundary_space_t)
-            dummy_data = (; test_data = zeros(axes(land_mask_t)))
+            land_fraction_t = Fields.zeros(boundary_space_t)
+            dummy_data = (; test_data = zeros(axes(land_fraction_t)))
 
             datafile_rll = sst_data
             varname = "SST"
@@ -152,7 +152,7 @@ for FT in (Float32, Float64)
                 comms_ctx,
                 segment_idx0 = [Int(1309)],
                 interpolate_daily = false,
-                land_mask = land_mask_t,
+                land_fraction = land_fraction_t,
             )
 
             dates = (; date = [date], date0 = [date0], date1 = [date1])
@@ -169,7 +169,7 @@ for FT in (Float32, Float64)
                 tspan, # tspan
                 Int(0), # t
                 Δt, # Δt_cpl
-                (;), # surface_masks
+                (;), # surface_fractions
                 (;), # model_sims
                 (;), # mode
                 (), # diagnostics
@@ -276,7 +276,7 @@ for FT in (Float32, Float64)
             topology = Topologies.Topology2D(mesh)
             quad = Spaces.Quadratures.GLL{Nq}()
             boundary_space_t = Spaces.SpectralElementSpace2D(topology, quad)
-            land_mask_t = Fields.zeros(boundary_space_t)
+            land_fraction_t = Fields.zeros(boundary_space_t)
 
             datafile_rll = mask_data
             varname = "LSMASK"
@@ -293,13 +293,13 @@ for FT in (Float32, Float64)
                 boundary_space_t,
                 comms_ctx,
                 segment_idx0 = [Int(1309)],
-                land_mask = land_mask_t,
+                land_fraction = land_fraction_t,
                 mono = mono,
             )
 
             # test that created object exists and has correct components
             @test @isdefined(bcf_info)
-            @test all(parent(bcf_info.land_mask) .== 0)
+            @test all(parent(bcf_info.land_fraction) .== 0)
 
             # construct weightfile name to test values
             hd_outfile_root = varname * "_cgll"

--- a/test/mpi_tests/bcreader_mpi_tests.jl
+++ b/test/mpi_tests/bcreader_mpi_tests.jl
@@ -35,7 +35,7 @@ ClimaComms.barrier(comms_ctx)
         topology = Topologies.DistributedTopology2D(comms_ctx, mesh, Topologies.spacefillingcurve(mesh))
         quad = Spaces.Quadratures.GLL{Nq}()
         boundary_space_t = Spaces.SpectralElementSpace2D(topology, quad)
-        land_mask_t = Fields.zeros(boundary_space_t)
+        land_fraction_t = Fields.zeros(boundary_space_t)
 
         datafile_rll = sst_data
         varname = "SST"
@@ -52,13 +52,13 @@ ClimaComms.barrier(comms_ctx)
             boundary_space_t,
             comms_ctx,
             segment_idx0 = [Int(1309)],
-            land_mask = land_mask_t,
+            land_fraction = land_fraction_t,
             mono = mono,
         )
 
         # test that created object exists and has correct components
         @test @isdefined(bcf_info)
-        @test all(parent(bcf_info.land_mask) .== 0)
+        @test all(parent(bcf_info.land_fraction) .== 0)
 
         # construct weightfile name to test values
         hd_outfile_root = varname * "_cgll"
@@ -98,8 +98,8 @@ end
         quad = Spaces.Quadratures.GLL{Nq}()
         boundary_space_t = Spaces.SpectralElementSpace2D(topology, quad)
 
-        land_mask_t = Fields.zeros(boundary_space_t)
-        dummy_data = (; test_data = zeros(axes(land_mask_t)))
+        land_fraction_t = Fields.zeros(boundary_space_t)
+        dummy_data = (; test_data = zeros(axes(land_fraction_t)))
 
         datafile_rll = sst_data
         varname = "SST"
@@ -118,7 +118,7 @@ end
             comms_ctx,
             segment_idx0 = [Int(1309)],
             interpolate_daily = false,
-            land_mask = land_mask_t,
+            land_fraction = land_fraction_t,
         )
 
         dates = (; date = [date], date0 = [date0], date1 = [date1])
@@ -135,7 +135,7 @@ end
             tspan, # tspan
             Int(0), # t
             Δt, # Δt_cpl
-            (;), # surface_masks
+            (;), # surface_fractions
             (;), # model_sims
             (;), # mode
             (), # diagnostics


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- rename (surface) masks to (area) fractions for objects which are not necessarily comprised of ones and zeros, to clarify their function. 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [x] rename where appropriate (in `AMIP/modular`, `tests`, `docs`)
- [x] add the missing mask to the slab ocean rhs

## QA
- [x] checked that no changes in behaviour of Buildkite drivers (compared to the merging #283 PR) 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
