### PR TITLE
remove closures in driver

### DIFF
--- a/src/BCReader.jl
+++ b/src/BCReader.jl
@@ -35,6 +35,7 @@ Stores information specific to each boundary condition from a file and each vari
 - segment_idx0::Vector{Int}       # `segment_idx` of the file data that is closest to date0
 - segment_length::Vector{Int}     # length of each month segment (used in the daily interpolation)
 - interpolate_daily::Bool         # switch to trigger daily interpolation
+- mono::Bool                      # flag for monotone remapping of input data
 """
 struct BCFileInfo{FT <: Real, B, X, S, V, D, C, O, M, VI}
     bcfile_dir::B
@@ -49,6 +50,7 @@ struct BCFileInfo{FT <: Real, B, X, S, V, D, C, O, M, VI}
     segment_idx0::VI
     segment_length::VI
     interpolate_daily::Bool
+    mono::Bool
 end
 
 BCFileInfo{FT}(args...) where {FT} = BCFileInfo{FT, typeof.(args[1:9])...}(args...)
@@ -164,6 +166,7 @@ function bcfile_info_init(
         segment_idx0,
         segment_length,
         interpolate_daily,
+        mono,
     )
 end
 

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -49,6 +49,8 @@ struct CoupledSimulation{
     TD <: Tuple,
     NTC <: NamedTuple,
     NTP <: NamedTuple,
+    TF,
+    TP,
 }
     comms_ctx::X
     dates::D
@@ -65,6 +67,8 @@ struct CoupledSimulation{
     diagnostics::TD
     callbacks::NTC
     dirs::NTP
+    turbulent_fluxes::TF
+    thermo_params::TP
 end
 
 CoupledSimulation{FT}(args...) where {FT} = CoupledSimulation{FT, typeof.(args[1:end])...}(args...)

--- a/test/bcreader_tests.jl
+++ b/test/bcreader_tests.jl
@@ -44,6 +44,7 @@ for FT in (Float32, Float64)
             segment_idx0,                       # segment_idx0
             Int[],                              # segment_length
             false,                              # interpolate_daily
+            false,                              # mono
         )
 
         idx = segment_idx0[1]
@@ -113,6 +114,7 @@ for FT in (Float32, Float64)
             segment_idx0,                       # segment_idx0
             segment_length,                     # segment_length
             interpolate_daily,                  # interpolate_daily
+            false,                              # mono
         )
         @test BCReader.interpolate_midmonth_to_daily(date0, bcf_info_interp) == ones(boundary_space_t) .* FT(0.5)
 
@@ -132,6 +134,7 @@ for FT in (Float32, Float64)
             segment_idx0,                       # segment_idx0
             segment_length,                     # segment_length
             interpolate_daily,                  # interpolate_daily
+            false,                              # mono
         )
         @test BCReader.interpolate_midmonth_to_daily(date0, bcf_info_no_interp) == monthly_fields[1]
     end
@@ -196,6 +199,8 @@ for FT in (Float32, Float64)
                 (), # diagnostics
                 (;), # callbacks
                 (;), # dirs
+                nothing, # turbulent_fluxes
+                nothing, # thermo_params
             )
 
             # step in time

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -100,6 +100,8 @@ for FT in (Float32, Float64)
             (), # diagnostics
             (;), # callbacks
             (;), # dirs
+            nothing, # turbulent_fluxes
+            nothing, # thermo_params
         )
 
         # set non-zero radiation and precipitation
@@ -178,6 +180,8 @@ for FT in (Float32, Float64)
             (), # diagnostics
             (;), # callbacks
             (;), # dirs
+            nothing, # turbulent_fluxes
+            nothing, # thermo_params
         )
 
         tot_energy, tot_water = check_conservation!(cs)

--- a/test/debug/debug_amip_plots.jl
+++ b/test/debug/debug_amip_plots.jl
@@ -83,6 +83,8 @@ plot_field_names(sim::SurfaceStub) = (:stub_field,)
         (), # diagnostics
         (;), # callbacks
         (;), # dirs
+        nothing, # turbulent_fluxes
+        nothing, # thermo_params
     )
 
     output_plots = "test_debug"

--- a/test/diagnostics_tests.jl
+++ b/test/diagnostics_tests.jl
@@ -53,6 +53,8 @@ for FT in (Float32, Float64)
                 (dg_2d,),
                 (;), # callbacks
                 (;), # dirs
+                nothing, # turbulent_fluxes
+                nothing, # thermo_params
             )
             accumulate_diagnostics!(cs)
             @test cs.diagnostics[1].field_vector[1] == expected_results[c_i]
@@ -89,6 +91,8 @@ for FT in (Float32, Float64)
                 (dg_2d,), # diagnostics
                 (;), # callbacks
                 (;), # dirs
+                nothing, # turbulent_fluxes
+                nothing, # thermo_params
             )
             save_diagnostics(cs, cs.diagnostics[1])
             file = filter(x -> endswith(x, ".hdf5"), readdir(test_dir))
@@ -129,6 +133,8 @@ for FT in (Float32, Float64)
                 (dg_2d,),
                 (;), # callbacks
                 (;), # dirs
+                nothing, # turbulent_fluxes
+                nothing, # thermo_params
             )
             accumulate_diagnostics!(cs)
             @test cs.diagnostics[1].field_vector[1] == expected_results[c_i][1]

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -57,6 +57,8 @@ for FT in (Float32, Float64)
             (), # diagnostics
             (;), # callbacks
             (;), # dirs
+            nothing, # turbulent_fluxes
+            nothing, # thermo_params
         )
 
         @test float_type(cs) == FT

--- a/test/mpi_tests/bcreader_mpi_tests.jl
+++ b/test/mpi_tests/bcreader_mpi_tests.jl
@@ -143,6 +143,8 @@ end
             (), # diagnostics
             (;), # callbacks
             (;), # dirs
+            nothing, # turbulent_fluxes
+            nothing, # thermo_params
         )
 
         ClimaComms.barrier(comms_ctx)

--- a/test/regridder_tests.jl
+++ b/test/regridder_tests.jl
@@ -83,6 +83,8 @@ for FT in (Float32, Float64)
             (), # diagnostics
             (;), # callbacks
             (;), # dirs
+            nothing, # turbulent_fluxes
+            nothing, # thermo_params
         )
 
         Regridder.update_surface_fractions!(cs)

--- a/test/time_manager_tests.jl
+++ b/test/time_manager_tests.jl
@@ -31,6 +31,8 @@ for FT in (Float32, Float64)
             (), # diagnostics
             (;), # callbacks
             (;), # dirs
+            nothing, # turbulent_fluxes
+            nothing, # thermo_params
         )
 
         for t in ((tspan[1] + Δt_cpl):Δt_cpl:tspan[end])
@@ -70,6 +72,8 @@ end
         (), # diagnostics
         (;), # callbacks
         (;), # dirs
+        nothing, # turbulent_fluxes
+        nothing, # thermo_params
     )
     @test TimeManager.trigger_callback(cs, TimeManager.Monthly()) == true
 end
@@ -110,6 +114,8 @@ end
             monthly_counter = monthly_counter,
         ), # callbacks
         (;), # dirs
+        nothing, # turbulent_fluxes
+        nothing, # thermo_params
     )
 
     TimeManager.trigger_callback!(cs, cs.callbacks.twhohourly_inactive)
@@ -172,6 +178,8 @@ end
         (), # diagnostics
         (;), # callbacks
         (;), # dirs
+        nothing, # turbulent_fluxes
+        nothing, # thermo_params
     )
 
     TimeManager.update_firstdayofmonth!(cs, nothing)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Remove closures over global variables in `coupler_driver.jl` to improve performance.

This includes changes for:
- comms_ctx
- mono_surface
- turbulent_fluxes
- thermo_params