### PR TITLE
move CoupledSim to Interfacer

### DIFF
--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -3,7 +3,7 @@
 This module contains functions for defining the interface for coupling component models, as well as stub objects that contain prescribed fields.
 
 ## Coupled Simulation
-- `CoupledSimulation` (`cs`, currently in Utilities - TODO) stores info for ESM run. We require that each `cs` contains four (`atmos_sim`, `land_sim`, `ocean_sim` and `ice_sim`) components. While this requirement will not be eventually needed, for the time being, if a simulation surface type is not needed for a given run, it should be initialized with `SurfaceStub` with a zero `area_fracion`. The `atmos_sim` should always be specified.
+- `CoupledSimulation` (`cs`) stores info for ESM run. We require that each `cs` contains four (`atmos_sim`, `land_sim`, `ocean_sim` and `ice_sim`) components. While this requirement will not be eventually needed, for the time being, if a simulation surface type is not needed for a given run, it should be initialized with `SurfaceStub` with a zero `area_fracion`. The `atmos_sim` should always be specified.
 
 ## Component model simulations
 - all Simulations that are not the `CoupledSimulation` fall under `ComponentModelSimulation`

--- a/experiments/AMIP/modular/coupler_driver_modular.jl
+++ b/experiments/AMIP/modular/coupler_driver_modular.jl
@@ -73,7 +73,7 @@ import ClimaCoupler.Regridder:
     update_surface_fractions!, combine_surfaces!, combine_surfaces_from_sol!, dummmy_remap!, binary_mask
 import ClimaCoupler.ConservationChecker:
     EnergyConservationCheck, WaterConservationCheck, check_conservation!, plot_global_conservation
-import ClimaCoupler.Utilities: CoupledSimulation, float_type, swap_space!
+import ClimaCoupler.Utilities: swap_space!
 import ClimaCoupler.BCReader:
     bcfile_info_init, float_type_bcf, update_midmonth_data!, next_date_in_file, interpolate_midmonth_to_daily
 import ClimaCoupler.TimeManager: current_date, datetime_to_strdate, trigger_callback, Monthly, EveryTimestep
@@ -81,6 +81,8 @@ import ClimaCoupler.Diagnostics: get_var, init_diagnostics, accumulate_diagnosti
 import ClimaCoupler.PostProcessor: postprocess
 
 import ClimaCoupler.Interfacer:
+    CoupledSimulation,
+    float_type,
     AtmosModelSimulation,
     SurfaceModelSimulation,
     SurfaceStub,

--- a/experiments/AMIP/modular/user_io/user_diagnostics.jl
+++ b/experiments/AMIP/modular/user_io/user_diagnostics.jl
@@ -3,6 +3,7 @@
 # Atmos diagnostics
 import ClimaAtmos.Parameters as CAP
 import Thermodynamics as TD
+using ClimaCoupler.Interfacer: CoupledSimulation, float_type
 
 """
     get_var(cs::CoupledSimulation, ::Val{:T})

--- a/src/ConservationChecker.jl
+++ b/src/ConservationChecker.jl
@@ -6,7 +6,6 @@ This module contains functions that check global conservation of energy and wate
 module ConservationChecker
 
 using ClimaCore: ClimaCore, Geometry, Meshes, Domains, Topologies, Spaces, Fields, InputOutput
-using ClimaCore.Utilities: half
 using ClimaComms
 using NCDatasets
 using ClimaCoreTempestRemap
@@ -16,7 +15,7 @@ using UnPack
 using Plots
 using ClimaAtmos: RRTMGPI
 using ClimaLSM
-using ClimaCoupler.Utilities: CoupledSimulation, swap_space!
+using ClimaCoupler.Utilities: swap_space!
 import ClimaCoupler: Interfacer
 
 export AbstractConservationCheck,
@@ -61,17 +60,17 @@ end
 Interfacer.name(::WaterConservationCheck) = "water [kg]"
 
 """
