### PR TITLE
initial Interfacer cleanup

### DIFF
--- a/docs/src/checkpointer.md
+++ b/docs/src/checkpointer.md
@@ -5,7 +5,7 @@ This module contains general functions for logging the model states and restarti
 ## Checkpointer API
 
 ```@docs
-    ClimaCoupler.Checkpointer.get_model_state_vector
+    ClimaCoupler.Checkpointer.get_model_prog_state
     ClimaCoupler.Checkpointer.restart_model_state!
     ClimaCoupler.Checkpointer.checkpoint_model_state
 ```

--- a/docs/src/fieldexchanger.md
+++ b/docs/src/fieldexchanger.md
@@ -9,7 +9,7 @@ The `FieldExchanger` needs to populate the coupler with
 The component models are updated by broadcasting the coupler fields, via the `update_model_sims!` function. For an update, this function requires that `update_field!` is defined for the particular variable and component model. Currently, we support the:
 - `AtmosModelSimulation`: `albedo`, `surface_temperature`
     - if calculating fluxes in the atmospheric model: `roughness_momentum`, `roughness_buoyancy`, `beta`
-- `SurfaceModelSimulation`: `air_density`, `turbulent_energy_flux`, `turbulent_moisture_flux`, `radiative_energy_flux`, `liquid_precipitation`, `snow_precipitation`
+- `SurfaceModelSimulation`: `air_density`, `turbulent_energy_flux`, `turbulent_moisture_flux`, `radiative_energy_flux_sfc`, `liquid_precipitation`, `snow_precipitation`
 
 If an `update_field!` function is not defined for a particular component model, it will be ignored.
 

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -1,55 +1,186 @@
 # Interfacer
+This module contains functions that define the interface for coupling
+component models, as well as stub objects that contain prescribed fields.
+Here we explain each type of component model, and the functions that must
+be implemented to use a component model with ClimaCoupler.jl
 
-This module contains functions for defining the interface for coupling component models, as well as stub objects that contain prescribed fields.
+## Coupled simulation
+A `CoupledSimulation` stores info for ESM run and contains each of the
+component model simulations. We currently require that each `CoupledSimulation`
+contains four components: `atmos_sim`, `land_sim`, `ocean_sim` and `ice_sim`.
+If a simulation surface type is not needed for a given run, it should be
+initialized with `SurfaceStub` with a zero `area_fracion`.
+The `atmos_sim` should always be specified.
 
-## Coupled Simulation
-- `CoupledSimulation` (`cs`) stores info for ESM run. We require that each `cs` contains four (`atmos_sim`, `land_sim`, `ocean_sim` and `ice_sim`) components. While this requirement will not be eventually needed, for the time being, if a simulation surface type is not needed for a given run, it should be initialized with `SurfaceStub` with a zero `area_fracion`. The `atmos_sim` should always be specified.
 
-## Component model simulations
-- all Simulations that are not the `CoupledSimulation` fall under `ComponentModelSimulation`
-- the current version requires that there is:
-    - one `AtmosModelSimulation`
-    - one or more `SurfaceModelSimulation`s, which require the following adapter functions:
-        ```
-        get_field(sim::SurfaceModelSimulation, ::Val{:area_fraction}) = ...
-        get_field(sim::SurfaceModelSimulation, ::Val{:surface_temperature}) = ...
-        get_field(sim::SurfaceModelSimulation, ::Val{:albedo}) = ...
-        get_field(sim::SurfaceModelSimulation, ::Val{:roughness_momentum}) = ...
-        get_field(sim::SurfaceModelSimulation, ::Val{:roughness_buoyancy}) = ...
-        get_field(sim::SurfaceModelSimulation, ::Val{:beta}) = ...
-        update_field!(sim::SurfaceModelSimulation, ::Val{:area_fraction}, field::Fields.Field) = ...
-        update_field!(sim::SurfaceModelSimulation, ::Val{:surface_temperature}, field::Fields.Field) = ...
-        ```
-        - these adapter functions, to be defined in the component models' init files (preferably in their own repositories), allow the coupler to operate without having to assume particular data structures of the underlying component models. This allows easy swapping of model components, as well as a stable source code with coupler-specific unit tests.
+## Component simulations
+Individual component model simulations fall under `ComponentModelSimulation`,
+which together combine to make the `CoupledSimulation`.
+We have two types of `ComponentModelSimulations`: `AtmosModelSimulation` and
+`SurfaceModelSimulation`. The two have different requirements,
+which are detailed below. `SurfaceModelSimulation` is further divided into
+`SeaIceModelSimulation`, `LandModelSimulation`, and `OceanModelSimulation`,
+representing the 3 currently-supported options for surface models.
 
