### PR TITLE
Update CI to use exp/AMIP/modular/

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,11 +38,6 @@ steps:
       - "julia --project=experiments/ClimaCore/sea_breeze -e 'using Pkg; Pkg.precompile()'"
       - "julia --project=experiments/ClimaCore/sea_breeze -e 'using Pkg; Pkg.status()'"
 
-      - echo "--- Instantiate amip env"
-      - "julia --project=experiments/AMIP/moist_mpi_earth/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project=experiments/AMIP/moist_mpi_earth/ -e 'using Pkg; Pkg.precompile()'"
-      - "julia --project=experiments/AMIP/moist_mpi_earth/ -e 'using Pkg; Pkg.status()'"
-
       - echo "--- Instantiate amip modular"
       - "julia --project=experiments/AMIP/modular/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=experiments/AMIP/modular/ -e 'using Pkg; Pkg.precompile()'"
@@ -176,49 +171,43 @@ steps:
       #   command: "julia --color=yes --project=test test/runtests.jl"
       #   artifact_paths: "test/*"
 
-      - label: "Moist earth with slab surface - default: bulk gray no_sponge idealinsol freq_dt_cpl"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface true --h_elem 4 --precip_model 0M --run_name default_mono --job_id default_mono"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/default_mono_artifacts/total_energy*.png"
+      - label: "Moist earth with slab surface - default: monin gray no_sponge idealinsol freq_dt_cpl"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface true --h_elem 4 --precip_model 0M --run_name default_mono --job_id default_mono"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/default_mono_artifacts/total_energy*.png"
 
-      - label: "Moist earth with slab surface - default: bulk gray no_sponge idealinsol freq_dt_cpl - bucket using BulkAlbedoFunction"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface true --h_elem 4 --precip_model 0M --albedo_from_file false --run_name default_albedo_prescribed --job_id default_albedo_from_file"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/default_albedo_from_file_artifacts/total_energy*.png"
+      - label: "Moist earth with slab surface - default: monin gray no_sponge idealinsol freq_dt_cpl - bucket using BulkAlbedoFunction"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface true --h_elem 4 --precip_model 0M --albedo_from_file false --run_name default_albedo_prescribed --job_id default_albedo_from_file"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/default_albedo_from_file_artifacts/total_energy*.png"
 
-      - label: "Moist earth with slab surface - notmono: bulk gray no_sponge idealinsol freq_dt_cpl notmono"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface false --h_elem 4 --precip_model 0M --run_name default_notmono --job_id default_notmono"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/default_notmono_artifacts/total_energy*.png"
+      - label: "Moist earth with slab surface - notmono: monin gray no_sponge idealinsol freq_dt_cpl notmono"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 200 --dt 200secs --mono_surface false --h_elem 4 --precip_model 0M --run_name default_notmono --job_id default_notmono"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/default_notmono_artifacts/total_energy*.png"
 
       # Note: this test fails when run with the more realistic albedo from file
       - label: "Moist earth with slab surface - target: monin allsky sponge realinsol infreq_dt_cpl - bucket using BulkAlbedoFunction"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl  --run_name target_params_in_slab --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --albedo_from_file false --job_id target_params_in_slab"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab_artifacts/total_energy*.png"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl  --run_name target_params_in_slab --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --albedo_from_file false --job_id target_params_in_slab"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/target_params_in_slab_artifacts/total_energy*.png"
 
       - label: "Moist earth with slab surface - test: monin allsky sponge idealinsol infreq_dt_cpl"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 21600 --dt 200secs --dt_rad 6hours --idealized_insolation true --mono_surface true --h_elem 4 --precip_model 0M --run_name target_params_in_slab_test1 --job_id target_params_in_slab_test1"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab_test1_artifacts/total_energy*.png"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 21600 --dt 200secs --dt_rad 6hours --idealized_insolation true --mono_surface true --h_elem 4 --precip_model 0M --run_name target_params_in_slab_test1 --job_id target_params_in_slab_test1"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/target_params_in_slab_test1_artifacts/total_energy*.png"
 
       - label: "Moist earth with slab surface - test: bulk allsky sponge realinsol infreq_dt_cpl"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme bulk --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --run_name target_params_in_slab_test2 --job_id target_params_in_slab_test2"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab_test2_artifacts/total_energy*.png"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --enable_threading true --coupled true --surface_scheme bulk --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --run_name target_params_in_slab_test2 --job_id target_params_in_slab_test2"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/target_params_in_slab_test2_artifacts/total_energy*.png"
 
       - label: "Moist earth with slab surface - test: monin gray sponge realinsol infreq_dt_cpl"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --run_name target_params_in_slab_test3 --job_id target_params_in_slab_test3"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab_test3_artifacts/total_energy*.png"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --run_name target_params_in_slab_test3 --job_id target_params_in_slab_test3"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/target_params_in_slab_test3_artifacts/total_energy*.png"
 
       # breaking:
       # - label: "Moist earth with slab surface - monin allsky no_sponge idealinsol infreq_dt_cpl"
-      #   command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge false --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 21600 --dt 200secs --dt_rad 6hours --idealized_insolation true --mono_surface true --h_elem 4 --precip_model 0M --run_name target_params_in_slab1"
-      #   artifact_paths: "experiments/AMIP/moist_mpi_earth/output/slabplanet/target_params_in_slab1_artifacts/total_energy*.png"
-
-      - label: "AMIP"
-        command: "julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 10days --precip_model 0M --run_name coarse_single --job_id coarse_single"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/coarse_single_artifacts/*"
-        agents:
-          slurm_mem: 20GB
+      #   command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --enable_threading true --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge false --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 21600 --dt 200secs --dt_rad 6hours --idealized_insolation true --mono_surface true --h_elem 4 --precip_model 0M --run_name target_params_in_slab1"
+      #   artifact_paths: "experiments/AMIP/modular/output/slabplanet/target_params_in_slab1_artifacts/total_energy*.png"
 
       - label: "AMIP - modular"
         key: "modular_amip"
-        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name coarse_single_modular --enable_threading true --coupled true  --surface_scheme bulk --moist equil --vert_diff true --rad gray --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 10days --precip_model 0M --job_id coarse_single_modular"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name coarse_single_modular --enable_threading true --coupled true  --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 10days --precip_model 0M --job_id coarse_single_modular"
         artifact_paths: "experiments/AMIP/modular/output/amip/coarse_single_modular_artifacts/*"
         env:
           FLAME_PLOT: ""
@@ -239,8 +228,8 @@ steps:
         artifact_paths: "sea_breeze/"
 
       - label: "MPI AMIP"
-        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 5days --precip_model 0M --run_name coarse_mpi_n2 --job_id coarse_mpi_n2"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/coarse_mpi_n2_artifacts/*"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --coupled true --surface_scheme monin_obukhov --moist equil --vert_diff true --rad gray --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 5days --precip_model 0M --run_name coarse_mpi_n2 --job_id coarse_mpi_n2"
+        artifact_paths: "experiments/AMIP/modular/output/amip/coarse_mpi_n2_artifacts/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
         agents:


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Our buildkite CI pipeline currently initialized both the `experiments/AMIP/moist_mpi_earth` and `experiments/AMIP/modular` environments, and runs tests using the drivers in both. The `modular` folder is meant to replace `moist_mpi_earth`, so we can remove the `moist_mpi_earth` initialization and replace all tests using it with the `modular` environment instead. 

This change makes the initialization stage of buildkite CI about 5 minutes faster.

Closes #299 

## Content
- [x] remove `moist_mpi_earth` environment initialization
- [x] replace `moist_mpi_earth` tests with `modular`


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
