### PR TITLE
Add buildkites for mono / binary masks to the final release list

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -110,6 +110,62 @@ steps:
   - group: "Integration Tests"
     steps:
 
+      # Drivers for release >
+
+
+      # SLABPLANET
+
+      # Slabplanet default:
+      # - this is the most lightweight example with conservation and visual checks, with CLI specification as follows
+      #   - numerics: dt = dt_cpl = 200s, nelem = 4
+      #   - physics: bulk aerodynamic surface fluxes, gray radiation, idealized insolation, equil moisture model, 0-moment microphysics
+      #   - input data: monotonous remapping (land mask, SST, SIC)
+      #   - slurm: unthreaded, 1 ntask
+      #   - diagnostics: check and plot energy conservation, output plots after 9 days
+      - label: "Slabplanet: default"
+        key: "slabplanet_default"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name slabplanet_default --enable_threading true --coupled true --surface_scheme bulk  --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 9days --dt_cpl 200 --dt 200secs --mono_surface true --h_elem 4 --precip_model 0M --anim true"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/slabplanet_default_artifacts/*"
+
+      # Test: non-monotonous remapping for land mask
+      - label: "Slabplanet: non-monotonous surface remap"
+        key: "slabplanet_non-monotonous"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name slabplanet_nonmono --enable_threading true --coupled true --surface_scheme bulk  --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 9days --dt_cpl 200 --dt 200secs --mono_surface false --h_elem 4 --precip_model 0M --anim true"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/slabplanet_nonmono_artifacts/*"
+
+
+      # AMIP
+
+      # ...
+
+
+      # PERFORMANCE
+
+      # slabplanet default: track unthreaded performance (alloc tests, flame graph, flame graph diff, build history)
+      - label: ":rocket: Slabplanet: default (unthreaded)"
+        key: "modular_slabplanet_unthreaded"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name default_modular_unthreaded --enable_threading false --coupled true --surface_scheme bulk  --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 9days --dt_cpl 200 --dt 200secs --mono_surface true --h_elem 4 --precip_model 0M --anim true"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/default_modular_unthreaded_artifacts/*"
+        env:
+          FLAME_PLOT: ""
+          BUILD_HISTORY_HANDLE: ""
+        agents:
+          slurm_ntasks: 1
+
+      - label: ":rocket: Slabplanet: default (unthreaded) - flame graph and allocation tests"
+        command: "julia --color=yes --project=perf perf/flame.jl --run_name 1"
+        artifact_paths: "perf/output/perf_default_modular_unthreaded/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: ":rocket: Slabplanet: default (unthreaded) - flame graph diff"
+        command: "julia --color=yes --project=perf perf/flame_diff.jl --run_name 1"
+        artifact_paths: "perf/output/perf_diff_default_modular_unthreaded/*"
+        agents:
+          slurm_mem: 20GB
+
+      # < end Drivers for release
+
       # - label: "Unit tests"
       #   command: "julia --color=yes --project=test test/runtests.jl"
       #   artifact_paths: "test/*"
@@ -126,28 +182,9 @@ steps:
         command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface false --h_elem 4 --precip_model 0M --run_name default_notmono"
         artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/default_notmono_artifacts/total_energy*.png"
 
-      - label: "Moist earth with slab surface - notmono + modular: bulk gray no_sponge idealinsol freq_dt_cpl"
-        key: "modular_slabplanet"
-        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name default_modular --enable_threading true --coupled true --surface_scheme bulk  --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface false --h_elem 4 --precip_model 0M"
-        artifact_paths: "experiments/AMIP/modular/output/slabplanet/default_modular_artifacts/total_energy*.png"
-        env:
-          BUILD_HISTORY_HANDLE: ""
-        agents:
-          slurm_ntasks: 1
-
-      - label: "Moist earth with slab surface (unthreaded) - notmono + modular: bulk gray no_sponge idealinsol freq_dt_cpl"
-        key: "modular_slabplanet_unthreaded"
-        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name default_modular_unthreaded --enable_threading true --coupled true --surface_scheme bulk  --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface false --h_elem 4 --precip_model 0M"
-        artifact_paths: "experiments/AMIP/modular/output/slabplanet/default_modular_unthreaded_artifacts/total_energy*.png"
-        env:
-          FLAME_PLOT: ""
-          BUILD_HISTORY_HANDLE: ""
-        agents:
-          slurm_ntasks: 1
-
       # Note: this test fails when run with the more realistic albedo from file
       - label: "Moist earth with slab surface - target: monin allsky sponge realinsol infreq_dt_cpl - bucket using BulkAlbedoFunction"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --albedo_from_file false --run_name target_params_in_slab"
+        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl  --run_name target_params_in_slab --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --albedo_from_file false"
         artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab_artifacts/total_energy*.png"
 
       - label: "Moist earth with slab surface - test: monin allsky sponge idealinsol infreq_dt_cpl"
@@ -212,21 +249,10 @@ steps:
           slurm_mem: 20GB
 
       # flame graphs + allocation tests
-      - label: ":rocket: flame graph and allocation tests: perf_default_modular_unthreaded"
-        command: "julia --color=yes --project=perf perf/flame.jl --run_name 1"
-        artifact_paths: "perf/output/perf_default_modular_unthreaded/*"
-        agents:
-          slurm_mem: 20GB
 
       - label: ":rocket: flame graph and allocation tests: perf_coarse_single_modular"
         command: "julia --color=yes --project=perf perf/flame.jl --run_name 2"
         artifact_paths: "perf/output/perf_coarse_single_modular/*"
-        agents:
-          slurm_mem: 20GB
-
-      - label: ":rocket: performance: flame graph diff: perf_default_modular_unthreaded"
-        command: "julia --color=yes --project=perf perf/flame_diff.jl --run_name 1"
-        artifact_paths: "perf/output/perf_diff_default_modular_unthreaded/*"
         agents:
           slurm_mem: 20GB
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- start a list of Buildkite drivers that we want to keep for the release.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- move / add tests for 
  - [x] slabplanet default (stating the default options)
  - [x] slabplanet - testing non-monotonous remapping of the land-sea
  - [x] slabplanet - performance tests

- AMIP will be added later, once we decide on the final AMIP default. 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