-    check_conservation!(coupler_sim::CoupledSimulation; runtime_check = false)
+    check_conservation!(coupler_sim::Interfacer.CoupledSimulation; runtime_check = false)
 
 itertes over all specified conservation checks.
 """
-check_conservation!(coupler_sim::CoupledSimulation; runtime_check = false) =
+check_conservation!(coupler_sim::Interfacer.CoupledSimulation; runtime_check = false) =
     map(x -> check_conservation!(x, coupler_sim, runtime_check), coupler_sim.conservation_checks)
 
 """
         check_conservation!(
         cc::EnergyConservationCheck,
-        coupler_sim,
+        coupler_sim::Interfacer.CoupledSimulation,
         runtime_check = false,
         )
 
@@ -79,7 +78,11 @@ computes the total energy, ∫ ρe dV, of the model components
 of the coupled simulations and the TOA radiation, and updates
 `cc` with these values.
 """
-function check_conservation!(cc::EnergyConservationCheck, coupler_sim::CoupledSimulation, runtime_check = false)
+function check_conservation!(
+    cc::EnergyConservationCheck,
+    coupler_sim::Interfacer.CoupledSimulation,
+    runtime_check = false,
+)
 
     ccs = cc.sums
     @unpack model_sims = coupler_sim
@@ -139,7 +142,7 @@ end
 """
     check_conservation!(
     cc::WaterConservationCheck,
-    coupler_sim,
+    coupler_sim::Interfacer.CoupledSimulation,
     runtime_check = false,
     )
 
@@ -148,7 +151,11 @@ of the coupled simulations, and updates `cc` with the values.
 
 Note: in the future this should not use `push!`.
 """
-function check_conservation!(cc::WaterConservationCheck, coupler_sim::CoupledSimulation, runtime_check = false)
+function check_conservation!(
+    cc::WaterConservationCheck,
+    coupler_sim::Interfacer.CoupledSimulation,
+    runtime_check = false,
+)
 
     ccs = cc.sums
     @unpack model_sims = coupler_sim
@@ -197,11 +204,11 @@ function check_conservation!(cc::WaterConservationCheck, coupler_sim::CoupledSim
 end
 
 """
-    surface_water_gain_from_rates(cs)
+    surface_water_gain_from_rates(cs::Interfacer.CoupledSimulation)
 
 Determines the total water content gain/loss of a surface from the begining of the simulation based on evaporation and precipitation rates.
 """
-function surface_water_gain_from_rates(cs::CoupledSimulation)
+function surface_water_gain_from_rates(cs::Interfacer.CoupledSimulation)
     evaporation = cs.fields.F_turb_moisture # kg / m^2 / s / layer depth
     precipitation_l = cs.fields.P_liq
     precipitation_s = cs.fields.P_snow
@@ -214,7 +221,7 @@ ENV["GKSwstype"] = "nul"
 """
     plot_global_conservation(
         cc::EnergyConservationCheck,
-        coupler_sim::CoupledSimulation;
+        coupler_sim::Interfacer.CoupledSimulation;
         figname1 = "total_energy.png",
         figname2 = "total_energy_log.png",
     )
