### PR TITLE
Remove ternary operator with nothing

### DIFF
--- a/experiments/AMIP/coupler_driver.jl
+++ b/experiments/AMIP/coupler_driver.jl
@@ -158,7 +158,7 @@ dir_paths = (; output = COUPLER_OUTPUT_DIR, artifacts = COUPLER_ARTIFACTS_DIR)
 
 if ClimaComms.iamroot(comms_ctx)
     @info(COUPLER_OUTPUT_DIR)
-    config_dict["print_config_dict"] ? @info(config_dict) : nothing
+    config_dict["print_config_dict"] && @info(config_dict)
 end
 
 #=
@@ -231,9 +231,9 @@ In the `SlabPlanet` mode, all ocean and sea ice are dynamical models, namely the
 - `slabplanet_eisenman` = land + slab ocean + slab sea ice with an evolving thickness
 =#
 
-ClimaComms.iamroot(comms_ctx) ? @info(mode_name) : nothing
+ClimaComms.iamroot(comms_ctx) && @info(mode_name)
 if mode_name == "amip"
-    ClimaComms.iamroot(comms_ctx) ? @info("AMIP boundary conditions - do not expect energy conservation") : nothing
+    ClimaComms.iamroot(comms_ctx) && @info("AMIP boundary conditions - do not expect energy conservation")
 
     ## land model
     land_sim = bucket_init(
@@ -669,7 +669,7 @@ function solve_coupler!(cs)
     (; model_sims, Δt_cpl, tspan, comms_ctx) = cs
     (; atmos_sim, land_sim, ocean_sim, ice_sim) = model_sims
 
-    ClimaComms.iamroot(comms_ctx) ? @info("Starting coupling loop") : nothing
+    ClimaComms.iamroot(comms_ctx) && @info("Starting coupling loop")
     ## step in time
     walltime = @elapsed for t in ((tspan[begin] + Δt_cpl):Δt_cpl:tspan[end])
 
@@ -677,7 +677,7 @@ function solve_coupler!(cs)
 
         ## print date on the first of month
         if cs.dates.date[1] >= cs.dates.date1[1]
-            ClimaComms.iamroot(comms_ctx) ? @show(cs.dates.date[1]) : nothing
+            ClimaComms.iamroot(comms_ctx) && @show(cs.dates.date[1])
         end
 
         if cs.mode.name == "amip"
@@ -715,7 +715,7 @@ function solve_coupler!(cs)
         end
 
         ## compute global energy
-        !isnothing(cs.conservation_checks) ? ConservationChecker.check_conservation!(cs) : nothing
+        !isnothing(cs.conservation_checks) && ConservationChecker.check_conservation!(cs)
         ClimaComms.barrier(comms_ctx)
 
         ## update water albedo from wind at dt_water_albedo (this will be extended to a radiation callback from the coupler)
@@ -757,7 +757,7 @@ function solve_coupler!(cs)
         TimeManager.trigger_callback!(cs, cs.callbacks.checkpoint)
 
     end
-    ClimaComms.iamroot(comms_ctx) ? @show(walltime) : nothing
+    ClimaComms.iamroot(comms_ctx) && @show(walltime)
 
     return cs
 end

--- a/perf/flame_test.jl
+++ b/perf/flame_test.jl
@@ -80,7 +80,7 @@ function find_child(flame_tree, target_name; self_count = false)
             end
         end
     end
-    return @isdefined(out) ? out : nothing
+    return @isdefined(out) && out
 end
 
 @testset "flame diff tests" begin

--- a/src/PostProcessor.jl
+++ b/src/PostProcessor.jl
@@ -119,7 +119,8 @@ function postprocess(
         DIR = joinpath(REGRID_DIR, "cgll2rll")
         isdir(DIR) ? nothing : mkpath(DIR)
         datafile_latlon =
-            (datafile_latlon == nothing) ? datafile_latlon = DIR * "/remapped_" * string(name) * ".nc" : datafile_latlon
+            (datafile_latlon === nothing) ? datafile_latlon = DIR * "/remapped_" * string(name) * ".nc" :
+            datafile_latlon
         Regridder.remap_field_cgll_to_rll(name, raw_data, DIR, datafile_latlon, nlat = nlat, nlon = nlon)
         new_data, coords = Regridder.read_remapped_field(name, datafile_latlon)
         raw_tag = length(size(new_data)) == 3 ? ZLatLonData() : LatLonData()
@@ -131,15 +132,14 @@ function postprocess(
 
     # spatial slicing and averaging
     if :horizontal_slice in p_methods
-        package.tag == RawData() ? @error("Cannot perform horizontal slicing on raw model data. Specify :regrid") :
-        nothing
+        package.tag == RawData() && @error("Cannot perform horizontal slicing on raw model data. Specify :regrid")
         if package.tag == ZLatLonData()
             package = DataPackage(ZLatData(), name, package.data[:, :, lev_slice], coords = package.coords)
         end
     end
 
     if :zonal_mean in p_methods
-        package.tag == RawData() ? @error("Cannot perform zonal mean on raw model data. Specify :regrid") : nothing
+        package.tag == RawData() && @error("Cannot perform zonal mean on raw model data. Specify :regrid")
         if package.tag == ZLatLonData()
             package = DataPackage(
                 ZLatData(),

--- a/src/Regridder.jl
+++ b/src/Regridder.jl
@@ -632,7 +632,7 @@ function cgll2latlonz(field; DIR = "cgll2latlonz_dir", nlat = 360, nlon = 720, c
     datafile_latlon = DIR * "/remapped_" * string(Interfacer.name) * ".nc"
     remap_field_cgll_to_rll(:var, field, DIR, datafile_latlon, nlat = nlat, nlon = nlon)
     new_data, coords = read_remapped_field(:var, datafile_latlon)
-    clean_dir ? rm(DIR; recursive = true) : nothing
+    clean_dir && rm(DIR; recursive = true)
     return new_data, coords
 end
 

--- a/test/TestHelper.jl
+++ b/test/TestHelper.jl
@@ -76,7 +76,7 @@ variable `varname`, and store it at `path`.
 - `val`: [FT] value to store as `varname` at all indices.
 """
 function gen_ncdata(FT, path, varname, val)
-    isfile(path) ? rm(path) : nothing
+    isfile(path) && rm(path)
 
     # Create dataset of all ones
     nc = NCDatasets.NCDataset(path, "c")

--- a/test/checkpointer_tests.jl
+++ b/test/checkpointer_tests.jl
@@ -16,7 +16,7 @@ Checkpointer.get_model_prog_state(sim::DummySimulation) = sim.state
     @test Checkpointer.get_model_prog_state(sim) == sim.state
 
     sim2 = Interfacer.SurfaceStub([])
-    @test Checkpointer.get_model_prog_state(sim2) == nothing
+    @test Checkpointer.get_model_prog_state(sim2) === nothing
 end
 
 @testset "checkpoint_model_state, restart_model_state!" begin

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -232,10 +232,10 @@ for FT in (Float32, Float64)
         end
     end
     @testset "reinit_model_sims! for FT=$FT" begin
-        @test FieldExchanger.reinit_model_sims!((; stub = TestSurfaceSimulation1(FT(0)))) == nothing
+        @test FieldExchanger.reinit_model_sims!((; stub = TestSurfaceSimulation1(FT(0)))) === nothing
     end
 
     @testset "step_model_sims! for FT=$FT" begin
-        @test FieldExchanger.step_model_sims!((; stub = TestSurfaceSimulation1(FT(0))), 1) == nothing
+        @test FieldExchanger.step_model_sims!((; stub = TestSurfaceSimulation1(FT(0))), 1) === nothing
     end
 end

--- a/test/mpi_tests/bcreader_mpi_tests.jl
+++ b/test/mpi_tests/bcreader_mpi_tests.jl
@@ -78,7 +78,7 @@ ClimaComms.barrier(comms_ctx)
 
         # delete testing directory and files
         ClimaComms.barrier(comms_ctx)
-        ClimaComms.iamroot(comms_ctx) ? rm(regrid_dir; recursive = true, force = true) : nothing
+        ClimaComms.iamroot(comms_ctx) && rm(regrid_dir; recursive = true, force = true)
         ClimaComms.barrier(comms_ctx)
     end
 end
@@ -298,7 +298,7 @@ end
         @test_throws ErrorException BCReader.update_midmonth_data!(date, bcf_info)
 
         ClimaComms.barrier(comms_ctx)
-        ClimaComms.iamroot(comms_ctx) ? rm(regrid_dir; recursive = true, force = true) : nothing
+        ClimaComms.iamroot(comms_ctx) && rm(regrid_dir; recursive = true, force = true)
         ClimaComms.barrier(comms_ctx)
     end
 end

--- a/test/mpi_tests/regridder_mpi_tests.jl
+++ b/test/mpi_tests/regridder_mpi_tests.jl
@@ -39,7 +39,7 @@ pid, nprocs = ClimaComms.init(comms_ctx)
         @test parent(input_field) == parent(output_field)
 
         ClimaComms.barrier(comms_ctx)
-        ClimaComms.iamroot(comms_ctx) ? rm(REGRID_DIR; recursive = true, force = true) : nothing
+        ClimaComms.iamroot(comms_ctx) && rm(REGRID_DIR; recursive = true, force = true)
         ClimaComms.barrier(comms_ctx)
     end
 end

--- a/test/regridder_tests.jl
+++ b/test/regridder_tests.jl
@@ -141,7 +141,7 @@ for FT in (Float32, Float64)
     if !Sys.iswindows()
         @testset "test write_to_hdf5 and read_from_hdf5" begin
             # Set up testing directory
-            ispath(REGRID_DIR) ? rm(REGRID_DIR; recursive = true, force = true) : nothing
+            ispath(REGRID_DIR) && rm(REGRID_DIR; recursive = true, force = true)
             mkpath(REGRID_DIR)
 
             hd_outfile_root = "hdf5_out_test"
@@ -162,7 +162,7 @@ for FT in (Float32, Float64)
         @testset "test remap_field_cgll_to_rll for FT=$FT" begin
             # Set up testing directory
             remap_tmpdir = joinpath(REGRID_DIR, "cgll_to_rll")
-            ispath(remap_tmpdir) ? rm(remap_tmpdir; recursive = true, force = true) : nothing
+            ispath(remap_tmpdir) && rm(remap_tmpdir; recursive = true, force = true)
             mkpath(remap_tmpdir)
             name = "testdata"
             datafile_rll = remap_tmpdir * "/" * name * "_rll.nc"
@@ -191,7 +191,7 @@ for FT in (Float32, Float64)
             # Test setup
             R = FT(6371e3)
             test_space = TestHelper.create_space(FT, R = R)
-            ispath(REGRID_DIR) ? rm(REGRID_DIR; recursive = true, force = true) : nothing
+            ispath(REGRID_DIR) && rm(REGRID_DIR; recursive = true, force = true)
             mkpath(REGRID_DIR)
 
             # Initialize dataset of all ones
@@ -221,7 +221,7 @@ for FT in (Float32, Float64)
             rm(REGRID_DIR; recursive = true, force = true)
 
             # Set up testing directory
-            ispath(REGRID_DIR) ? rm(REGRID_DIR; recursive = true, force = true) : nothing
+            ispath(REGRID_DIR) && rm(REGRID_DIR; recursive = true, force = true)
             mkpath(REGRID_DIR)
 
             # Initialize dataset of all 0.5s
@@ -245,7 +245,7 @@ for FT in (Float32, Float64)
             R = FT(6371e3)
             space = TestHelper.create_space(FT, nz = 2, ne = 16, R = R)
 
-            ispath(REGRID_DIR) ? rm(REGRID_DIR; recursive = true, force = true) : nothing
+            ispath(REGRID_DIR) && rm(REGRID_DIR; recursive = true, force = true)
             mkpath(REGRID_DIR)
 
             # lat-lon dataset


### PR DESCRIPTION
Thanks to the magic of regular expressions:
```
find . -type f -name "*.jl" -exec sed -i -E 's/(.+)\\s?\\?\\s?(.*)\\s?:\\s?nothing/\1 \&\& \2/g' {} \;
```

Closes #719 