### PR TITLE
Truncate data to regrid only necessary dates

### DIFF
--- a/artifacts/artifact_funcs.jl
+++ b/artifacts/artifact_funcs.jl
@@ -59,3 +59,25 @@ function pr_obs_data_path()
     )
     return AW.get_data_folder(pr_obs_data)
 end
+
+"""
+    artifact_data(datapath_full, name)
+
+Returns input dataset at datapath_full
+"""
+function artifact_data(datapath_full, name)
+    datafile_truncated = joinpath(datapath_full, string(name, ".nc"))
+    return datafile_truncated
+end
+
+"""
+    artifact_data(datapath_full, name, datapath_trunc, date0, time_start, time_end, comms_ctx)
+
+Truncates given data set, and constructs a new dataset containing only the dates needed and stores it in datapath_trunc
+"""
+function artifact_data(datapath_full, name, datapath_trunc, date0, time_start, time_end, comms_ctx)
+    datafile = joinpath(datapath_full, string(name, ".nc"))
+    datafile_truncated =
+        Regridder.truncate_dataset(datafile, name, datapath_trunc, date0, time_start, time_end, comms_ctx)
+    return datafile_truncated
+end

--- a/experiments/AMIP/coupler_driver.jl
+++ b/experiments/AMIP/coupler_driver.jl
@@ -168,10 +168,10 @@ original sources.
 =#
 
 include(joinpath(pkgdir(ClimaCoupler), "artifacts", "artifact_funcs.jl"))
-sst_data = joinpath(sst_dataset_path(), "sst.nc")
-sic_data = joinpath(sic_dataset_path(), "sic.nc")
-co2_data = joinpath(co2_dataset_path(), "mauna_loa_co2.nc")
-land_mask_data = joinpath(mask_dataset_path(), "seamask.nc")
+sst_data = artifact_data(sst_dataset_path(), "sst", REGRID_DIR, date0, t_start, t_end, comms_ctx)
+sic_data = artifact_data(sic_dataset_path(), "sic", REGRID_DIR, date0, t_start, t_end, comms_ctx)
+co2_data = artifact_data(co2_dataset_path(), "mauna_loa_co2", REGRID_DIR, date0, t_start, t_end, comms_ctx)
+land_mask_data = artifact_data(mask_dataset_path(), "seamask")
 
 #=
 ## Component Model Initialization

--- a/test/regridder_tests.jl
+++ b/test/regridder_tests.jl
@@ -6,6 +6,7 @@ import Dates
 import NCDatasets
 import ClimaComms
 import ClimaCore as CC
+import ClimaCoupler
 import ClimaCoupler: Interfacer, Regridder, TestHelper, TimeManager
 
 REGRID_DIR = @isdefined(REGRID_DIR) ? REGRID_DIR : joinpath("", "regrid_tmp/")
@@ -310,4 +311,75 @@ for FT in (Float32, Float64)
             rm(REGRID_DIR; recursive = true, force = true)
         end
     end
+end
+# test dataset truncation 
+@testset "test dataset truncation" begin
+    # Get the original dataset set up 
+    include(joinpath(pkgdir(ClimaCoupler), "artifacts", "artifact_funcs.jl"))
+    sst_data_all = joinpath(sst_dataset_path(), "sst.nc")
+    ds = NCDatasets.NCDataset(sst_data_all, "r")
+    dates = ds["time"][:]
+    first_date = dates[1]
+    last_date = last(dates)
+
+    # set up comms_ctx 
+    device = ClimaComms.device()
+    comms_ctx = ClimaComms.context(device)
+    ClimaComms.init(comms_ctx)
+
+    # make path for truncated datasets 
+    COUPLER_OUTPUT_DIR = joinpath("experiments", "AMIP", "output", "tests")
+    mkpath(COUPLER_OUTPUT_DIR)
+
+    REGRID_DIR = joinpath(COUPLER_OUTPUT_DIR, "regrid_tmp", "")
+    mkpath(REGRID_DIR)
+
+    # values for the truncations 
+    time_start = 0.0
+    time_end = 1.728e6
+    date0test = ["18690101", "18700101", "19790228", "20220301", "20230101"]
+    for date in date0test
+        date0 = Dates.DateTime(date, Dates.dateformat"yyyymmdd")
+        sst_data = Regridder.truncate_dataset(sst_data_all, "test", REGRID_DIR, date0, time_start, time_end, comms_ctx)
+        ds_truncated = NCDatasets.NCDataset(sst_data, "r")
+        new_dates = ds_truncated["time"][:]
+
+        date_start = date0 + Dates.Second(time_start)
+        date_end = date0 + Dates.Second(time_start + time_end)
+
+        # start date is before the first date of datafile
+        if date_start < first_date
+            @test new_dates[1] == first_date
+            # start date is after the last date in datafile
+        elseif date_start > last_date
+            @test new_dates[1] == last_date
+            # start date is within the bounds of the datafile
+        else
+            @test new_dates[1] <= date_start
+            @test new_dates[2] >= date_start
+        end
+
+        # end date is before the first date of datafile 
+        if date_end < first_date
+            @test last(new_dates) == first_date
+            # end date is after the last date of datafile 
+        elseif date_end > last_date
+            @test last(new_dates) == last_date
+            # end date is within the bounds of datafile
+        else
+            @test last(new_dates) >= date_end
+            @test new_dates[length(new_dates) - 1] <= date_end
+        end
+
+        # check that truncation is indexing correctly 
+        all_data = ds["SST"][:, :, :]
+        new_data = ds_truncated["SST"][:, :, :]
+        (start_id, end_id) = Regridder.find_idx_bounding_dates(dates, date_start, date_end)
+        @test new_data[:, :, 1] ≈ all_data[:, :, start_id]
+        @test new_data[:, :, length(new_dates)] ≈ all_data[:, :, end_id]
+
+        close(ds_truncated)
+    end
+
+    close(ds)
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR aims to truncate the data sets that are regridded in the coupler driver to significantly reduce processing time and memory

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
