### PR TITLE
Add up_deps.jl script

### DIFF
--- a/.dev/up_deps.jl
+++ b/.dev/up_deps.jl
@@ -1,0 +1,37 @@
+#=
+A simple script for updating the manifest
+files in all of our environments.
+=#
+
+root = dirname(@__DIR__)
+dirs = (
+    root,
+    joinpath(root, "artifacts"),
+    joinpath(root, "test"),
+    joinpath(root, ".dev"),
+    joinpath(root, "perf"),
+    joinpath(root, "docs"),
+    joinpath(root, "experiments/AMIP/modular"),
+)
+
+cd(root) do
+    for dir in dirs
+        reldir = relpath(dir, root)
+        @info "Updating environment `$reldir`"
+        cmd = if dir == root
+            `$(Base.julia_cmd()) --project -e """import Pkg; Pkg.update()"""`
+        elseif dir == joinpath(root, ".dev")
+            `$(Base.julia_cmd()) --project=$reldir -e """import Pkg; Pkg.update()"""`
+        else
+            `$(Base.julia_cmd()) --project=$reldir -e """import Pkg; Pkg.develop(;path=\".\"); Pkg.update()"""`
+        end
+        run(cmd)
+    end
+end
+
+# https://github.com/JuliaLang/Pkg.jl/issues/3014
+for dir in dirs
+    cd(dir) do
+        rm("LocalPreferences.toml"; force = true)
+    end
+end


### PR DESCRIPTION
## Purpose 
The purpose of this PR is to add an `up_deps.jl` script to streamline/automate updating dependencies. To update dependencies in the relevant environments, from now on, just simply run the following command:

```
julia ./.dev/up_deps.jl
```

Closes #409 

## Content
- Solution implemented: 
    - [x] Added an `up_deps.jl` script that automatically updates the relevant environments

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
