### PR TITLE
Add current target to longruns

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -27,9 +27,9 @@ steps:
       - julia -e 'using Pkg; Pkg.add("MPIPreferences"); using MPIPreferences; use_system_binary()'
 
       - echo "--- Instantiate AMIP env"
-      - "julia --project=experiments/AMIP/moist_mpi_earth/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project=experiments/AMIP/moist_mpi_earth/ -e 'using Pkg; Pkg.precompile()'"
-      - "julia --project=experiments/AMIP/moist_mpi_earth/ -e 'using Pkg; Pkg.status()'"
+      - "julia --project=experiments/AMIP/modular/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project=experiments/AMIP/modular/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project=experiments/AMIP/modular/ -e 'using Pkg; Pkg.status()'"
 
       - echo "--- Download artifacts"
       - "julia --project=artifacts -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
@@ -54,32 +54,43 @@ steps:
 
     steps:
 
-      - label: "Moist earth with slab surface - notmono + modular: bulk gray no_sponge idealinsol freq_dt_cpl"
-        key: "slabplanet"
-        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name default_modular_long --coupled true  --moist equil --vert_diff true --rad gray --energy_check true --anim true --mode_name slabplanet --t_end 10days --dt_save_to_sol 1days --dt_cpl 200 --dt 200secs --mono_surface false --h_elem 4 --precip_model 0M"
-        artifact_paths: "experiments/AMIP/modular/output/slabplanet/default_modular_long_artifacts/total_energy*.png"
+      - label: "Slabplanet: default"
+        key: "slabplanet_default_longrun"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name slabplanet_default_longrun --FLOAT_TYPE Float64 --coupled true --surface_setup PrescribedSurface  --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 60days --dt_save_to_sol 10days --dt_cpl 200 --dt 200secs --mono_surface true --h_elem 6 --precip_model 0M --anim true --job_id slabplanet_default_longrun"
+        artifact_paths: "experiments/AMIP/modular/output/slabplanet/slabplanet_default_longrun_artifacts/*"
         env:
           BUILD_HISTORY_HANDLE: ""
         agents:
           slurm_ntasks: 1
           slurm_mem_per_cpu: 16G
 
-      - label: "MPI AMIP FINE: longrun"
-        key: "amip_longrun"
-        command: "mpiexec julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name target_amip_n64_longrun --coupled true --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 180days --dt_save_to_sol 10days --mono_surface false --precip_model 0M"
-        artifact_paths: "experiments/AMIP/modular/output/amip/target_amip_n64_longrun_artifacts/*"
+      # - label: "MPI AMIP FINE: longrun" # unstable after 6 months
+      #   key: "amip_longrun_fine"
+      #   command: "mpiexec julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name amip_longrun_fine --coupled true  --anim true  --surface_setup PrescribedSurface --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 140days --dt_save_to_sol 10days --mono_surface false --precip_model 0M"
+      #   artifact_paths: "experiments/AMIP/modular/output/amip/amip_longrun_fine_artifacts/*"
+      #   env:
+      #     CLIMACORE_DISTRIBUTED: "MPI"
+      #     BUILD_HISTORY_HANDLE: ""
+      #   agents:
+      #     slurm_ntasks: 64
+      #     slurm_mem_per_cpu: 16G
+
+      - label: "MPI AMIP FINE: target longrun"
+        key: "amip_longrun_target"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name amip_longrun_target --coupled true  --anim true --surface_setup PrescribedSurface --dt_cpl 150 --energy_check false --mode_name amip --mono_surface false --vert_diff true --moist equil --rad clearsky --precip_model 0M --z_elem 35 --dz_bottom 50 --h_elem 12 --kappa_4 3e16 --rayleigh_sponge true --alpha_rayleigh_uh 0 --dt 150secs --t_end 140days --job_id amip_longrun_target --dt_save_to_sol 5days --dt_save_to_disk 1days --FLOAT_TYPE Float64"
+        artifact_paths: "experiments/AMIP/modular/output/amip/amip_longrun_target_artifacts/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
           BUILD_HISTORY_HANDLE: ""
         agents:
-          slurm_ntasks: 64
+          slurm_ntasks: 32
           slurm_mem_per_cpu: 16G
 
       # MPI performance scaling (10 days)
       - label: "MPI AMIP FINE: n64"
         key: "mpi_amip_fine_n64"
