### PR TITLE
Switch back to default flux type option for interactive runs

### DIFF
--- a/experiments/AMIP/modular/coupler_driver_modular.jl
+++ b/experiments/AMIP/modular/coupler_driver_modular.jl
@@ -83,7 +83,7 @@ if isinteractive()
     parsed_args["dt_cpl"] = 200 #hide
     parsed_args["dt"] = "200secs" #hide
     parsed_args["mono_surface"] = true #hide
-    parsed_args["turb_flux_partition"] = "PartitionedStateFluxes" #hide
+    parsed_args["turb_flux_partition"] = "CombinedStateFluxes" #hide
     parsed_args["h_elem"] = 4 #hide
     # parsed_args["dt_save_restart"] = "5days" #hide
     parsed_args["precip_model"] = "0M" #hide


### PR DESCRIPTION
Switch back to `CombinedStateFluxes` as the default option for interactive debug runs. This is faster and more stable for the current coarse benchmarks.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