-## Prescribed conditions
-- `SurfaceStub` is a `SurfaceModelSimulation`, but it only contains required data in `<surface_stub>.cache`, e.g., for the calculation of surface fluxes through a prescribed surface state.  The above adapter functions are already predefined for `SurfaceStub`, with the cache variables specified as:
+### ComponentModelSimulation - required functions
+A component model simulation should be implemented as a struct that is a concrete subtype
+of a `ComponentModelSimulation`. This struct should contain all of the
+information needed to run that simulation.
+
+Each `ComponentModelSimulation` must extend the following functions to be able
+to use our coupler. For some existing models, these are defined within
+ClimaCoupler.jl in that model’s `init.jl` file, but it is preferable
+for these to be defined in a model’s own repository. Note that the dispatch
+`::ComponentModelSimulation` in the function definitions given below should
+be replaced with the particular component model extending these functions.
+- `init`: construct and return an instance of the `ComponentModelSimulation`,
+and perform all initialization. This function should return a simulation that
+is ready to be stepped in the coupled simulation. The interface for this
+function varies across component models.
+- `name(::ComponentModelSimulation)`: return a string containing the name of
+this `ComponentModelSimulation`, which is used for printing information about
+component models and writing to checkpoint files.
+- `step!(::ComponentModelSimulation, t)`: A function to update the
+simulation in-place with values calculate for time `t`. For the
+models we currently have implemented, this is a simple wrapper around
+the `step!` function implemented in SciMLBase.jl.
+- `reinit!(::ComponentModelSimulation)`: A function to restart a simulation
+after solving of the simulation has been paused or interrupted. Like
+`step!`, this is currently a simple wrapper around the `reinit!` function
+of SciMLBase.jl.
+- `get_model_prog_state(::ComponentModelSimulation)`: A function that
+returns the state vector of the simulation at its current state. This
+is used for checkpointing the simulation.
+
+### ComponentModelSimulation - optional functions
+- `update_sim!(::ComponentModelSimulation, csf, turbulent_fluxes)`: A
+function to update each of the fields of the component model simulation
+that are updated by the coupler. ClimaCoupler.jl provides defaults of
+this function for both `AtmosModelSimulation` and
+`SurfaceModelSimulation` that update each of the fields expected by
+the coupler. This function can optionally be extended to include
+additional field updates as desired.
+
+### AtmosModelSimulation - required functions
+In addition to the functions required for a general
+`ComponentModelSimulation`, an `AtmosModelSimulation` requires the
+following functions to retrieve and update its fields.
+- `get_field(::AtmosModelSimulation. ::Val{property})`: This getter
+function returns the value of the field property for the simulation
+in its current state. For an `AtmosModelSimulation`, it must be extended
+for the following properties:
+
+| Coupler name      | Description | Units |
+|-------------------|-------------|-------|
+| `air_density`       | air density at the surface of the atmosphere | kg m^-3 |
+| `air_temperature`   | air temperature at the surface of the atmosphere | K |
+| `energy`            | globally integrated energy | J |
+| `height_int`        | height at the first internal model level | m |
+| `height_sfc`        | height at the surface (only required when using `PartitionedStateFluxes`) | m |
+| `liquid_precipitation` | liquid precipitation at the surface | kg m^-2 s^-1 |
+| `radiative_energy_flux_sfc` | net radiative flux at the surface | W m^-2 |
+| `radiative_energy_flux_toa` | net radiative flux at the top of the atmosphere | W m^-2 |
+| `snow_precipitation` | snow precipitation at the surface | kg m^-2 s^-1 |
+| `turbulent_energy_flux` | aerodynamic turbulent surface fluxes of energy (sensible and latent heat) | W m^-2 |
+| `turbulent_moisture_flux` | aerodynamic turbulent surface fluxes of energy (evaporation) | kg m^-2 s^-1 |
+| `thermo_state_int`  | thermodynamic state at the first internal model level | |
+| `uv_int`            | horizontal wind velocity vector at the first internal model level | m s^-1 |
+| `water`             | globally integrated water | kg |
+
+
+
+- `update_field!(::AtmosModelSimulation. ::Val{property}, field)`:
+A function to update the value of property in the component model
+simulation, using the values in `field`. This update should
+be done in place. If this function isn't extended for a property,
+that property will remain constant throughout the simulation
+and a warning will be raised.
+This function is expected to be extended for the
+following properties:
+
+| Coupler name      | Description | Units |
+|-------------------|-------------|-------|
+| `co2`              | global mean co2 | ppm |
+| `surface_albedo`   | bulk surface albedo over the whole surface space | |
+| `surface_temperature` | temperature over the combined surface space | K |
+| `turbulent_fluxes` | turbulent fluxes (note: only required when using `PartitionedStateFluxes` option - see our `FluxCalculator` module docs for more information) | W m^-2 |
+
+
+### SurfaceModelSimulation - required functions
+Analogously to the `AtmosModelSimulation`, a `SurfaceModelSimulation`
+requires additional functions to those required for a general `ComponentModelSimulation`.
+- `get_field(::SurfaceModelSimulation. ::Val{property})`: This getter
+function returns the value of the field property for the simulation at
+the current time. For a `SurfaceModelSimulation`, it must be extended
+for the following properties:
+
+| Coupler name      | Description | Units |
+|-------------------|-------------|-------|
+| `air_density`       | surface air density | kg m^-3 |
+| `area_fraction`     | fraction of the simulation grid surface area this model covers | |
+| `beta`              | factor that scales evaporation based on its estimated level of saturation | |
+| `roughness_buoyancy` | aerodynamic roughness length for buoyancy | m |
+| `roughness_momentum` | aerodynamic roughness length for momentum | m |
+| `surface_albedo`    | bulk surface albedo | |
+| `surface_humidity`  | surface humidity | kg kg^-1 |
+| `surface_temperature` | surface temperature | K |
+
+- `update_field!(::SurfaceModelSimulation. ::Val{property}, field)`:
+A function to update the value of property in the component model
+simulation, using the values in `field` passed from the coupler
+This update should be done in place. If this function
+isn't extended for a property,
+that property will remain constant throughout the simulation
+and a warning will be raised.
+This function is expected to be extended for the
+following properties:
+
+| Coupler name      | Description | Units |
+|-------------------|-------------|-------|
+| `air_density`       | surface air density | kg m^-3 |
+| `area_fraction`     | fraction of the simulation grid surface area this model covers | |
+| `liquid_precipitation` | liquid precipitation at the surface | kg m^-2 s^-1 |
+| `radiative_energy_flux_sfc` | net radiative flux at the surface | W m^-2 |
+| `snow_precipitation` | snow precipitation at the surface | kg m^-2 s^-1 |
+| `turbulent_energy_flux` | aerodynamic turbulent surface fluxes of energy (sensible and latent heat) | W m^-2 |
+| `turbulent_moisture_flux` | aerodynamic turbulent surface fluxes of energy (evaporation) | kg m^-2 s^-1 |
+
+### SurfaceModelSimulation - optional functions
+- `update_turbulent_fluxes_point!(::ComponentModelSimulation, fields::NamedTuple, colidx)`:
+This function updates the turbulent fluxes of the component model simulation
+at this point in horizontal space. The values are updated using the energy
+and moisture turbulent fluxes stored in fields which are calculated by the
+coupler. Note that this function is only required when using the
+`PartitionedStateFluxes` option of ClimaCoupler.jl. See our `FluxCalculator`
+module docs for more information.
+
+### Prescribed surface conditions - SurfaceStub
+- `SurfaceStub` is a `SurfaceModelSimulation`, but it only contains
+required data in `<surface_stub>.cache`, e.g., for the calculation
+of surface fluxes through a prescribed surface state. The above
+adapter functions are already predefined for `SurfaceStub`, with
+the cache variables specified as:
 ```
+get_field(sim::SurfaceStub, ::Val{:air_density}) = sim.cache.ρ_sfc
 get_field(sim::SurfaceStub, ::Val{:area_fraction}) = sim.cache.area_fraction
-get_field(sim::SurfaceStub, ::Val{:surface_temperature}) = sim.cache.T_sfc
-get_field(sim::SurfaceStub, ::Val{:albedo}) = sim.cache.α
-get_field(sim::SurfaceStub, ::Val{:roughness_momentum}) = sim.cache.z0m
-get_field(sim::SurfaceStub, ::Val{:roughness_buoyancy}) = sim.cache.z0b
 get_field(sim::SurfaceStub, ::Val{:beta}) = sim.cache.beta
+get_field(sim::SurfaceStub, ::Val{:energy}) = nothing
+get_field(sim::SurfaceStub, ::Val{:roughness_buoyancy}) = sim.cache.z0b
+get_field(sim::SurfaceStub, ::Val{:roughness_momentum}) = sim.cache.z0m
+get_field(sim::SurfaceStub, ::Val{:surface_albedo}) = sim.cache.α
+get_field(sim::SurfaceStub, ::Val{:surface_humidity}) = TD.q_vap_saturation_generic.(sim.cache.thermo_params, sim.cache.T_sfc, sim.cache.ρ_sfc, sim.cache.phase)
+get_field(sim::SurfaceStub, ::Val{:surface_temperature}) = sim.cache.T_sfc
+get_field(sim::SurfaceStub, ::Val{:water}) = nothing
 ```
