### PR TITLE
update GPU AMIP longrun agents

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -241,23 +241,19 @@ steps:
 
       - label: "GPU AMIP FINE: new target amip: topo"
         key: "gpu_amip_target_topo"
-        command: "mpiexec julia --color=yes --project=experiments/AMIP/ experiments/AMIP/coupler_driver.jl --config_file $CONFIG_PATH/gpu_amip_target_topo.yml"
+        command: "srun julia --color=yes --project=experiments/AMIP/ experiments/AMIP/coupler_driver.jl --config_file $CONFIG_PATH/gpu_amip_target_topo.yml"
         artifact_paths: "experiments/AMIP/output/amip/gpu_amip_target_topo_artifacts/*"
         agents:
-          slurm_ntasks_per_node: 16
-          slurm_nodes: 4
-          slurm_mem_per_cpu: 16G
           slurm_gpus: 1
+          slurm_mem: 16GB
 
       - label: "GPU AMIP FINE: new target amip: topo + diagedmf"
         key: "gpu_amip_target_topo_diagedmf"
-        command: "mpiexec julia --color=yes --project=experiments/AMIP/ experiments/AMIP/coupler_driver.jl --config_file $CONFIG_PATH/gpu_amip_target_topo_diagedmf.yml"
+        command: "srun julia --color=yes --project=experiments/AMIP/ experiments/AMIP/coupler_driver.jl --config_file $CONFIG_PATH/gpu_amip_target_topo_diagedmf.yml"
         artifact_paths: "experiments/AMIP/output/amip/gpu_amip_target_topo_diagedmf_artifacts/*"
         agents:
-          slurm_ntasks_per_node: 16
-          slurm_nodes: 4
-          slurm_mem_per_cpu: 16G
           slurm_gpus: 1
+          slurm_mem: 16GB
 
   - group: "Other AMIP targets"
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
fixes buildkite agent specification for GPU AMIP longruns

closes #662

note: running these jobs on clima shows memory usage around 5GB, so I've set the limit to 16GB