### PR TITLE
add aqua tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,0 +1,32 @@
+using Test
+using ClimaCoupler
+using Aqua
+
+@testset "Aqua tests (performance)" begin
+    # This tests that we don't accidentally run into
+    # https://github.com/JuliaLang/julia/issues/29393
+    ua = Aqua.detect_unbound_args_recursively(ClimaCoupler)
+    @test length(ua) == 0
+
+    # See: https://github.com/SciML/OrdinaryDiffEq.jl/issues/1750
+    # Test that we're not introducing method ambiguities across deps
+    ambs = Aqua.detect_ambiguities(ClimaCoupler; recursive = true)
+    pkg_match(pkgname, pkdir::Nothing) = false
+    pkg_match(pkgname, pkdir::AbstractString) = occursin(pkgname, pkdir)
+    filter!(x -> pkg_match("ClimaCoupler", pkgdir(last(x).module)), ambs)
+
+    # Uncomment for debugging:
+    # for method_ambiguity in ambs
+    #     @show method_ambiguity
+    # end
+    @test length(ambs) == 0
+end
+
+@testset "Aqua tests (additional)" begin
+    Aqua.test_undefined_exports(ClimaCoupler)
+    Aqua.test_stale_deps(ClimaCoupler)
+    Aqua.test_deps_compat(ClimaCoupler)
+    Aqua.test_project_extras(ClimaCoupler)
+    Aqua.test_project_toml_formatting(ClimaCoupler)
+    Aqua.test_piracy(ClimaCoupler)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using SafeTestsets
 
+@safetestset "Aqua tests" begin
+    include("aqua.jl")
+end
 @safetestset "Clock tests" begin
     include("CoupledSimulations/clock.jl")
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add aqua tests for code quality and performance checks. Copied directly from [ClimaAtmos aqua tests](https://github.com/CliMA/ClimaAtmos.jl/blob/main/test/aqua.jl).

Closes #351 

## To-do
- [x] Copy aqua tests from ClimaAtmos/ClimaLSM
- [x] Verify that tests pass


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