-with the corresponding `update_field!` functions
+and with the corresponding `update_field!` functions
 ```
+function update_field!(sim::SurfaceStub, ::Val{:air_density}, field)
+    sim.cache.ρ_sfc .= field
+end
 function update_field!(sim::SurfaceStub, ::Val{:area_fraction}, field::Fields.Field)
     sim.cache.area_fraction .= field
 end
 function update_field!(sim::SurfaceStub, ::Val{:surface_temperature}, field::Fields.Field)
     sim.cache.T_sfc .= field
 end
-```
-
-## Interfacer API
-
-```@docs
-    ClimaCoupler.Interfacer.ComponentModelSimulation
-    ClimaCoupler.Interfacer.AtmosModelSimulation
-    ClimaCoupler.Interfacer.SurfaceModelSimulation
-    ClimaCoupler.Interfacer.SurfaceStub
-    ClimaCoupler.Interfacer.name
-    ClimaCoupler.Interfacer.get_field
-    ClimaCoupler.Interfacer.update_field!
 ```

--- a/experiments/AMIP/components/land/bucket_utils.jl
+++ b/experiments/AMIP/components/land/bucket_utils.jl
@@ -46,7 +46,7 @@ get_field(sim::BucketSimulation, ::Val{:roughness_momentum}) = sim.model.paramet
 get_field(sim::BucketSimulation, ::Val{:roughness_buoyancy}) = sim.model.parameters.z_0b
 get_field(sim::BucketSimulation, ::Val{:beta}) =
     ClimaLand.surface_evaporative_scaling(sim.model, sim.integrator.u, sim.integrator.p)
-get_field(sim::BucketSimulation, ::Val{:albedo}) =
+get_field(sim::BucketSimulation, ::Val{:surface_albedo}) =
     ClimaLand.surface_albedo(sim.model, sim.integrator.u, sim.integrator.p)
 get_field(sim::BucketSimulation, ::Val{:area_fraction}) = sim.area_fraction
 get_field(sim::BucketSimulation, ::Val{:air_density}) = sim.integrator.p.bucket.ρ_sfc
