### PR TITLE
move SurfaceStub to its own file

### DIFF
--- a/docs/src/fieldexchanger.md
+++ b/docs/src/fieldexchanger.md
@@ -13,8 +13,6 @@ The component models are updated by broadcasting the coupler fields, via the `up
 
 If an `update_field!` function is not defined for a particular component model, it will be ignored.
 
-Each component model is also required to define its own `step!` and `reinit!` functions, otherwise this will be ignored.
-
 ## FieldExchanger API
 
 ```@docs
@@ -24,12 +22,4 @@ Each component model is also required to define its own `step!` and `reinit!` fu
     ClimaCoupler.FieldExchanger.update_sim!
     ClimaCoupler.FieldExchanger.reinit_model_sims!
     ClimaCoupler.FieldExchanger.step_model_sims!
-```
-
-
-## FieldExchanger Internal Functions
-
-```@docs
-    ClimaCoupler.FieldExchanger.step!
-    ClimaCoupler.FieldExchanger.reinit!
 ```

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -163,7 +163,8 @@ module docs for more information.
 - `SurfaceStub` is a `SurfaceModelSimulation`, but it only contains
 required data in `<surface_stub>.cache`, e.g., for the calculation
 of surface fluxes through a prescribed surface state. The above
-adapter functions are already predefined for `SurfaceStub`, with
+adapter functions are already predefined for `SurfaceStub`
+in the `surface_stub.jl` file, with
 the cache variables specified as:
 ```
 get_field(sim::SurfaceStub, ::Val{:air_density}) = sim.cache.ρ_sfc

--- a/experiments/AMIP/components/atmosphere/climaatmos.jl
+++ b/experiments/AMIP/components/atmosphere/climaatmos.jl
@@ -17,9 +17,9 @@ import ClimaCoupler.FluxCalculator:
     extrapolate_ρ_to_sfc,
     get_surface_params,
     water_albedo_from_atmosphere!
-import ClimaCoupler.Interfacer: get_field, update_field!, name
+import ClimaCoupler.Interfacer: get_field, update_field!, name, step!, reinit!
 import ClimaCoupler.Checkpointer: get_model_prog_state
-import ClimaCoupler.FieldExchanger: update_sim!, step!, reinit!
+import ClimaCoupler.FieldExchanger: update_sim!
 import ClimaCoupler.Utilities: swap_space!
 
 include("climaatmos_extra_diags.jl")

--- a/experiments/AMIP/components/land/climaland_bucket.jl
+++ b/experiments/AMIP/components/land/climaland_bucket.jl
@@ -18,8 +18,7 @@ using ClimaLand:
     CoupledAtmosphere
 import ClimaLand.Parameters as LP
 
-import ClimaCoupler.Interfacer: LandModelSimulation, get_field, update_field!, name
-import ClimaCoupler.FieldExchanger: step!, reinit!
+import ClimaCoupler.Interfacer: LandModelSimulation, get_field, update_field!, name, step!, reinit!
 import ClimaCoupler.FluxCalculator: update_turbulent_fluxes_point!, surface_thermo_state
 
 ###

--- a/experiments/AMIP/components/ocean/eisenman_seaice.jl
+++ b/experiments/AMIP/components/ocean/eisenman_seaice.jl
@@ -7,8 +7,7 @@ import ClimaTimeSteppers as CTS
 import ClimaCoupler: FluxCalculator
 import ClimaCoupler.FluxCalculator:
     update_turbulent_fluxes_point!, differentiate_turbulent_fluxes!, surface_thermo_state
-import ClimaCoupler.Interfacer: get_field, update_field!
-import ClimaCoupler.FieldExchanger: step!, reinit!
+import ClimaCoupler.Interfacer: get_field, update_field!, step!, reinit!
 
 ###
 ### Functions required by ClimaCoupler.jl for a SurfaceModelSimulation

--- a/experiments/AMIP/components/ocean/prescr_seaice.jl
+++ b/experiments/AMIP/components/ocean/prescr_seaice.jl
@@ -4,8 +4,7 @@ using ClimaCore
 import ClimaTimeSteppers as CTS
 import Thermodynamics as TD
 
-import ClimaCoupler.Interfacer: SeaIceModelSimulation, get_field, update_field!, name
-import ClimaCoupler.FieldExchanger: step!, reinit!
+import ClimaCoupler.Interfacer: SeaIceModelSimulation, get_field, update_field!, name, step!, reinit!
 import ClimaCoupler.FluxCalculator: update_turbulent_fluxes_point!
 using ClimaCoupler: Regridder
 import ClimaCoupler.Utilities: swap_space!

