### PR TITLE
fix MPI test failures

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,11 +86,10 @@ steps:
     steps:
       - label: "MPI Regridder unit tests"
         key: "regridder_mpi_tests"
-        command: "mpirun julia --color=yes --project=test/ test/mpi_tests/regridder_mpi_tests.jl --config_file $MPI_CONFIG_PATH/regridder_mpi.yml"
+        command: "srun julia --color=yes --project=test/ test/mpi_tests/regridder_mpi_tests.jl --config_file $MPI_CONFIG_PATH/regridder_mpi.yml"
         timeout_in_minutes: 20
         env:
           CLIMACORE_DISTRIBUTED: "MPI"
-          # CLIMACOMMS_CONTEXT: "MPI"
           NPROCS: 2
         agents:
           slurm_ntasks: 2


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
BCReader and Regridder tests are failing sometimes (but not every time) with an error `LoadError: Unable to find compatible target in system image`. For example, [here](https://buildkite.com/clima/climacoupler-ci/builds/2285#018ccc20-7bb0-4062-868c-6efcade86a49). 

closes #552 

### Failure examples
- [seabreeze branch](https://buildkite.com/clima/climacoupler-ci/builds/2283#018ccbba-11d4-4bf3-9789-3c12acfa0b2d)
  - Host name	hpc-92-37.cm.cluster
Operating System	CentOS 7.9.2009
Agent Version	3.59.0
- [seabreeze branch 2](https://buildkite.com/clima/climacoupler-ci/builds/2285#018ccc20-7bb0-4062-868c-6efcade86a49)
  - Host name	hpc-92-37.cm.cluster
Operating System	CentOS 7.9.2009
Agent Version	3.59.0
- [bucket debug branch](https://buildkite.com/clima/climacoupler-ci/builds/2289#018ccc96-914c-42b2-80b7-1bdaf6ebcaac)
  - Host name	hpc-92-37.cm.cluster
Operating System	CentOS 7.9.2009
Agent Version	3.59.0
- [atm-ocn-lnd branch](https://buildkite.com/clima/climacoupler-ci/builds/2286#018ccc30-108f-4651-860c-e12f4126015c)
  - Host name	hpc-92-37.cm.cluster
Operating System	CentOS 7.9.2009
Agent Version	3.59.0
- [docs branch](https://buildkite.com/clima/climacoupler-ci/builds/2275#018c8deb-d667-4ae4-ae50-0ad321282501)
  - Host name	hpc-24-12.cm.cluster
Operating System	CentOS 7.9.2009
Agent Version	3.59.0

### Passing examples
- [seabreeze branch](https://buildkite.com/clima/climacoupler-ci/builds/2288#018ccc93-d6a3-4a9a-85ec-78edd4fb64ce)
  - Host name	hpc-92-37.cm.cluster
Operating System	CentOS 7.9.2009
Agent Version	3.59.0
- [seabreeze branch 2](https://buildkite.com/clima/climacoupler-ci/builds/2294#018ccd4e-989d-4afb-8b58-4a5e431278ac)
  - Host name	hpc-92-37.cm.cluster
Operating System	CentOS 7.9.2009
Agent Version	3.59.0