@@ -58,7 +58,7 @@ function update_field!(sim::BucketSimulation, ::Val{:turbulent_moisture_flux}, f
     ρ_liq = (LP.ρ_cloud_liq(sim.model.parameters.earth_param_set))
     parent(sim.integrator.p.bucket.turbulent_fluxes.vapor_flux) .= parent(field ./ ρ_liq) # TODO: account for sublimation
 end
-function update_field!(sim::BucketSimulation, ::Val{:radiative_energy_flux}, field)
+function update_field!(sim::BucketSimulation, ::Val{:radiative_energy_flux_sfc}, field)
     parent(sim.integrator.p.bucket.R_n) .= parent(field)
 end
 function update_field!(sim::BucketSimulation, ::Val{:liquid_precipitation}, field)
@@ -106,11 +106,11 @@ function surface_thermo_state(
 end
 
 """
-    get_model_state_vector(sim::BucketSimulation)
+    get_model_prog_state(sim::BucketSimulation)
 
-Extension of Checkpointer.get_model_state_vector to get the model state.
+Extension of Checkpointer.get_model_prog_state to get the model state.
 """
-function get_model_state_vector(sim::BucketSimulation)
+function get_model_prog_state(sim::BucketSimulation)
     return sim.integrator.u.bucket
 end
 

--- a/experiments/AMIP/components/ocean/prescr_seaice_init.jl
+++ b/experiments/AMIP/components/ocean/prescr_seaice_init.jl
@@ -124,10 +124,10 @@ end
 
 # file-specific
 """
-    clean_sic(SIC, _info)
+    scale_sic(SIC, _info)
 Ensures that the space of the SIC struct matches that of the mask, and converts the units from area % to area fraction.
 """
-clean_sic(SIC, _info) = swap_space!(zeros(axes(_info.land_fraction)), SIC) ./ float_type_bcf(_info)(100.0)
+scale_sic(SIC, _info) = swap_space!(zeros(axes(_info.land_fraction)), SIC) ./ float_type_bcf(_info)(100.0)
 
 # setting that SIC < 0.5 is counted as ocean if binary remapping.
 get_ice_fraction(h_ice::FT, mono::Bool, threshold = 0.5) where {FT} =
@@ -139,7 +139,7 @@ get_field(sim::PrescribedIceSimulation, ::Val{:surface_humidity}) = sim.integrat
 get_field(sim::PrescribedIceSimulation, ::Val{:roughness_momentum}) = sim.integrator.p.params.z0m
 get_field(sim::PrescribedIceSimulation, ::Val{:roughness_buoyancy}) = sim.integrator.p.params.z0b
 get_field(sim::PrescribedIceSimulation, ::Val{:beta}) = convert(eltype(sim.integrator.u), 1.0)
-get_field(sim::PrescribedIceSimulation, ::Val{:albedo}) = sim.integrator.p.params.α
+get_field(sim::PrescribedIceSimulation, ::Val{:surface_albedo}) = sim.integrator.p.params.α
 get_field(sim::PrescribedIceSimulation, ::Val{:area_fraction}) = sim.integrator.p.area_fraction
 get_field(sim::PrescribedIceSimulation, ::Val{:air_density}) = sim.integrator.p.ρ_sfc
 
@@ -150,7 +150,7 @@ end
 function update_field!(sim::PrescribedIceSimulation, ::Val{:turbulent_energy_flux}, field)
     parent(sim.integrator.p.F_turb_energy) .= parent(field)
 end
-function update_field!(sim::PrescribedIceSimulation, ::Val{:radiative_energy_flux}, field)
+function update_field!(sim::PrescribedIceSimulation, ::Val{:radiative_energy_flux_sfc}, field)
     parent(sim.integrator.p.F_radiative) .= parent(field)
 end
 function update_field!(sim::PrescribedIceSimulation, ::Val{:air_density}, field)
@@ -168,11 +168,11 @@ function update_turbulent_fluxes_point!(sim::PrescribedIceSimulation, fields::Na
 end
 
 """
-    get_model_state_vector(sim::PrescribedIceSimulation)
+    get_model_prog_state(sim::PrescribedIceSimulation)
 
-Extension of Checkpointer.get_model_state_vector to get the model state.
+Extension of Checkpointer.get_model_prog_state to get the model state.
 """
-function get_model_state_vector(sim::PrescribedIceSimulation)
+function get_model_prog_state(sim::PrescribedIceSimulation)
     return sim.integrator.u
 end
 

--- a/experiments/AMIP/components/ocean/slab_ocean_init.jl
+++ b/experiments/AMIP/components/ocean/slab_ocean_init.jl
@@ -126,10 +126,10 @@ end
 
 # file specific
 """
-    clean_sst(SST::FT, _info)
+    scale_sst(SST::FT, _info)
 Ensures that the space of the SST struct matches that of the land_fraction, and converts the units to Kelvin (N.B.: this is dataset specific)
 """
-clean_sst(SST, _info) = (swap_space!(zeros(axes(_info.land_fraction)), SST) .+ float_type_bcf(_info)(273.15))
+scale_sst(SST, _info) = (swap_space!(zeros(axes(_info.land_fraction)), SST) .+ float_type_bcf(_info)(273.15))
 
 # extensions required by Interfacer
 get_field(sim::SlabOceanSimulation, ::Val{:surface_temperature}) = sim.integrator.u.T_sfc
@@ -137,7 +137,7 @@ get_field(sim::SlabOceanSimulation, ::Val{:surface_humidity}) = sim.integrator.p
 get_field(sim::SlabOceanSimulation, ::Val{:roughness_momentum}) = sim.integrator.p.params.z0m
 get_field(sim::SlabOceanSimulation, ::Val{:roughness_buoyancy}) = sim.integrator.p.params.z0b
 get_field(sim::SlabOceanSimulation, ::Val{:beta}) = convert(eltype(sim.integrator.u), 1.0)
-get_field(sim::SlabOceanSimulation, ::Val{:albedo}) = sim.integrator.p.params.α
+get_field(sim::SlabOceanSimulation, ::Val{:surface_albedo}) = sim.integrator.p.params.α
 get_field(sim::SlabOceanSimulation, ::Val{:area_fraction}) = sim.integrator.p.area_fraction
 get_field(sim::SlabOceanSimulation, ::Val{:air_density}) = sim.integrator.p.ρ_sfc
 
@@ -148,7 +148,7 @@ end
 function update_field!(sim::SlabOceanSimulation, ::Val{:turbulent_energy_flux}, field)
     parent(sim.integrator.p.F_turb_energy) .= parent(field)
 end
-function update_field!(sim::SlabOceanSimulation, ::Val{:radiative_energy_flux}, field)
+function update_field!(sim::SlabOceanSimulation, ::Val{:radiative_energy_flux_sfc}, field)
     parent(sim.integrator.p.F_radiative) .= parent(field)
 end
 function update_field!(sim::SlabOceanSimulation, ::Val{:air_density}, field)
@@ -167,11 +167,11 @@ function update_turbulent_fluxes_point!(sim::SlabOceanSimulation, fields::NamedT
 end
 
 """
-    get_model_state_vector(sim::SlabOceanSimulation)
+    get_model_prog_state(sim::SlabOceanSimulation)
 
-Extension of Checkpointer.get_model_state_vector to get the model state.
+Extension of Checkpointer.get_model_prog_state to get the model state.
 """
-function get_model_state_vector(sim::SlabOceanSimulation)
+function get_model_prog_state(sim::SlabOceanSimulation)
     return sim.integrator.u
 end
 

--- a/experiments/AMIP/user_io/debug_plots.jl
+++ b/experiments/AMIP/user_io/debug_plots.jl
@@ -27,8 +27,19 @@ If `cs_fields_ref` is provided (e.g., using a copy of cs.fields from the initial
 plot the anomalies of the fields with respect to `cs_fields_ref`.
 """
 function debug(cs_fields::NamedTuple, dir, cs_fields_ref = nothing)
-    field_names =
-        (:albedo, :F_radiative, :F_turb_energy, :F_turb_moisture, :P_liq, :T_S, :ρ_sfc, :q_sfc, :beta, :z0b_S, :z0m_S)
+    field_names = (
+        :surface_albedo,
+        :F_radiative,
+        :F_turb_energy,
+        :F_turb_moisture,
+        :P_liq,
+        :T_S,
+        :ρ_sfc,
+        :q_sfc,
+        :beta,
+        :z0b_S,
+        :z0m_S,
+    )
     all_plots = []
     for field_name in field_names
         field = getproperty(cs_fields, field_name)

--- a/experiments/AMIP/user_io/user_logging.jl
+++ b/experiments/AMIP/user_io/user_logging.jl
@@ -19,7 +19,7 @@ This is a callback function that checkpoints all simulations defined in the curr
 """
 function checkpoint_sims(cs::CoupledSimulation, _)
     for sim in cs.model_sims
-        if get_model_state_vector(sim) !== nothing
+        if get_model_prog_state(sim) !== nothing
             t = Dates.datetime2epochms(cs.dates.date[1])
             t0 = Dates.datetime2epochms(cs.dates.date0[1])
             Checkpointer.checkpoint_model_state(sim, cs.comms_ctx, Int((t - t0) / 1e3), output_dir = cs.dirs.artifacts)

--- a/src/Checkpointer.jl
+++ b/src/Checkpointer.jl
@@ -9,15 +9,15 @@ using ClimaCore: Fields, InputOutput
 using ClimaCoupler: Interfacer
 using Dates
 using ClimaComms
-export get_model_state_vector, checkpoint_model_state, restart_model_state!
+export get_model_prog_state, checkpoint_model_state, restart_model_state!
 
 """
-    get_model_state_vector(sim::Interfacer.ComponentModelSimulation)
+    get_model_prog_state(sim::Interfacer.ComponentModelSimulation)
 
 Returns the model state of a simulation as a `ClimaCore.FieldVector`.
 This is a template function that should be implemented for each component model.
 """
-get_model_state_vector(sim::Interfacer.ComponentModelSimulation) = nothing
+get_model_prog_state(sim::Interfacer.ComponentModelSimulation) = nothing
 
 """
     checkpoint_model_state(sim::Interfacer.ComponentModelSimulation, comms_ctx::ClimaComms.AbstractCommsContext, t::Int; output_dir = "output")
@@ -30,7 +30,7 @@ function checkpoint_model_state(
     t::Int;
     output_dir = "output",
 )
-    Y = get_model_state_vector(sim)
+    Y = get_model_prog_state(sim)
     day = floor(Int, t / (60 * 60 * 24))
     sec = floor(Int, t % (60 * 60 * 24))
     @info "Saving checkpoint " * Interfacer.name(sim) * " model state to HDF5 on day $day second $sec"
@@ -55,7 +55,7 @@ function restart_model_state!(
     t::Int;
     input_dir = "input",
 )
-    Y = get_model_state_vector(sim)
+    Y = get_model_prog_state(sim)
     day = floor(Int, t / (60 * 60 * 24))
     sec = floor(Int, t % (60 * 60 * 24))
     input_file = joinpath(input_dir, "checkpoint", "checkpoint_" * Interfacer.name(sim) * "_$t.hdf5")

--- a/src/ConservationChecker.jl
+++ b/src/ConservationChecker.jl
@@ -96,14 +96,15 @@ function check_conservation!(
     for sim in model_sims
         sim_name = Symbol(Interfacer.name(sim))
         if sim isa Interfacer.AtmosModelSimulation
-            F_radiative_TOA = coupler_sim.fields.F_radiative_TOA
+            radiative_energy_flux_toa = coupler_sim.fields.radiative_energy_flux_toa
             # save radiation source
-            parent(F_radiative_TOA) .= parent(Interfacer.get_field(sim, Val(:F_radiative_TOA)))
+            parent(radiative_energy_flux_toa) .= parent(Interfacer.get_field(sim, Val(:radiative_energy_flux_toa)))
 
             if isempty(ccs.toa_net_source)
-                radiation_sources_accum = sum(F_radiative_TOA .* FT(coupler_sim.Δt_cpl)) # ∫ J / m^2 dA
+                radiation_sources_accum = sum(radiative_energy_flux_toa .* FT(coupler_sim.Δt_cpl)) # ∫ J / m^2 dA
             else
-                radiation_sources_accum = sum(F_radiative_TOA .* FT(coupler_sim.Δt_cpl)) .+ ccs.toa_net_source[end] # ∫ J / m^2 dA
+                radiation_sources_accum =
+                    sum(radiative_energy_flux_toa .* FT(coupler_sim.Δt_cpl)) .+ ccs.toa_net_source[end] # ∫ J / m^2 dA
             end
             push!(ccs.toa_net_source, radiation_sources_accum)
 

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -379,38 +379,12 @@ end
 
 update_turbulent_fluxes_point!(sim::Interfacer.SurfaceStub, fields::NamedTuple, colidx::Fields.ColumnIndex) = nothing
 
+"""
+    differentiate_turbulent_fluxes!(sim::Interfacer.SurfaceModelSimulation, args)
+
+This function provides a placeholder for differentiating fluxes with respect to
+surface temperature in surface energy balance calculations.
+"""
 differentiate_turbulent_fluxes!(::Interfacer.SurfaceModelSimulation, args) = nothing
-
-"""
-    differentiate_turbulent_fluxes(sim::Interfacer.SurfaceModelSimulation, thermo_params, input_args, fluxes, δT_sfc = 0.1)
-
-Differentiates the turbulent fluxes in the surface model simulation `sim` with respect to the surface temperature,
-using δT_sfc as the perturbation.
-"""
-function differentiate_turbulent_fluxes!(
-    sim::Interfacer.SurfaceModelSimulation,
-    thermo_params,
-    input_args,
-    fluxes;
-    δT_sfc = 0.1,
-)
-    (; thermo_state_int, surface_params, surface_scheme, colidx) = input_args
-    thermo_state_sfc_dT = surface_thermo_state(sim, thermo_params, thermo_state_int, colidx, δT_sfc = δT_sfc)
-    input_args = merge(input_args, (; thermo_state_sfc = thermo_state_sfc_dT))
-
-    # set inputs based on whether the surface_scheme is `MoninObukhovScheme` or `BulkScheme`
-    inputs = surface_inputs(surface_scheme, input_args)
-
-    # calculate the surface fluxes
-    _, _, F_shf_δT_sfc, F_lhf_δT_sfc, _ = get_surface_fluxes_point!(inputs, surface_params)
-
-    (; F_shf, F_lhf) = fluxes
-
-    # calculate the derivative
-    ∂F_turb_energy∂T_sfc = @. (F_shf_δT_sfc + F_lhf_δT_sfc - F_shf - F_lhf) / δT_sfc
-
-    Interfacer.update_field!(sim, Val(:∂F_turb_energy∂T_sfc), ∂F_turb_energy∂T_sfc, colidx)
-
-end
 
 end # module

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -101,6 +101,63 @@ abstract type SeaIceModelSimulation <: SurfaceModelSimulation end
 abstract type LandModelSimulation <: SurfaceModelSimulation end
 abstract type OceanModelSimulation <: SurfaceModelSimulation end
 
+"""
+    get_field(sim::AtmosModelSimulation, val::Val)
+
+A getter function that should not allocate. Here we implement a default that
+will raise an error if `get_field` isn't defined for all required fields of
+an atmosphere component model.
+"""
+get_field(
+    sim::AtmosModelSimulation,
+    val::Union{
+        Val{:air_density},
+        Val{:air_temperature},
+        Val{:energy},
+        Val{:height_int},
+        Val{:height_sfc},
+        Val{:liquid_precipitation},
+        Val{:radiative_energy_flux_sfc},
+        Val{:radiative_energy_flux_toa},
+        Val{:snow_precipitation},
+        Val{:turblent_energy_flux},
+        Val{:turbulent_moisture_flux},
+        Val{:thermo_state_int},
+        Val{:uv_int},
+        Val{:water},
+    },
+) = get_field_error(sim, val)
+
+"""
+    get_field(sim::SurfaceModelSimulation, val::Val)
+
+A getter function that should not allocate. Here we implement a default that
+will raise an error if `get_field` isn't defined for all required fields of
+a surface component model.
+"""
+get_field(
+    sim::SurfaceModelSimulation,
+    val::Union{
+        Val{:air_density},
+        Val{:area_fraction},
+        Val{:beta},
+        Val{:roughness_buoyancy},
+        Val{:roughness_momentum},
+        Val{:surface_albedo},
+        Val{:surface_humidity},
+        Val{:surface_temperature},
+    },
+) = get_field_error(sim, val)
+
+"""
+    get_field(sim::ComponentModelSimulation, val::Val)
+
+Generic fallback for `get_field` that raises an error.
+"""
+get_field(sim::ComponentModelSimulation, val::Val) = get_field_error(sim, val)
+
+get_field_error(sim, val::Val{X}) where {X} = error("undefined field `$X` for " * name(sim))
+
 
 """
     SurfaceStub
@@ -112,24 +169,27 @@ struct SurfaceStub{I} <: SurfaceModelSimulation
 end
 
 """
+    stub_init(cache)
+
+Initialization function for SurfaceStub simulation type.
+"""
+stub_init(cache) = SurfaceStub(cache)
+
+"""
     get_field(::SurfaceStub, ::Val)
 
 A getter function, that should not allocate. If undefined, it returns a descriptive error.
 """
+get_field(sim::SurfaceStub, ::Val{:air_density}) = sim.cache.ρ_sfc
 get_field(sim::SurfaceStub, ::Val{:area_fraction}) = sim.cache.area_fraction
-get_field(sim::SurfaceStub, ::Val{:surface_temperature}) = sim.cache.T_sfc
-get_field(sim::SurfaceStub, ::Val{:albedo}) = sim.cache.α
-get_field(sim::SurfaceStub, ::Val{:roughness_momentum}) = sim.cache.z0m
-get_field(sim::SurfaceStub, ::Val{:roughness_buoyancy}) = sim.cache.z0b
 get_field(sim::SurfaceStub, ::Val{:beta}) = sim.cache.beta
+get_field(sim::SurfaceStub, ::Val{:energy}) = nothing
+get_field(sim::SurfaceStub, ::Val{:roughness_buoyancy}) = sim.cache.z0b
+get_field(sim::SurfaceStub, ::Val{:roughness_momentum}) = sim.cache.z0m
+get_field(sim::SurfaceStub, ::Val{:surface_albedo}) = sim.cache.α
 get_field(sim::SurfaceStub, ::Val{:surface_humidity}) =
     TD.q_vap_saturation_generic.(sim.cache.thermo_params, sim.cache.T_sfc, sim.cache.ρ_sfc, sim.cache.phase)
-
-function get_field(sim::ComponentModelSimulation, val::Val)
-    error("undefined field $val for " * name(sim))
-end
-
-get_field(sim::SurfaceStub, ::Val{:energy}) = nothing
+get_field(sim::SurfaceStub, ::Val{:surface_temperature}) = sim.cache.T_sfc
 get_field(sim::SurfaceStub, ::Val{:water}) = nothing
 
 """
@@ -146,21 +206,41 @@ function get_field(sim::ComponentModelSimulation, val::Val, colidx::Fields.Colum
 end
 
 """
-    update_field!(::ComponentModelSimulation, ::Val, _...)
+    update_field!(::AtmosModelSimulation, ::Val, _...)
 
-No update in unspecified in the particular component model simulation.
+Default functions for updating fields at each timestep in an atmosphere
+component model simulation. This should be extended by component models.
+If it isn't extended, the field won't be updated and a warning will be raised.
 """
-update_field!(sim::ComponentModelSimulation, val::Val, _...) = nothing
+update_field!(
+    sim::AtmosModelSimulation,
+    val::Union{Val{:co2}, Val{:surface_albedo}, Val{:surface_temperature}, Val{:turbulent_fluxes}},
+    _,
+) = update_field_warning(sim, val)
 
-# TODO:
-# function update_field!(sim::ComponentModelSimulation, val::Val, _...)
-#     warning = Warning("undefined `update!` for $val in " * name(sim) * ": skipping")
-#     @warn(warning.message, maxlog=10)
-#     return warning
-# end
-# struct Warning
-#     message::String
-# end
+"""
+    update_field!(::SurfaceModelSimulation, ::Val, _...)
+
+Default functions for updating fields at each timestep in an atmosphere
+component model simulation. This should be extended by component models.
+If it isn't extended, the field won't be updated and a warning will be raised.
+"""
+update_field!(
+    sim::SurfaceModelSimulation,
+    val::Union{
+        Val{:air_density},
+        Val{:area_fraction},
+        Val{:liquid_precipitation},
+        Val{:radiative_energy_flux_sfc},
+        Val{:snow_precipitation},
+        Val{:turbulent_energy_flux},
+        Val{:turbulent_moisture_flux},
+    },
+    _,
+) = update_field_warning(sim, val)
+
+update_field_warning(sim, val::Val{X}) where {X} =
+    @warn("`update_field!` is not extended for the `$X` field of " * name(sim) * ": skipping update.", maxlog = 1)
 
 """
     update_field!(sim::SurfaceStub, ::Val{:area_fraction}, field::Fields.Field)

--- a/test/checkpointer_tests.jl
+++ b/test/checkpointer_tests.jl
@@ -3,22 +3,22 @@ using ClimaCoupler: TestHelper
 using ClimaComms
 using Test
 import ClimaCoupler: Interfacer
-import ClimaCoupler.Checkpointer: get_model_state_vector, restart_model_state!, checkpoint_model_state
+import ClimaCoupler.Checkpointer: get_model_prog_state, restart_model_state!, checkpoint_model_state
 
 FT = Float64
 
 struct DummySimulation{S} <: Interfacer.AtmosModelSimulation
     state::S
 end
-get_model_state_vector(sim::DummySimulation) = sim.state
+get_model_prog_state(sim::DummySimulation) = sim.state
 
-@testset "get_model_state_vector" begin
+@testset "get_model_prog_state" begin
     boundary_space = TestHelper.create_space(FT)
     sim = DummySimulation((; T = ones(boundary_space)))
-    @test get_model_state_vector(sim) == sim.state
+    @test get_model_prog_state(sim) == sim.state
 
     sim2 = Interfacer.SurfaceStub([])
-    @test get_model_state_vector(sim2) == nothing
+    @test get_model_prog_state(sim2) == nothing
 end
 
 @testset "checkpoint_model_state, restart_model_state!" begin

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -25,7 +25,7 @@ struct TestAtmos{I} <: Interfacer.AtmosModelSimulation
     i::I
 end
 name(s::TestAtmos) = "TestAtmos"
-get_field(s::TestAtmos, ::Val{:F_radiative_TOA}) = ones(s.i.space) .* 200
+get_field(s::TestAtmos, ::Val{:radiative_energy_flux_toa}) = ones(s.i.space) .* 200
 get_field(s::TestAtmos, ::Val{:water}) = ones(s.i.space) .* 1
 function get_field(s::TestAtmos, ::Val{:energy})
     FT = Domains.float_type(Meshes.domain(s.i.space.grid.topology.mesh))
@@ -74,13 +74,13 @@ for FT in (Float32, Float64)
 
         # coupler fields
         cf = (;
-            F_radiative_TOA = Fields.ones(space),
+            radiative_energy_flux_toa = Fields.ones(space),
             P_net = Fields.zeros(space),
             P_liq = Fields.zeros(space),
             P_snow = Fields.zeros(space),
             F_turb_moisture = Fields.zeros(space),
         )
-        @. cf.F_radiative_TOA = 200
+        @. cf.radiative_energy_flux_toa = 200
         @. cf.P_liq = -100
 
         # init
@@ -103,7 +103,7 @@ for FT in (Float32, Float64)
         )
 
         # set non-zero radiation and precipitation
-        F_r = cf.F_radiative_TOA
+        F_r = cf.radiative_energy_flux_toa
         P = cf.P_liq
         Δt = cs.Δt_cpl
 
@@ -152,13 +152,13 @@ for FT in (Float32, Float64)
 
         # coupler fields
         cf = (;
-            F_radiative_TOA = Fields.ones(space),
+            radiative_energy_flux_toa = Fields.ones(space),
             P_net = Fields.zeros(space),
             P_liq = Fields.zeros(space),
             P_snow = Fields.zeros(space),
             F_turb_moisture = Fields.zeros(space),
         )
-        @. cf.F_radiative_TOA = 200
+        @. cf.radiative_energy_flux_toa = 200
         @. cf.P_liq = -100
 
         # init

--- a/test/debug/debug_amip_plots.jl
+++ b/test/debug/debug_amip_plots.jl
@@ -38,8 +38,19 @@ plot_field_names(sim::SurfaceStub) = (:stub_field,)
 @testset "import_atmos_fields!" begin
 
     boundary_space = TestHelper.create_space(FT)
-    coupler_names =
-        (:albedo, :F_radiative, :F_turb_energy, :F_turb_moisture, :P_liq, :T_S, :ρ_sfc, :q_sfc, :beta, :z0b_S, :z0m_S)
+    coupler_names = (
+        :surface_albedo,
+        :F_radiative,
+        :F_turb_energy,
+        :F_turb_moisture,
+        :P_liq,
+        :T_S,
+        :ρ_sfc,
+        :q_sfc,
+        :beta,
+        :z0b_S,
+        :z0m_S,
+    )
     atmos_names = (:atmos_field,)
     surface_names = (:surface_field,)
     stub_names = (:stub_field,)

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -17,8 +17,7 @@ import ClimaCoupler.FluxCalculator:
     surface_inputs,
     get_surface_fluxes_point!,
     get_scheme_properties,
-    surface_thermo_state,
-    differentiate_turbulent_fluxes!
+    surface_thermo_state
 import ClimaCoupler: Interfacer
 
 import CLIMAParameters as CP
@@ -97,7 +96,7 @@ Interfacer.get_field(sim::TestOcean, ::Val{:beta}) = sim.integrator.p.beta
 Interfacer.get_field(sim::TestOcean, ::Val{:area_fraction}) = sim.integrator.p.area_fraction
 Interfacer.get_field(sim::TestOcean, ::Val{:heat_transfer_coefficient}) = sim.integrator.p.Ch
 Interfacer.get_field(sim::TestOcean, ::Val{:drag_coefficient}) = sim.integrator.p.Cd
-Interfacer.get_field(sim::TestOcean, ::Val{:albedo}) = sim.integrator.p.α
+Interfacer.get_field(sim::TestOcean, ::Val{:surface_albedo}) = sim.integrator.p.α
 
 function surface_thermo_state(
     sim::TestOcean,
@@ -130,9 +129,6 @@ Interfacer.get_field(sim::DummySurfaceSimulation3, ::Val{:heat_transfer_coeffici
 Interfacer.get_field(sim::DummySurfaceSimulation3, ::Val{:drag_coefficient}) = sim.integrator.p.Cd
 Interfacer.get_field(sim::DummySurfaceSimulation3, ::Val{:beta}) = sim.integrator.p.beta
 
-function Interfacer.update_field!(sim::DummySurfaceSimulation3, ::Val{:∂F_turb_energy∂T_sfc}, field, colidx)
-    sim.integrator.p.∂F_turb_energy∂T_sfc[colidx] .= field
-end
 function surface_thermo_state(
     sim::DummySurfaceSimulation3,
     thermo_params::ThermodynamicsParameters,
@@ -224,7 +220,7 @@ for FT in (Float32, Float64)
 
             coupler_cache_names = (
                 :T_S,
-                :albedo,
+                :surface_albedo,
                 :F_R_sfc,
                 :F_R_toa,
                 :P_liq,
@@ -325,64 +321,5 @@ for FT in (Float32, Float64)
         colidx = Fields.ColumnIndex{2}((1, 1), 73) # arbitrary index
         @test surface_thermo_state(surface_sim, thermo_params, thermo_state_int[colidx], colidx).ρ ==
               thermo_state_int[colidx].ρ
-    end
-
-    @testset "differentiate_turbulent_fluxes! for FT=$FT" begin
-        boundary_space = TestHelper.create_space(FT)
-        _ones = Fields.ones(boundary_space)
-        surface_sim = DummySurfaceSimulation3(
-            [],
-            [],
-            [],
-            (;
-                T = _ones .* FT(300),
-                ρ = _ones .* FT(1.2),
-                p = (;
-                    q = _ones .* FT(0.00),
-                    area_fraction = _ones,
-                    Ch = FT(0.001),
-                    Cd = FT(0.001),
-                    beta = _ones,
-                    ∂F_turb_energy∂T_sfc = _ones .* 0,
-                    q_sfc = _ones .* 0,
-                ),
-            ),
-        )
-        atmos_sim =
-            TestAtmos((; FT = FT), [], [], (; T = _ones .* FT(300), ρ = _ones .* FT(1.2), q = _ones .* FT(0.00)))
-        thermo_params = get_thermo_params(atmos_sim)
-        colidx = Fields.ColumnIndex{2}((1, 1), 73) # arbitrary index
-
-        thermo_state_int = Interfacer.get_field(atmos_sim, Val(:thermo_state_int))[colidx]
-        surface_scheme = BulkScheme()
-        surface_params = get_surface_params(atmos_sim)
-        uₕ_int = Geometry.UVVector.(Geometry.Covariant12Vector.(_ones .* FT(1), _ones .* FT(1)))[colidx]
-        z_int = _ones[colidx]
-        z_sfc = (_ones .* FT(0))[colidx]
-        thermo_state_sfc = surface_thermo_state(surface_sim, thermo_params, thermo_state_int[colidx], colidx)
-        scheme_properties = get_scheme_properties(surface_scheme, surface_sim, colidx)
-        input_args = (;
-            thermo_state_sfc,
-            thermo_state_int,
-            uₕ_int,
-            z_int,
-            z_sfc,
-            surface_params,
-            surface_scheme,
-            scheme_properties,
-            colidx,
-        )
-
-        inputs = surface_inputs(surface_scheme, input_args)
-        fluxes = get_surface_fluxes_point!(inputs, surface_params)
-
-        dFdTs = differentiate_turbulent_fluxes!(surface_sim, thermo_params, input_args, fluxes, δT_sfc = 1)
-
-        sf_out = SF.surface_conditions.(surface_params, inputs)
-
-        cp_m = TD.cp_m.(thermo_params, thermo_state_int)
-        dFdTs_analytical = @. thermo_state_sfc.ρ * sf_out.Ch * SF.windspeed.(inputs) * cp_m
-
-        @test all(isapprox(parent(dFdTs), parent(dFdTs_analytical), atol = 0.1))
     end
 end

--- a/test/mpi_tests/checkpointer_mpi_tests.jl
+++ b/test/mpi_tests/checkpointer_mpi_tests.jl
@@ -10,7 +10,7 @@ using ClimaCoupler: TestHelper
 using ClimaComms
 using Test
 import ClimaCoupler: Interfacer
-import ClimaCoupler.Checkpointer: get_model_state_vector, restart_model_state!, checkpoint_model_state
+import ClimaCoupler.Checkpointer: get_model_prog_state, restart_model_state!, checkpoint_model_state
 
 # set up MPI communications context
 const comms_ctx = ClimaComms.context(ClimaComms.CPUSingleThreaded())
@@ -22,7 +22,7 @@ FT = Float64
 struct DummySimulation{S} <: Interfacer.AtmosModelSimulation
     state::S
 end
-get_model_state_vector(sim::DummySimulation) = sim.state
+get_model_prog_state(sim::DummySimulation) = sim.state
 @testset "checkpoint_model_state, restart_model_state!" begin
     boundary_space = TestHelper.create_space(FT, comms_ctx = comms_ctx)
     t = 1


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
First steps of Interfacer cleanup. Some of it (e.g. restructuring) will be done in separate PRs so this one doesn't get too big.

closes #339 

## To-do

## Content
### get_field
- [x] add get_field(surfacestub, :air_density)
- [x] remove get_field(atmossim, :cv_m) and get_field(atmossim, :gas_constant_air)
- [x] get_field, update_field: implement default for each variable we expect, output warning with maxlog = 1 for each
- [x] alphabetize get_field and update_field functions for readability

### surfacestub
- [x] add stub_init function (just wrap SurfaceStub constructor)

### renaming variables
- [x] rename co2_gm -> co2 (explain in docs global mean)
- [x] rename albedo -> surface_albedo (atmos update_field, surfaces get_field)
- [x] rename clean_sst, clean_sic -> scale_sst, scale_sic
- [x] rename `get_model_state_vector` -> `get_model_prog_state`

### restructuring
- [x] differentiate_turbulent_fluxes: dispatch on eisenman sea ice type, move to eisenman file (specific to that model)

### docs
- [x] note that update_field(::atmossim, turbulent_fluxes) required for partitionedfluxes option
- [x] note: update_sim! can be optionally overwritten, but not required
- [x] update_turb_fluxes_point required for surface model if using partitioned sf
- [x] get_model_state_vector required for checkpointing
- [x] note in docs: surface model precip only needs update, get not required
- [x] explain that CO2 from atmos is expected to be global mean
- [x] add units to docs

## QA
- [x] test update_field! warnings
- [x] check docs rendering

## To Do in future PRs
- [ ] component model files: rename each to `<model>.jl`, combine bucket_init and bucket_utils -> bucket.jl; separate required vs model-specific (internal) functions and objects in component model files - see #647 
- [ ] separate surfacestub from Interfacer/FieldExchanger https://github.com/CliMA/ClimaCoupler.jl/issues/669
  - move surfacestub to separate file outside of Interfacer.jl, and include from Interfacer.jl so it's still in that module
  - same for FieldExchanger.jl

## Remaining questions
- to run with partitioned fluxes, does the atmos model need to extend `update_turbulent_fluxes_point`? or just surface models as it is currently?
  - No, `update_turbulent_fluxes_point` is called by surface models only. Once the surfaces are updated and fluxes per each fractional surface calculated, the coupler combines the fluxes so that we have one flux value per atmos grid point, and we update atmos in the same way as for the CombinedStateFluxes. I will work on the flux calculation interface in a few weeks, with the aim of making this function more transparent and performant. :)
- Are fields in component models (e.g. those returned by get_field) expected to be 2d or just individual floats? Does it vary e.g. for surface albedo vs co2 global mean? (might want to clarify in docs)
  - We should be able to handle both, and (for now) co2 stays constant in space and variable in time. 
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
