### PR TITLE
remove wait from longruns

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -62,6 +62,7 @@ steps:
       - "julia --project=artifacts -e 'using Pkg; Pkg.status()'"
       - "julia --project=artifacts artifacts/download_artifacts.jl"
 
+      - echo "--- Run simulation"
       - "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/coupler_driver.jl --config_file $CONFIG_PATH/gpu_dyamond_target.yml"
     artifact_paths: "experiments/AMIP/output/amip/gpu_dyamond_target_artifacts/*"
     agents:
@@ -69,8 +70,6 @@ steps:
       slurm_mem: 20GB
       slurm_gpus: 1
       modules: common
-
-  - wait
 
   - group: "Coupler integration and conservation tests"
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This is a very small PR that makes 2 changes:
1. Remove the `wait` command that's currently after the GPU DYAMOND longrun that runs on clima. In our [most recent scheduled build](https://buildkite.com/clima/climacoupler-longruns/builds/487#018e4e01-2179-4754-8f6c-76e30057d3bc), this job failed and the wait caused everything else to not run.
2. Add a print before this same job, so the running of the simulation appears in its own tab on buildkite, instead of within of the `Download artifacts` part of the job