--- a/experiments/AMIP/components/ocean/slab_ocean.jl
+++ b/experiments/AMIP/components/ocean/slab_ocean.jl
@@ -2,8 +2,7 @@ import SciMLBase: ODEProblem, init
 
 using ClimaCore
 import ClimaTimeSteppers as CTS
-import ClimaCoupler.Interfacer: OceanModelSimulation, get_field, update_field!, name
-import ClimaCoupler.FieldExchanger: step!, reinit!
+import ClimaCoupler.Interfacer: OceanModelSimulation, get_field, update_field!, name, step!, reinit!
 import ClimaCoupler.FluxCalculator: update_turbulent_fluxes_point!
 import ClimaCoupler.Utilities: swap_space!
 import ClimaCoupler.BCReader: float_type_bcf

--- a/experiments/AMIP/coupler_driver.jl
+++ b/experiments/AMIP/coupler_driver.jl
@@ -60,7 +60,7 @@ using ClimaCoupler.FluxCalculator:
     MoninObukhovScheme,
     partitioned_turbulent_fluxes!,
     water_albedo_from_atmosphere!
-using ClimaCoupler.Interfacer: CoupledSimulation, SurfaceStub, get_field, update_field!
+using ClimaCoupler.Interfacer: CoupledSimulation, SurfaceStub, get_field, update_field!, step!
 using ClimaCoupler.Regridder
 using ClimaCoupler.Regridder: update_surface_fractions!, combine_surfaces!, binary_mask
 using ClimaCoupler.TimeManager:

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -6,11 +6,11 @@ atmospheric and surface component models.
 """
 module FieldExchanger
 
-import SciMLBase: step!, reinit!
 export import_atmos_fields!,
     import_combined_surface_fields!, update_sim!, update_model_sims!, reinit_model_sims!, step_model_sims!
 
 using ClimaCoupler: Interfacer, FluxCalculator, Regridder, Utilities
+import ClimaCoupler.Interfacer: step!, reinit!
 
 """
     import_atmos_fields!(csf, model_sims, boundary_space, turbulent_fluxes)