@@ -226,7 +233,7 @@ relative to the initial value;
 """
 function plot_global_conservation(
     cc::AbstractConservationCheck,
-    coupler_sim::CoupledSimulation;
+    coupler_sim::Interfacer.CoupledSimulation;
     figname1 = "total.png",
     figname2 = "total_log.png",
 )

--- a/src/Diagnostics.jl
+++ b/src/Diagnostics.jl
@@ -6,7 +6,7 @@ This module contains functions for defining, gathering and outputting online mod
 module Diagnostics
 
 using ClimaCore: Spaces, Fields, InputOutput
-using ClimaCoupler.Utilities: CoupledSimulation
+using ClimaCoupler.Interfacer: CoupledSimulation
 using Dates
 using ClimaCoupler.TimeManager: AbstractFrequency, Monthly, EveryTimestep, trigger_callback
 using ClimaComms

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -7,7 +7,9 @@ module Interfacer
 import Thermodynamics as TD
 
 using ClimaCore: Fields
-export ComponentModelSimulation,
+export CoupledSimulation,
+    float_type,
+    ComponentModelSimulation,
     AtmosModelSimulation,
     SurfaceModelSimulation,
     SurfaceStub,
@@ -17,6 +19,57 @@ export ComponentModelSimulation,
     name,
     get_field,
     update_field!
+
+
+"""
+    AbstractSimulation
+
+An abstract super-type representing a simulation.
+"""
+abstract type AbstractSimulation{FT} end
+
+"""
+    CoupledSimulation
+Stores information needed to run a simulation with the coupler.
+"""
+struct CoupledSimulation{
+    FT <: Real,
+    X,
+    D,
+    B,
+    FV,
+    P,
+    E,
+    TS,
+    TI <: Real,
+    DTI <: Real,
+    NTSM <: NamedTuple,
+    NTMS <: NamedTuple,
+    NTM <: NamedTuple,
+}
+    comms_ctx::X
+    dates::D
+    boundary_space::B
+    fields::FV
+    parsed_args::P
+    conservation_checks::E
+    tspan::TS
+    t::TI
+    Δt_cpl::DTI
+    surface_fractions::NTSM
+    model_sims::NTMS
+    mode::NTM
+    diagnostics::Tuple
+end
+
+CoupledSimulation{FT}(args...) where {FT} = CoupledSimulation{FT, typeof.(args[1:12])...}(args...)
+
+"""
+    float_type(::CoupledSimulation)
+
+Return the floating point type backing `T`: `T` can either be an object or a type.
+"""
+float_type(::CoupledSimulation{FT}) where {FT} = FT
 
 """
     ComponentModelSimulation

--- a/src/TimeManager.jl
+++ b/src/TimeManager.jl
@@ -6,7 +6,7 @@ of data.
 """
 module TimeManager
 
-using ..Utilities
+using ..Interfacer: CoupledSimulation
 using Dates
 
 export current_date,

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -8,57 +8,7 @@ module Utilities
 
 using ClimaCore: Fields, Spaces
 
-export CoupledSimulation, float_type, swap_space!
-
-"""
-    AbstractSimulation
-
-An abstract super-type representing a simulation.
-"""
-abstract type AbstractSimulation{FT} end
-
-"""
-    CoupledSimulation
-Stores information needed to run a simulation with the coupler.
-"""
-struct CoupledSimulation{
-    FT <: Real,
-    X,
-    D,
-    B,
-    FV,
-    P,
-    E,
-    TS,
-    TI <: Real,
-    DTI <: Real,
-    NTSM <: NamedTuple,
-    NTMS <: NamedTuple,
-    NTM <: NamedTuple,
-}
-    comms_ctx::X
-    dates::D
-    boundary_space::B
-    fields::FV
-    parsed_args::P
-    conservation_checks::E
-    tspan::TS
-    t::TI
-    Δt_cpl::DTI
-    surface_fractions::NTSM
-    model_sims::NTMS
-    mode::NTM
-    diagnostics::Tuple
-end
-
-CoupledSimulation{FT}(args...) where {FT} = CoupledSimulation{FT, typeof.(args[1:12])...}(args...)
-
-"""
-    float_type(::CoupledSimulation)
-
-Return the floating point type backing `T`: `T` can either be an object or a type.
-"""
-float_type(::CoupledSimulation{FT}) where {FT} = FT
+export swap_space!
 
 """
     swap_space!(field_out::Fields.Field, field_in::Fields.Field)

--- a/test/bcreader_tests.jl
+++ b/test/bcreader_tests.jl
@@ -2,7 +2,7 @@
     Unit tests for ClimaCoupler BCReader module
 =#
 
-using ClimaCoupler: Regridder, BCReader, TimeManager, Utilities
+using ClimaCoupler: Regridder, BCReader, TimeManager, Interfacer
 using ClimaCore: Fields, Meshes, Domains, Topologies, Spaces
 using ClimaComms
 using Test
@@ -180,7 +180,7 @@ for FT in (Float32, Float64)
             SST_all = []
             updating_dates = []
 
