### PR TITLE
add GPU DYAMOND runs

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -45,6 +45,31 @@ steps:
       JULIA_NUM_PRECOMPILE_TASKS: 8
       JULIA_MAX_NUM_PRECOMPILE_FILES: 50
 
+  # DYAMOND AMIP: 1 day (convection resolving)
+  - label: "GPU AMIP SUPERFINE: dyamond_target"
+    key: "gpu_dyamond_target"
+    command:
+      - "echo $$JULIA_DEPOT_PATH"
+
+      - echo "--- Instantiate AMIP env"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.status()'"
+
+      - echo "--- Download artifacts"
+      - "julia --project=artifacts -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project=artifacts -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project=artifacts -e 'using Pkg; Pkg.status()'"
+      - "julia --project=artifacts artifacts/download_artifacts.jl"
+
+      - "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/coupler_driver.jl --config_file $CONFIG_PATH/gpu_dyamond_target.yml"
+    artifact_paths: "experiments/AMIP/output/amip/gpu_dyamond_target_artifacts/*"
+    agents:
+      queue: clima
+      slurm_mem: 20GB
+      slurm_gpus: 1
+      modules: common
+
   - wait
 
   - group: "Coupler integration and conservation tests"
@@ -260,7 +285,6 @@ steps:
     steps:
 
       # DYAMOND AMIP: 1 day (convection resolving)
-
       - label: "MPI AMIP SUPERFINE: dyamond_target"
         key: "dyamond_target"
         command: "srun julia --color=yes --project=experiments/AMIP/ experiments/AMIP/coupler_driver.jl --config_file $CONFIG_PATH/dyamond_target.yml"

--- a/config/longrun_configs/gpu_dyamond_target.yml
+++ b/config/longrun_configs/gpu_dyamond_target.yml
@@ -1,0 +1,15 @@
+anim: false
+atmos_config_file: "config/longrun_configs/longrun_aquaplanet_dyamond.yml"
+dt_cpl: 50
+dt_save_state_to_disk: "0.5days"
+dt_save_to_sol: "0.5days"
+energy_check: false
+job_id: "gpu_dyamond_target"
+land_albedo_type: "map_temporal"
+mode_name: "amip"
+mono_surface: false
+monthly_checkpoint: false
+run_name: "gpu_dyamond_target"
+start_date: "19790301"
+t_end: "1days"
+turb_flux_partition: "CombinedStateFluxes"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #658

Only adding a longrun, no shortrun.
This run exceeds the memory available on P100s. Caltech's V100s have 16GB and 32 GB options, neither of which is large enough for this job, according to https://www.hpc.caltech.edu/resources. Instead of running on central like the rest of the longruns, this job will run on clima (which has A100s with 80GB of memory). I've opened an issue to address the allocations seen in this run: https://github.com/CliMA/ClimaCoupler.jl/issues/683

view run on buildkite here: https://buildkite.com/clima/climacoupler-longruns/builds/480#_

## Content
- [x] add config file based on `config/longrun_configs/dyamond_target.yml` for longrun
  - set `anim: false` for gpu-compatibility
- [x] add longrun using GPU

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