@@ -149,14 +149,6 @@ function update_sim!(sim::Interfacer.SurfaceModelSimulation, csf, turbulent_flux
 end
 
 """
-    update_sim!(::SurfaceStub, csf, area_fraction)
-
-The stub surface simulation only updates the air density (needed for the turbulent flux calculation).
-"""
-function update_sim!(sim::Interfacer.SurfaceStub, csf, area_fraction)
-    Interfacer.update_field!(sim, Val(:air_density), csf.ρ_sfc)
-end
-"""
     update_model_sims!(model_sims, csf, turbulent_fluxes)
 
 Iterates `update_sim!` over all component model simulations saved in `cs.model_sims`.
@@ -193,13 +185,6 @@ function reinit_model_sims!(model_sims)
 end
 
 """
-    reinit!(cs::SurfaceStub)
-
-The stub surface simulation is not updated by this function. Extends `SciMLBase.reinit!`.
-"""
-reinit!(::Interfacer.SurfaceStub) = nothing
-
-"""
     step_model_sims!(model_sims, t)
 
 Iterates `step!` over all component model simulations saved in `cs.model_sims`.
@@ -213,12 +198,5 @@ function step_model_sims!(model_sims, t)
         step!(sim, t)
     end
 end
-
-"""
-    step!(::SurfaceStub, t)
-
-The stub surface simulation is not updated by this function. Extends `SciMLBase.step!`.
-"""
-step!(::Interfacer.SurfaceStub, _) = nothing
 
 end # module

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -377,8 +377,6 @@ function update_turbulent_fluxes_point!(
     )
 end
 
-update_turbulent_fluxes_point!(sim::Interfacer.SurfaceStub, fields::NamedTuple, colidx::Fields.ColumnIndex) = nothing
-
 """
     differentiate_turbulent_fluxes!(sim::Interfacer.SurfaceModelSimulation, args)
 

--- a/src/surface_stub.jl
+++ b/src/surface_stub.jl
@@ -1,0 +1,94 @@
+"""
+    SurfaceStub
+
+On object containing simulation-like info, used as a stub or for prescribed data.
+"""
+struct SurfaceStub{I} <: SurfaceModelSimulation
+    cache::I
+end
+
+"""
+    stub_init(cache)
+
+Initialization function for SurfaceStub simulation type.
+"""
+stub_init(cache) = SurfaceStub(cache)
+
+## Extensions of Interfacer.jl functions
+
+"""
+    get_field(::SurfaceStub, ::Val)
+
+A getter function, that should not allocate. If undefined, it returns a descriptive error.
+"""
+get_field(sim::SurfaceStub, ::Val{:air_density}) = sim.cache.ρ_sfc
+get_field(sim::SurfaceStub, ::Val{:area_fraction}) = sim.cache.area_fraction
+get_field(sim::SurfaceStub, ::Val{:beta}) = sim.cache.beta
+get_field(sim::SurfaceStub, ::Val{:energy}) = nothing
+get_field(sim::SurfaceStub, ::Val{:roughness_buoyancy}) = sim.cache.z0b
+get_field(sim::SurfaceStub, ::Val{:roughness_momentum}) = sim.cache.z0m
+get_field(sim::SurfaceStub, ::Val{:surface_direct_albedo}) = sim.cache.α_direct
+get_field(sim::SurfaceStub, ::Val{:surface_diffuse_albedo}) = sim.cache.α_diffuse
+get_field(sim::SurfaceStub, ::Val{:surface_humidity}) =
+    TD.q_vap_saturation_generic.(sim.cache.thermo_params, sim.cache.T_sfc, sim.cache.ρ_sfc, sim.cache.phase)
+get_field(sim::SurfaceStub, ::Val{:surface_temperature}) = sim.cache.T_sfc
+get_field(sim::SurfaceStub, ::Val{:water}) = nothing
+
+"""
+    update_field!(sim::SurfaceStub, ::Val{:area_fraction}, field::Fields.Field)
+
+Updates the specified value in the cache of `SurfaceStub`.
+"""
+function update_field!(sim::SurfaceStub, ::Val{:area_fraction}, field::Fields.Field)
+    sim.cache.area_fraction .= field
+end
+function update_field!(sim::SurfaceStub, ::Val{:surface_temperature}, field::Fields.Field)
+    sim.cache.T_sfc .= field
+end
+function update_field!(sim::SurfaceStub, ::Val{:air_density}, field)
+    parent(sim.cache.ρ_sfc) .= parent(field)
+end
+function update_field!(sim::SurfaceStub, ::Val{:surface_direct_albedo}, field::Fields.Field)
+    sim.cache.α_direct .= field
+end
+function update_field!(sim::SurfaceStub, ::Val{:surface_diffuse_albedo}, field::Fields.Field)
+    sim.cache.α_diffuse .= field
+end
+
+"""
+    name(::ComponentModelSimulation)
+
+Returns simulation name, if defined, or `Unnamed` if not.
+"""
+name(::SurfaceStub) = "SurfaceStub"
+
+
+## Extensions of FieldExchanger.jl functions
+
+"""
+    update_sim!(::SurfaceStub, csf, area_fraction)
+
+The stub surface simulation only updates the air density (needed for the turbulent flux calculation).
+"""
+function update_sim!(sim::SurfaceStub, csf, area_fraction)
+    update_field!(sim, Val(:air_density), csf.ρ_sfc)
+end
+
+"""
+    reinit!(cs::SurfaceStub)
+
+The stub surface simulation is not updated by this function. Extends `SciMLBase.reinit!`.
+"""
+reinit!(::SurfaceStub) = nothing
+
+"""
+    step!(::SurfaceStub, t)
+
+The stub surface simulation is not updated by this function. Extends `SciMLBase.step!`.
+"""
+step!(::SurfaceStub, _) = nothing
+
+
+## Extensions of FluxCalculator.jl functions
+
+update_turbulent_fluxes_point!(sim::SurfaceStub, fields::NamedTuple, colidx::Fields.ColumnIndex) = nothing

--- a/test/component_model_tests/eisenman_seaice_tests.jl
+++ b/test/component_model_tests/eisenman_seaice_tests.jl
@@ -5,7 +5,7 @@ using ClimaCore: Fields, Spaces
 
 import ClimaCoupler
 import ClimaCoupler.TestHelper
-import ClimaCoupler.Interfacer: SeaIceModelSimulation
+import ClimaCoupler.Interfacer: SeaIceModelSimulation, step!
 import ClimaCoupler: Regridder
 
 import ClimaParams as CP

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -2,16 +2,11 @@ using Test
 using ClimaCore: Meshes, Domains, Topologies, Spaces, Fields, InputOutput
 using ClimaCoupler: Utilities, Regridder, TestHelper
 import ClimaCoupler.Interfacer:
-    update_field!, AtmosModelSimulation, SurfaceModelSimulation, SurfaceStub, get_field, update_field!
+    update_field!, AtmosModelSimulation, SurfaceModelSimulation, SurfaceStub, get_field, update_field!, step!, reinit!
 import ClimaCoupler.FluxCalculator: CombinedStateFluxes, PartitionedStateFluxes, calculate_surface_air_density
 import ClimaCoupler.FieldExchanger:
-    import_atmos_fields!,
-    import_combined_surface_fields!,
-    update_model_sims!,
-    reinit_model_sims!,
-    reinit!,
-    step_model_sims!,
-    step!
+    import_atmos_fields!, import_combined_surface_fields!, update_model_sims!, reinit_model_sims!, step_model_sims!
+
 
 
 # test for a simple generic atmos model
@@ -60,6 +55,8 @@ get_field(sim::Union{TestSurfaceSimulation1, TestSurfaceSimulation2}, ::Val{:sur
 get_field(sim::Union{TestSurfaceSimulation2, TestSurfaceSimulation2}, ::Val{:surface_humidity}) =
     sim.cache_field .* eltype(sim.cache_field)(0)
 
+reinit!(::TestSurfaceSimulation1) = nothing
+step!(::TestSurfaceSimulation1, _) = nothing
 
 # atmos sim
 struct TestAtmosSimulation{C} <: AtmosModelSimulation
@@ -239,10 +236,10 @@ for FT in (Float32, Float64)
         end
     end
     @testset "reinit_model_sims! for FT=$FT" begin
-        @test reinit_model_sims!((; stub = SurfaceStub(FT(0)))) == nothing
+        @test reinit_model_sims!((; stub = TestSurfaceSimulation1(FT(0)))) == nothing
     end
 
     @testset "step_model_sims! for FT=$FT" begin
-        @test step_model_sims!((; stub = SurfaceStub(FT(0))), 1) == nothing
+        @test step_model_sims!((; stub = TestSurfaceSimulation1(FT(0))), 1) == nothing
     end
 end

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -301,15 +301,13 @@ for FT in (Float32, Float64)
     end
 
     @testset "update_turbulent_fluxes_point! for FT=$FT" begin
-        sim = Interfacer.SurfaceStub([])
-        sim2 = DummySurfaceSimulation3([], [], [], [])
+        sim = DummySurfaceSimulation3([], [], [], [])
         colidx = Fields.ColumnIndex{2}((1, 1), 73) # arbitrary index
-        @test update_turbulent_fluxes_point!(sim, (;), colidx) == nothing
         @test_throws ErrorException(
             "update_turbulent_fluxes_point! is required to be dispatched on" *
-            Interfacer.name(sim2) *
+            Interfacer.name(sim) *
             ", but no method defined",
-        ) update_turbulent_fluxes_point!(sim2, (;), colidx) == ErrorException
+        ) update_turbulent_fluxes_point!(sim, (;), colidx) == ErrorException
     end
 
     @testset "surface_thermo_state for FT=$FT" begin

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -15,7 +15,10 @@ import ClimaCoupler.Interfacer:
     SeaIceModelSimulation,
     AtmosModelSimulation,
     SurfaceStub,
-    update_field!
+    update_field!,
+    reinit!,
+    step!,
+    update_turbulent_fluxes_point!
 
 # test for a simple generic surface model
 struct DummySimulation{S} <: SeaIceModelSimulation
@@ -229,6 +232,34 @@ end
         ) update_field!(sim, val, dummy_field)
         @test_throws ErrorException("undefined field `$value` for " * name(sim)) get_field(sim, val)
     end
+end
+
+@testset "undefined step! error" begin
+    FT = Float32
+    sim = DummySimulation3(nothing)
+    @test_throws ErrorException("undefined step! for " * name(sim)) step!(sim, 1)
+end
+
+@testset "undefined reinit! error" begin
+    FT = Float32
+    sim = DummySimulation3(nothing)
+    @test_throws ErrorException("undefined reinit! for " * name(sim)) reinit!(sim)
+end
+
+@testset "SurfaceStub step!" begin
+    FT = Float32
+    @test step!(SurfaceStub(FT(0)), 1) == nothing
+end
+
+@testset "SurfaceStub reinit!" begin
+    FT = Float32
+    @test reinit!(SurfaceStub(FT(0))) == nothing
+end
+
+@testset "SurfaceStub update_turbulent_fluxes_point!" begin
+    FT = Float32
+    colidx = Fields.ColumnIndex{2}((1, 1), 73) # arbitrary index
+    @test update_turbulent_fluxes_point!(SurfaceStub(FT(0)), (;), colidx) == nothing
 end
 
 # # Test that update_field! gives correct warnings for unextended fields


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #669 


## To-do
- move SurfaceStub struct and functions from `src/Interfacer` to `src/surface_stub.jl`
- move additional SurfaceStub functions from `src/FieldExchanger` and `src/FluxCalculator` to `src/surface_stub.jl`
- update docs


## Questions
- Maybe we want to create a folder `src/Interfacer/` that contains `surface_stub.jl` and `Interfacer.jl`. On one hand, this might be nicer to organize `src/` and make it clear which module `surface_stub.jl` belongs to. On the other hand, it could be nice to maintain the flat structure we currently have in `src/`.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