-        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --run_name target_amip_n64_shortrun --coupled true --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n64_shortrun_artifacts/*"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name amip_n64_shortrun --coupled true --surface_setup PrescribedSurface --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/modular/output/amip/amip_n64_shortrun_artifacts/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
           BUILD_HISTORY_HANDLE: ""
@@ -90,8 +101,8 @@ steps:
 
       - label: "MPI AMIP FINE: n32"
         key: "mpi_amip_fine_n32"
-        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --run_name target_amip_n32_shortrun --coupled true --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n32_shortrun_artifacts/*"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name amip_n32_shortrun --coupled true --surface_setup PrescribedSurface --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/modular/output/amip/amip_n32_shortrun_artifacts/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
           BUILD_HISTORY_HANDLE: ""
@@ -102,8 +113,8 @@ steps:
 
       - label: "MPI AMIP FINE: n8"
         key: "mpi_amip_fine_n8"
-        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --run_name target_amip_n8_shortrun --coupled true --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n8_shortrun_artifacts/*"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name amip_n8_shortrun --coupled true --surface_setup PrescribedSurface --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/modular/output/amip/amip_n8_shortrun_artifacts/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
           BUILD_HISTORY_HANDLE: ""
@@ -112,10 +123,10 @@ steps:
           slurm_mem_per_cpu: 16G
           slurm_tasks_per_node: 8
 
-      - label: "MPI AMIP FINE: n2"
+      - label: "MPI AMIP FINE: n2" # 10d take 21h, so reducing to 1d
         key: "mpi_amip_fine_n2"
-        command: "mpiexec julia --color=yes --project=experiments/AMIP/moist_mpi_earth/ experiments/AMIP/moist_mpi_earth/coupler_driver.jl --run_name target_amip_n2_shortrun --coupled true --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
-        artifact_paths: "experiments/AMIP/moist_mpi_earth/output/amip/target_amip_n2_shortrun_artifacts/*"
+        command: "mpiexec julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name amip_n2_shortrun --coupled true --surface_setup PrescribedSurface --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 1days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/modular/output/amip/amip_n2_shortrun_artifacts/*"
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
           BUILD_HISTORY_HANDLE: ""
@@ -124,16 +135,16 @@ steps:
           slurm_mem_per_cpu: 16G
           slurm_tasks_per_node: 2
 
-      - label: "Unthreaded AMIP FINE" # also reported by longruns with a flame graph
-        key: "unthreaded_amip_fine"
-        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name target_amip_n1_shortrun --coupled true --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 10days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
-        artifact_paths: "experiments/AMIP/modular/output/amip/target_amip_n1_shortrun_artifacts/*"
+      - label: "MPI AMIP FINE: n1" # also reported by longruns with a flame graph; 10d take 21h, so reducing to 1d
+        key: "mpi_amip_fine_n1"
+        command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name amip_n1_shortrun --coupled true --surface_setup PrescribedSurface --moist equil --vert_diff true --rad gray --z_elem 50 --dz_top 3000 --dz_bottom 30 --h_elem 16 --kappa_4 1e16 --z_stretch false --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --dt_cpl 150 --dt 150secs --dt_rad 1hours --FLOAT_TYPE Float64 --energy_check false --mode_name amip --t_end 1days --dt_save_to_sol 100days --mono_surface false --precip_model 0M"
+        artifact_paths: "experiments/AMIP/modular/output/amip/amip_n1_shortrun_artifacts/*"
         env:
           BUILD_HISTORY_HANDLE: ""
         agents:
           slurm_mem_per_cpu: 16G
 
-      # Unthreaded flame graph report (NB: arguments passed from the ci pipeline.yml)
+      # mpi_amip_fine_n1 flame graph report (NB: arguments passed from the ci pipeline.yml)
       - label: ":rocket: performance: flame graph diff: perf_target_amip_n1_shortrun"
         command: "julia --color=yes --project=perf perf/flame_diff.jl --run_name 4"
         artifact_paths: "perf/output/perf_diff_target_amip_n1_shortrun/*"
@@ -157,12 +168,16 @@ steps:
 
       - label: ":envelope: Slack report: Slabplanet"
         command:
-          - slack-upload -c "#coupler-report" -f experiments/AMIP/modular/output/slabplanet/default_modular_long_artifacts/total_energy_log_bucket.png -m png -n slab_coarse_log -x "Slabplanet energy conservation (log error)"
-          - slack-upload -c "#coupler-report" -f experiments/AMIP/modular/output/slabplanet/default_modular_long_artifacts/total_energy_bucket.png -m png -n slab_coarse -x "Slabplanet energy conservation"
+          - slack-upload -c "#coupler-report" -f experiments/AMIP/modular/output/slabplanet/slabplanet_default_longrun_artifacts/total_energy_log_bucket.png -m png -n slab_coarse_log -x "Slabplanet energy conservation (log error)"
+          - slack-upload -c "#coupler-report" -f experiments/AMIP/modular/output/slabplanet/slabplanet_default_longrun_artifacts/total_energy_bucket.png -m png -n slab_coarse -x "Slabplanet energy conservation"
+
+      # - label: ":envelope: Slack report: AMIP fine benchmark"
+      #   command:
+      #     - slack-upload -c "#coupler-report" -f experiments/AMIP/modular/output/amip/amip_longrun_fine_artifacts/amip_paperplots.png -m png -n amip_fine -x "AMIP Longrun"
 
       - label: ":envelope: Slack report: target AMIP"
         command:
-          - slack-upload -c "#coupler-report" -f experiments/AMIP/modular/output/amip/target_amip_n64_longrun_artifacts/amip_paperplots.png -m png -n amip_fine -x "AMIP Longrun"
+          - slack-upload -c "#coupler-report" -f experiments/AMIP/modular/output/amip/amip_longrun_target_artifacts/amip_paperplots.png -m png -n amip_fine -x "AMIP Target Longrun"
 
       - label: ":envelope: Slack report: Flame Diff"
         command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -126,6 +126,8 @@ steps:
         key: "slabplanet_default"
         command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --run_name slabplanet_default --FLOAT_TYPE Float64 --coupled true --surface_setup PrescribedSurface  --moist equil --vert_diff true --rad gray --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 9days --dt_cpl 200 --dt 200secs --mono_surface true --h_elem 4 --precip_model 0M --anim true --job_id slabplanet_default"
         artifact_paths: "experiments/AMIP/modular/output/slabplanet/slabplanet_default_artifacts/*"
+        agents:
+          slurm_mem: 20GB
 
       # Test: non-monotonous remapping for land mask
       - label: "Slabplanet: non-monotonous surface remap"
@@ -205,6 +207,8 @@ steps:
       - label: "Moist earth with slab surface - test: bulk allsky sponge realinsol infreq_dt_cpl"
         command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --FLOAT_TYPE Float64 --coupled true --surface_setup PrescribedSurface --moist equil --vert_diff true --rad allskywithclear --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --run_name target_params_in_slab_test2 --job_id target_params_in_slab_test2"
         artifact_paths: "experiments/AMIP/modular/output/slabplanet/target_params_in_slab_test2_artifacts/total_energy*.png"
+        agents:
+          slurm_mem: 20GB
 
       - label: "Moist earth with slab surface - test: monin gray sponge realinsol infreq_dt_cpl"
         command: "julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --FLOAT_TYPE Float64 --coupled true --surface_setup PrescribedSurface --moist equil --vert_diff true --rad gray --rayleigh_sponge true --alpha_rayleigh_uh 0 --alpha_rayleigh_w 10 --energy_check true --mode_name slabplanet --t_end 10days --dt_save_to_sol 3600secs --dt_cpl 3600 --dt 200secs --dt_rad 6hours --idealized_insolation false --mono_surface true --h_elem 6 --precip_model 0M --run_name target_params_in_slab_test3 --job_id target_params_in_slab_test3"
@@ -238,6 +242,8 @@ steps:
       - label: "sea_breeze"
         command: "julia --color=yes --project=experiments/ClimaCore/sea_breeze experiments/ClimaCore/sea_breeze/run.jl"
         artifact_paths: "sea_breeze/"
+        agents:
+          slurm_mem: 20GB
 
       - label: "MPI AMIP"
         command: "mpiexec julia --color=yes --project=experiments/AMIP/modular/ experiments/AMIP/modular/coupler_driver_modular.jl --FLOAT_TYPE Float64 --coupled true --surface_setup PrescribedSurface --moist equil --vert_diff true --rad gray --energy_check false --mode_name amip --anim true --t_end 32days --dt_save_to_sol 1days --dt_cpl 400 --dt 400secs --mono_surface false --h_elem 6 --dt_save_restart 5days --precip_model 0M --run_name coarse_mpi_n2 --job_id coarse_mpi_n2"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->

Closes #355 

[ClimaCoupler-Longruns](https://buildkite.com/clima/climacoupler-longruns/builds/199)

Note: the old AMIP FINE benchmark crashes (unconverged SFs) after 120d. We will need to find the new stability region for these options, so it is commented for now. 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