-            cs_t = Utilities.CoupledSimulation{FT}(
+            cs_t = Interfacer.CoupledSimulation{FT}(
                 comms_ctx, # comms_ctx
                 dates, # dates
                 nothing, # boundary_space

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -2,7 +2,7 @@
     Unit tests for ClimaCoupler ConservationChecker, with parsed objects mimicking those in the full coupled system
 =#
 
-using ClimaCoupler: Utilities, Regridder, TestHelper, Interfacer
+using ClimaCoupler: Regridder, TestHelper, Interfacer
 using ClimaCoupler.ConservationChecker:
     EnergyConservationCheck, WaterConservationCheck, check_conservation!, plot_global_conservation
 using ClimaCore: ClimaCore, Geometry, Meshes, Domains, Topologies, Spaces, Fields, InputOutput
@@ -72,7 +72,7 @@ get_field(s::TestLand, ::Val{:area_fraction}) = ones(s.i.space) .* 0.25
     @. cf.P_liq = -100
 
     # init
-    cs = Utilities.CoupledSimulation{FT}(
+    cs = Interfacer.CoupledSimulation{FT}(
         nothing, # comms_ctx
         nothing, # dates
         space, # boundary_space
@@ -149,7 +149,7 @@ end
     @. cf.P_liq = -100
 
     # init
-    cs = Utilities.CoupledSimulation{FT}(
+    cs = Interfacer.CoupledSimulation{FT}(
         nothing, # comms_ctx
         nothing, # dates
         space, # boundary_space

--- a/test/debug/debug_amip_plots.jl
+++ b/test/debug/debug_amip_plots.jl
@@ -4,8 +4,14 @@ using Test
 using ClimaCore
 using ClimaCoupler: TestHelper
 import ClimaCoupler.Interfacer:
-    update_field!, AtmosModelSimulation, SurfaceModelSimulation, SurfaceStub, get_field, update_field!, name
-using ClimaCoupler.Utilities: CoupledSimulation, CoupledSimulation
+    CoupledSimulation,
+    update_field!,
+    AtmosModelSimulation,
+    SurfaceModelSimulation,
+    SurfaceStub,
+    get_field,
+    update_field!,
+    name
 
 FT = Float64
 

--- a/test/diagnostics_tests.jl
+++ b/test/diagnostics_tests.jl
@@ -5,7 +5,7 @@ using Test
 using Dates
 using ClimaCore: InputOutput
 using ClimaComms
-using ClimaCoupler: Utilities
+using ClimaCoupler: Interfacer
 using ClimaCoupler.TimeManager: EveryTimestep, Monthly
 using ClimaCoupler.TestHelper: create_space
 import ClimaCoupler.Diagnostics:
@@ -21,7 +21,7 @@ import ClimaCoupler.Diagnostics:
 
 
 FT = Float64
-get_var(cs::Utilities.CoupledSimulation, ::Val{:x}) = FT(1)
+get_var(cs::Interfacer.CoupledSimulation, ::Val{:x}) = FT(1)
 
 @testset "init_diagnostics" begin
     names = (:x, :y)
@@ -38,7 +38,7 @@ end
         space = create_space(FT)
         dg_2d = init_diagnostics(names, space, save = EveryTimestep(), operations = (; accumulate = case))
         dg_2d.field_vector .= FT(2)
-        cs = Utilities.CoupledSimulation{FT}(
+        cs = Interfacer.CoupledSimulation{FT}(
             nothing, # comms_ctx
             nothing, # dates
             nothing, # boundary_space
@@ -72,7 +72,7 @@ if !Sys.iswindows() # Windows has NetCDF / HDF5 support limitations
             operations = (; accumulate = TimeMean([Int(0)])),
             output_dir = test_dir,
         ) # or use accumulate = nothing for snapshop save
-        cs = Utilities.CoupledSimulation{FT}(
+        cs = Interfacer.CoupledSimulation{FT}(
             ClimaComms.SingletonCommsContext(), # comms_ctx
             (date = [DateTime(0, 2)], date1 = [DateTime(0, 1)]), # dates
             nothing, # boundary_space
@@ -110,7 +110,7 @@ end
         space = create_space(FT)
         dg_2d = init_diagnostics(names, space, save = EveryTimestep(), operations = (; accumulate = case))
         dg_2d.field_vector .= FT(3)
-        cs = Utilities.CoupledSimulation{FT}(
+        cs = Interfacer.CoupledSimulation{FT}(
             nothing, # comms_ctx
             nothing, # dates
             nothing, # boundary_space

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -1,10 +1,12 @@
 using ClimaCore: Meshes, Domains, Topologies, Spaces, Fields, InputOutput
-using ClimaCoupler: Utilities, Regridder, TestHelper
+using ClimaCoupler: Regridder, TestHelper
 using Test
 import Thermodynamics as TD
 import CLIMAParameters as CP
 import Thermodynamics.Parameters as TDP
 import ClimaCoupler.Interfacer:
+    CoupledSimulation,
+    float_type,
     get_field,
     name,
     SurfaceModelSimulation,
@@ -25,61 +27,85 @@ get_field(::SurfaceModelSimulation, ::Val{:var}) = ones(boundary_space)
 get_field(::SurfaceModelSimulation, ::Val{:var_float}) = FT(2)
 get_field(::SurfaceModelSimulation, ::Val{:surface_temperature}) = ones(boundary_space) .* FT(300)
 
-@testset "get_field indexing" begin
-    for sim in (DummySimulation(), DummySimulation2(), DummySimulation3())
-        # field
-        colidx = Fields.ColumnIndex{2}((1, 1), 73)
-        @test parent(get_field(sim, Val(:var), colidx))[1] == FT(1)
-        # float
-        @test get_field(sim, Val(:var_float), colidx) == FT(2)
+for FT in (Float32, Float64)
+    @testset "test CoupledSim construction, float_type for FT=$FT" begin
+        cs = CoupledSimulation{FT}(
+            nothing, # comms_ctx
+            nothing, # dates
+            nothing, # boundary_space
+            nothing, # fields
+            nothing, # parsed_args
+            nothing, # conservation_checks
+            (Int(0), Int(1000)), # tspan
+            Int(200), # t
+            Int(200), # Δt_cpl
+            (;), # surface_masks
+            (;), # model_sims
+            (;), # mode
+            (), # diagnostics
+        )
+
+        @test float_type(cs) == FT
     end
-end
 
-@testset "undefined get_field" begin
-    sim = DummySimulation()
-    val = Val(:v)
-    @test_throws ErrorException("undefined field $val for " * name(sim)) get_field(sim, val)
-end
+    @testset "get_field indexing" begin
+        for sim in (DummySimulation(), DummySimulation2(), DummySimulation3())
+            # field
+            colidx = Fields.ColumnIndex{2}((1, 1), 73)
+            @test parent(get_field(sim, Val(:var), colidx))[1] == FT(1)
+            # float
+            @test get_field(sim, Val(:var_float), colidx) == FT(2)
+        end
+    end
 
-# test for a simple generic surface model
-@testset "get_field for a SurfaceStub" begin
+    @testset "undefined get_field" begin
+        sim = DummySimulation()
+        val = Val(:v)
+        @test_throws ErrorException("undefined field $val for " * name(sim)) get_field(sim, val)
+    end
 
-    toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
-    aliases = string.(fieldnames(TDP.ThermodynamicsParameters))
-    param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
-    thermo_params = TDP.ThermodynamicsParameters{FT}(; param_pairs...)
+    # test for a simple generic surface model
+    @testset "get_field for a SurfaceStub" begin
 
-    stub = SurfaceStub((;
-        area_fraction = FT(1),
-        T_sfc = FT(280),
-        α = 3,
-        z0m = 4,
-        z0b = 5,
-        beta = 6,
-        ρ_sfc = FT(1),
-        phase = TD.Liquid(),
-        thermo_params = thermo_params,
-    ))
-    @test get_field(stub, Val(:area_fraction)) == FT(1)
-    @test get_field(stub, Val(:surface_temperature)) == FT(280)
-    @test get_field(stub, Val(:albedo)) == 3
-    @test get_field(stub, Val(:roughness_momentum)) == 4
-    @test get_field(stub, Val(:roughness_buoyancy)) == 5
-    @test get_field(stub, Val(:beta)) == 6
-    @test ≈(get_field(stub, Val(:surface_humidity))[1], FT(0.0076), atol = FT(1e-4))
-end
+        toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
+        aliases = string.(fieldnames(TDP.ThermodynamicsParameters))
+        param_pairs = CP.get_parameter_values!(toml_dict, aliases, "Thermodynamics")
+        thermo_params = TDP.ThermodynamicsParameters{FT}(; param_pairs...)
 
-@testset "name(::SurfaceStub)" begin
-    stub = SurfaceStub((;))
-    @test name(stub) == "SurfaceStub"
-end
+        stub = SurfaceStub((;
+            area_fraction = FT(1),
+            T_sfc = FT(280),
+            α = 3,
+            z0m = 4,
+            z0b = 5,
+            beta = 6,
+            ρ_sfc = FT(1),
+            phase = TD.Liquid(),
+            thermo_params = thermo_params,
+        ))
+        @test get_field(stub, Val(:area_fraction)) == FT(1)
+        @test get_field(stub, Val(:surface_temperature)) == FT(280)
+        @test get_field(stub, Val(:albedo)) == 3
+        @test get_field(stub, Val(:roughness_momentum)) == 4
+        @test get_field(stub, Val(:roughness_buoyancy)) == 5
+        @test get_field(stub, Val(:beta)) == 6
+        @test ≈(get_field(stub, Val(:surface_humidity))[1], FT(0.0076), atol = FT(1e-4))
+    end
 
-@testset "update_field! the SurfaceStub area_fraction" begin
-    stub = SurfaceStub((; area_fraction = zeros(boundary_space), T_sfc = zeros(boundary_space)))
+    @testset "name(::SurfaceStub)" begin
+        stub = SurfaceStub((;))
+        @test name(stub) == "SurfaceStub"
+    end
 
-    update_field!(stub, Val(:area_fraction), ones(boundary_space))
-    update_field!(stub, Val(:surface_temperature), ones(boundary_space) .* 2)
+    @testset "update_field! the SurfaceStub area_fraction" begin
+        boundary_space = TestHelper.create_space(FT)
 
-    @test parent(get_field(stub, Val(:area_fraction)))[1] == FT(1)
-    @test parent(get_field(stub, Val(:surface_temperature)))[1] == FT(2)
+        stub = SurfaceStub((; area_fraction = zeros(boundary_space), T_sfc = zeros(boundary_space)))
+
+        update_field!(stub, Val(:area_fraction), ones(boundary_space))
+        update_field!(stub, Val(:surface_temperature), ones(boundary_space) .* 2)
+
+        @test parent(get_field(stub, Val(:area_fraction)))[1] == FT(1)
+        @test parent(get_field(stub, Val(:surface_temperature)))[1] == FT(2)
+    end
 end

--- a/test/mpi_tests/bcreader_mpi_tests.jl
+++ b/test/mpi_tests/bcreader_mpi_tests.jl
@@ -5,7 +5,7 @@ These are in a separate testing file from the other BCReader unit tests so
 that MPI can be enabled for testing of these functions.
 =#
 
-using ClimaCoupler: Regridder, BCReader, TimeManager, Utilities
+using ClimaCoupler: Regridder, BCReader, TimeManager, Interfacer
 using ClimaCore: Fields, Meshes, Domains, Topologies, Spaces
 using ClimaComms
 using Test
@@ -126,7 +126,7 @@ end
         SST_all = []
         updating_dates = []
 
-        cs_t = Utilities.CoupledSimulation{FT}(
+        cs_t = Interfacer.CoupledSimulation{FT}(
             comms_ctx, # comms_ctx
             dates, # dates
             nothing, # boundary_space

--- a/test/regridder_tests.jl
+++ b/test/regridder_tests.jl
@@ -8,7 +8,7 @@ using Test
 using NCDatasets
 using Dates
 
-using ClimaCoupler: Utilities, Regridder, TestHelper
+using ClimaCoupler: Interfacer, Regridder, TestHelper
 import ClimaCoupler.Interfacer: get_field, name, SurfaceModelSimulation, SurfaceStub, update_field!
 
 REGRID_DIR = @isdefined(REGRID_DIR) ? REGRID_DIR : joinpath("", "regrid_tmp/")
@@ -67,7 +67,7 @@ for FT in (Float32, Float64)
         ocean_d = Fields.zeros(test_space)
 
         # Fill in only the necessary parts of the simulation
-        cs = Utilities.CoupledSimulation{FT}(
+        cs = Interfacer.CoupledSimulation{FT}(
             nothing, # comms_ctx
             nothing, # dates
             nothing, # boundary_space

--- a/test/time_manager_tests.jl
+++ b/test/time_manager_tests.jl
@@ -1,10 +1,10 @@
-#= 
+#=
     Unit tests for ClimaCoupler TimeManager module
 =#
 
 using Test
 using Dates
-using ClimaCoupler: Utilities, TimeManager
+using ClimaCoupler: Interfacer, TimeManager
 using ClimaComms
 
 for FT in (Float32, Float64)
@@ -15,7 +15,7 @@ for FT in (Float32, Float64)
         Δt_cpl = 1 * 24 * 3600
 
         # Fill in only the necessary parts of the simulation
-        cs = Utilities.CoupledSimulation{FT}(
+        cs = Interfacer.CoupledSimulation{FT}(
             ClimaComms.SingletonCommsContext(), # comms_ctx
             dates, # dates
             nothing, # boundary_space
@@ -51,7 +51,7 @@ end
     date0 = date = DateTime("19790321", dateformat"yyyymmdd")
     dates = (; date = [date], date0 = [date0], date1 = [Dates.firstdayofmonth(date0)])
 
-    cs = Utilities.CoupledSimulation{Float64}(
+    cs = Interfacer.CoupledSimulation{Float64}(
         nothing, # comms_ctx
         dates, # dates
         nothing, # boundary_space

--- a/test/utilities_tests.jl
+++ b/test/utilities_tests.jl
@@ -7,26 +7,6 @@ using ClimaCoupler: Utilities, TestHelper
 using ClimaCore: Fields
 
 for FT in (Float32, Float64)
-    @testset "test float_type for FT=$FT" begin
-        cs = Utilities.CoupledSimulation{FT}(
-            nothing, # comms_ctx
-            nothing, # dates
-            nothing, # boundary_space
-            nothing, # fields
-            nothing, # parsed_args
-            nothing, # conservation_checks
-            (Int(0), Int(1000)), # tspan
-            Int(200), # t
-            Int(200), # Δt_cpl
-            (;), # surface_masks
-            (;), # model_sims
-            (;), # mode
-            (), # diagnostics
-        )
-
-        @test Utilities.float_type(cs) == FT
-    end
-
     @testset "test swap_space!" begin
         space1 = TestHelper.create_space(FT, R = FT(6371e3))
         space2 = TestHelper.create_space(FT, R = FT(6371e3))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #333


### Components:
- [x] move the code
- [x] revamp unit tests

### QA
- [x] ensure there is no behavioral change in Buildkites (AMIP paperplots (namely the 32 day run), conservation check for slabplanet, performance in build_history)


### Questions:
- `src/CoupledSimulations/coupled_simulation.jl` [CoupledSimulation](https://github.com/CliMA/ClimaCoupler.jl/blob/main/src/CoupledSimulations/coupled_simulation.jl#L27) vs Interfacer.[CoupledSimulation](https://github.com/CliMA/ClimaCoupler.jl/pull/455/files#diff-2d14afcf445ddbcfbab2975b494c7561f70fb6ec9ef569732d48aae65f6c61ffR35) - why is this type defined in two places?
- `timestepping.md` refers to ClimaCoupler.[CoupledSimulation](https://github.com/CliMA/ClimaCoupler.jl/blob/main/docs/src/timestepping.md) - which of the two types is this?
- should we keep [AbstractSimulation](https://github.com/CliMA/ClimaCoupler.jl/pull/455/files#diff-2d14afcf445ddbcfbab2975b494c7561f70fb6ec9ef569732d48aae65f6c61ffR29) defined in Interfacer? This is also defined in `src/CoupledSimulations/coupled_simulation.jl` as well


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
