### PR TITLE
add GPU AMIP runs with albedo from file

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -396,6 +396,24 @@ steps:
           slurm_mem: 20GB
           slurm_gpus: 1
 
+      - label: "GPU AMIP: albedo from static map"
+        key: "gpu_amip_albedo_static_map"
+        command: "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/coupler_driver.jl --config_file $CONFIG_PATH/gpu_amip_albedo_static_map.yml"
+        artifact_paths: "experiments/AMIP/output/amip/gpu_amip_albedo_static_map_artifacts/*"
+        agents:
+          slurm_mem: 20GB
+          slurm_gpus: 1
+
+      - label: "GPU AMIP: albedo from temporal map"
+        key: "gpu_amip_albedo_temporal_map"
+        command: "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/coupler_driver.jl --config_file $CONFIG_PATH/gpu_amip_albedo_temporal_map.yml"
+        artifact_paths: "experiments/AMIP/output/amip/gpu_amip_albedo_temporal_map_artifacts/*"
+        agents:
+          slurm_mem: 20GB
+          slurm_gpus: 1
+
+
+
       - wait
 
   - wait

--- a/config/model_configs/gpu_amip_albedo_static_map.yml
+++ b/config/model_configs/gpu_amip_albedo_static_map.yml
@@ -8,14 +8,14 @@ dt_save_to_sol: "1days"
 dz_bottom: 30
 dz_top: 3000
 h_elem: 4
-job_id: "gpu_amip_albedo_function"
-land_albedo_type: "function"
+job_id: "gpu_amip_albedo_static_map"
+land_albedo_type: "map_static"
 mode_name: "amip"
 moist: "equil"
 precip_model: "0M"
 rad: "gray"
 rayleigh_sponge: true
-run_name: "gpu_amip_albedo_function"
+run_name: "gpu_amip_albedo_static_map"
 t_end: "300secs"
 vert_diff: "true"
 z_elem: 50

--- a/config/model_configs/gpu_amip_albedo_temporal_map.yml
+++ b/config/model_configs/gpu_amip_albedo_temporal_map.yml
@@ -8,14 +8,14 @@ dt_save_to_sol: "1days"
 dz_bottom: 30
 dz_top: 3000
 h_elem: 4
-job_id: "gpu_amip_albedo_function"
-land_albedo_type: "function"
+job_id: "gpu_amip_albedo_temporal_map"
+land_albedo_type: "map_temporal"
 mode_name: "amip"
 moist: "equil"
 precip_model: "0M"
 rad: "gray"
 rayleigh_sponge: true
-run_name: "gpu_amip_albedo_function"
+run_name: "gpu_amip_albedo_temporal_map"
 t_end: "300secs"
 vert_diff: "true"
 z_elem: 50

--- a/config/model_configs/gpu_slabplanet_albedo_temporal_map.yml
+++ b/config/model_configs/gpu_slabplanet_albedo_temporal_map.yml
@@ -4,7 +4,7 @@ dt: "200secs"
 dt_cpl: 200
 dt_save_to_sol: "3600secs"
 energy_check: true
-h_elem: 6
+h_elem: 4
 job_id: "gpu_slabplanet_albedo_temporal_map"
 land_albedo_type: "map_temporal"
 mode_name: "slabplanet"

--- a/config/model_configs/slabplanet_albedo_temporal_map.yml
+++ b/config/model_configs/slabplanet_albedo_temporal_map.yml
@@ -3,7 +3,7 @@ dt: "200secs"
 dt_cpl: 200
 dt_save_to_sol: "3600secs"
 energy_check: true
-h_elem: 6
+h_elem: 4
 job_id: "slabplanet_albedo_temporal_map"
 land_albedo_type: "map_temporal"
 mode_name: "slabplanet"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Builds off of #573 - copies the config file introduced there and adds two new runs based on it, using albedo from static map and temporal map instead of function.

The goal of the runs introduced in this PR is to ensure that the coupled simulation can run in the AMIP setup with both types of file reading. Because of this, the simulation length of these runs is only two timesteps. More complex, physically significant setups will be added to the longruns.

closes #583

## Content
- [x] simple AMIP on GPU with bucket albedo from static map (run for 2 timesteps)
- [x] simple AMIP on GPU with bucket albedo from temporal map (run for 2 timesteps)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
