### PR TITLE
Use refs for long variable names

### DIFF
--- a/experiments/AMIP/components/land/bucket_utils.jl
+++ b/experiments/AMIP/components/land/bucket_utils.jl
@@ -15,8 +15,10 @@ function make_land_domain(
     @assert zlim[1] < zlim[2]
     depth = zlim[2] - zlim[1]
 
-    radius = ClimaCore.Spaces.topology(atmos_boundary_space).mesh.domain.radius
-    nelements_horz = ClimaCore.Spaces.topology(atmos_boundary_space).mesh.ne
+    mesh = ClimaCore.Spaces.topology(atmos_boundary_space).mesh
+
+    radius = mesh.domain.radius
+    nelements_horz = mesh.ne
     npolynomial =
         ClimaCore.Spaces.Quadratures.polynomial_degree(ClimaCore.Spaces.quadrature_style(atmos_boundary_space))
     nelements = (nelements_horz, nelements_vert)
@@ -79,9 +81,10 @@ reinit!(sim::BucketSimulation) = reinit!(sim.integrator)
 # extensions required by FluxCalculator (partitioned fluxes)
 function update_turbulent_fluxes_point!(sim::BucketSimulation, fields::NamedTuple, colidx::Fields.ColumnIndex)
     (; F_turb_energy, F_turb_moisture) = fields
-    sim.integrator.p.bucket.turbulent_fluxes.shf[colidx] .= F_turb_energy
-    sim.integrator.p.bucket.turbulent_fluxes.vapor_flux[colidx] .=
-        F_turb_moisture ./ LP.ρ_cloud_liq(sim.model.parameters.earth_param_set)
+    turbulent_fluxes = sim.integrator.p.bucket.turbulent_fluxes
+    turbulent_fluxes.shf[colidx] .= F_turb_energy
+    earth_params = sim.model.parameters.earth_param_set
+    turbulent_fluxes.vapor_flux[colidx] .= F_turb_moisture ./ LP.ρ_cloud_liq(earth_params)
     return nothing
 end
 

--- a/src/ConservationChecker.jl
+++ b/src/ConservationChecker.jl
@@ -96,14 +96,14 @@ function check_conservation!(
     for sim in model_sims
         sim_name = Symbol(Interfacer.name(sim))
         if sim isa Interfacer.AtmosModelSimulation
+            F_radiative_TOA = coupler_sim.fields.F_radiative_TOA
             # save radiation source
-            parent(coupler_sim.fields.F_radiative_TOA) .= parent(Interfacer.get_field(sim, Val(:F_radiative_TOA)))
+            parent(F_radiative_TOA) .= parent(Interfacer.get_field(sim, Val(:F_radiative_TOA)))
 
             if isempty(ccs.toa_net_source)
-                radiation_sources_accum = sum(coupler_sim.fields.F_radiative_TOA .* FT(coupler_sim.Δt_cpl)) # ∫ J / m^2 dA
+                radiation_sources_accum = sum(F_radiative_TOA .* FT(coupler_sim.Δt_cpl)) # ∫ J / m^2 dA
             else
-                radiation_sources_accum =
-                    sum(coupler_sim.fields.F_radiative_TOA .* FT(coupler_sim.Δt_cpl)) .+ ccs.toa_net_source[end] # ∫ J / m^2 dA
+                radiation_sources_accum = sum(F_radiative_TOA .* FT(coupler_sim.Δt_cpl)) .+ ccs.toa_net_source[end] # ∫ J / m^2 dA
             end
             push!(ccs.toa_net_source, radiation_sources_accum)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Cleans up long variable names found in experiments/AMIP and src

closes [#234](https://github.com/CliMA/ClimaCoupler.jl/issues/234)

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
-Found long variable names in experiments/AMIP and src
-Locally renamed with refs
-Verified that there is no change through bit wise comparison

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
