### PR TITLE
truncate stacktraces for non-interactive runs

### DIFF
--- a/experiments/AMIP/coupler_driver.jl
+++ b/experiments/AMIP/coupler_driver.jl
@@ -1,3 +1,10 @@
+# When Julia 1.10+ is used interactively, stacktraces contain reduced type information to make them shorter.
+# On the other hand, the full type information is printed when julia is not run interactively.
+# Given that ClimaCore objects are heavily parametrized, non-abbreviated stacktraces are hard to read,
+# so we force abbreviated stacktraces even in non-interactive runs.
+# (See also Base.type_limited_string_from_context())
+redirect_stderr(IOContext(stderr, :stacktrace_types_limited => Ref(false)))
+
 include("mpi/mpi_init.jl") # setup MPI context for distributed runs #hide
 
 # # AMIP Driver


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
When Julia 1.10+ is used interactively, stacktraces contain reduced type information to make them shorter. This PR does the same for non-interactive runs
As was done in ClimaAtmos [#2549](https://github.com/CliMA/ClimaAtmos.jl/pull/2549)
