### PR TITLE
Reducing allocations through temp fields

### DIFF
--- a/experiments/AMIP/components/atmosphere/climaatmos.jl
+++ b/experiments/AMIP/components/atmosphere/climaatmos.jl
@@ -238,8 +238,8 @@ function Interfacer.update_field!(sim::ClimaAtmosSimulation, ::Val{:turbulent_fl
     sim.integrator.p.precomputed.sfc_conditions.ρ_flux_uₕ .= (
         surface_normal .⊗
         CA.C12.(
-            Utilities.swap_space!(ones(axes(vec_ct12_ct1)), F_turb_ρτxz) .* vec_ct12_ct1 .+
-            Utilities.swap_space!(ones(axes(vec_ct12_ct2)), F_turb_ρτyz) .* vec_ct12_ct2,
+            Utilities.swap_space!(axes(vec_ct12_ct1), F_turb_ρτxz) .* vec_ct12_ct1 .+
+            Utilities.swap_space!(axes(vec_ct12_ct2), F_turb_ρτyz) .* vec_ct12_ct2,
             surface_local_geometry,
         )
     )
@@ -285,7 +285,7 @@ Extension for this function to calculate surface density.
 function FluxCalculator.calculate_surface_air_density(atmos_sim::ClimaAtmosSimulation, T_S::CC.Fields.Field)
     thermo_params = get_thermo_params(atmos_sim)
     ts_int = Interfacer.get_field(atmos_sim, Val(:thermo_state_int))
-    FluxCalculator.extrapolate_ρ_to_sfc.(Ref(thermo_params), ts_int, Utilities.swap_space!(ones(axes(ts_int.ρ)), T_S))
+    FluxCalculator.extrapolate_ρ_to_sfc.(Ref(thermo_params), ts_int, Utilities.swap_space!(axes(ts_int.ρ), T_S))
 end
 
 # FluxCalculator.get_surface_params required by FluxCalculator (partitioned fluxes)

--- a/experiments/AMIP/components/land/climaland_bucket.jl
+++ b/experiments/AMIP/components/land/climaland_bucket.jl
@@ -26,6 +26,20 @@ struct BucketSimulation{M, Y, D, I, A} <: Interfacer.LandModelSimulation
 end
 Interfacer.name(::BucketSimulation) = "BucketSimulation"
 
+"""
+    get_new_cache(p, Y, energy_check)
+
+Returns a new `p` with an updated field to store e_per_area if energy conservation 
+    checks are turned on. 
+"""
+function get_new_cache(p, Y, energy_check)
+    if energy_check
+        e_per_area_field = CC.Fields.zeros(axes(Y.bucket.W))
+        return merge(p, (; e_per_area = e_per_area_field))
+    else
+        return p
+    end
+end
 
 """
     bucket_init
@@ -46,6 +60,7 @@ function bucket_init(
     stepper = CTS.RK4(),
     date_ref::Dates.DateTime,
     t_start::Float64,
+    energy_check::Bool,
 ) where {FT}
     if config != "sphere"
         println(
@@ -93,6 +108,7 @@ function bucket_init(
 
     # Initial conditions with no moisture
     Y, p, coords = CL.initialize(model)
+    p = get_new_cache(p, Y, energy_check)
 
     # Get temperature anomaly function
     T_functions = Dict("aquaplanet" => temp_anomaly_aquaplanet, "amip" => temp_anomaly_amip)
@@ -148,7 +164,7 @@ Extension of Interfacer.get_field that provides the total energy contained in th
 """
 function Interfacer.get_field(bucket_sim::BucketSimulation, ::Val{:energy})
     # required by ConservationChecker
-    e_per_area = zeros(axes(bucket_sim.integrator.u.bucket.W))
+    e_per_area = bucket_sim.integrator.p.e_per_area .= 0
     CC.Operators.column_integral_definite!(
         e_per_area,
         bucket_sim.model.parameters.ρc_soil .* bucket_sim.integrator.u.bucket.T,

--- a/experiments/AMIP/components/ocean/prescr_seaice.jl
+++ b/experiments/AMIP/components/ocean/prescr_seaice.jl
@@ -156,8 +156,7 @@ end
     scale_sic(SIC, _info)
 Ensures that the space of the SIC struct matches that of the mask, and converts the units from area % to area fraction.
 """
-scale_sic(SIC, _info) =
-    Utilities.swap_space!(zeros(axes(_info.land_fraction)), SIC) ./ BCReader.float_type_bcf(_info)(100.0)
+scale_sic(SIC, _info) = Utilities.swap_space!(axes(_info.land_fraction), SIC) ./ BCReader.float_type_bcf(_info)(100.0)
 
 # setting that SIC < 0.5 is counted as ocean if binary remapping.
 get_ice_fraction(h_ice::FT, mono::Bool, threshold = 0.5) where {FT} =

--- a/experiments/AMIP/components/ocean/slab_ocean.jl
+++ b/experiments/AMIP/components/ocean/slab_ocean.jl
@@ -169,7 +169,7 @@ end
 Ensures that the space of the SST struct matches that of the land_fraction, and converts the units to Kelvin (N.B.: this is dataset specific)
 """
 scale_sst(SST, _info) =
-    (Utilities.swap_space!(zeros(axes(_info.land_fraction)), SST) .+ BCReader.float_type_bcf(_info)(273.15))
+    (Utilities.swap_space!(axes(_info.land_fraction), SST) .+ BCReader.float_type_bcf(_info)(273.15))
 
 # ode
 function slab_ocean_rhs!(dY, Y, cache, t)

--- a/experiments/AMIP/coupler_driver.jl
+++ b/experiments/AMIP/coupler_driver.jl
@@ -243,6 +243,7 @@ if mode_name == "amip"
         area_fraction = land_area_fraction,
         date_ref = date0,
         t_start = t_start,
+        energy_check = energy_check,
     )
 
     ## ocean stub
@@ -342,6 +343,7 @@ elseif mode_name in ("slabplanet", "slabplanet_aqua", "slabplanet_terra")
         area_fraction = land_area_fraction,
         date_ref = date0,
         t_start = t_start,
+        energy_check = energy_check,
     )
 
     ## ocean model
@@ -388,6 +390,7 @@ elseif mode_name == "slabplanet_eisenman"
         area_fraction = land_area_fraction,
         date_ref = date0,
         t_start = t_start,
+        energy_check = energy_check,
     )
 
     ## ocean stub (here set to zero area coverage)
@@ -608,7 +611,7 @@ Regridder.update_surface_fractions!(cs)
 
 # 2.surface density (`ρ_sfc`): calculated by the coupler by adiabatically extrapolating atmospheric thermal state to the surface.
 # For this, we need to import surface and atmospheric fields. The model sims are then updated with the new surface density.
-FieldExchanger.import_combined_surface_fields!(cs.fields, cs.model_sims, cs.boundary_space, cs.turbulent_fluxes)
+FieldExchanger.import_combined_surface_fields!(cs.fields, cs.model_sims, cs.turbulent_fluxes)
 FieldExchanger.import_atmos_fields!(cs.fields, cs.model_sims, cs.boundary_space, cs.turbulent_fluxes)
 FieldExchanger.update_model_sims!(cs.model_sims, cs.fields, cs.turbulent_fluxes)
 
@@ -622,7 +625,7 @@ Interfacer.step!(ice_sim, Δt_cpl)
 # or the partitioned state method
 if cs.turbulent_fluxes isa FluxCalculator.CombinedStateFluxes
     ## import the new surface properties into the coupler (note the atmos state was also imported in step 3.)
-    FieldExchanger.import_combined_surface_fields!(cs.fields, cs.model_sims, cs.boundary_space, cs.turbulent_fluxes) # i.e. T_sfc, albedo, z0, beta, q_sfc
+    FieldExchanger.import_combined_surface_fields!(cs.fields, cs.model_sims, cs.turbulent_fluxes) # i.e. T_sfc, albedo, z0, beta, q_sfc
     ## calculate turbulent fluxes inside the atmos cache based on the combined surface state in each grid box
     FluxCalculator.combined_turbulent_fluxes!(cs.model_sims, cs.fields, cs.turbulent_fluxes) # this updates the atmos thermo state, sfc_ts
 elseif cs.turbulent_fluxes isa FluxCalculator.PartitionedStateFluxes
@@ -723,7 +726,7 @@ function solve_coupler!(cs)
         FieldExchanger.step_model_sims!(cs.model_sims, t)
 
         ## exchange combined fields and (if specified) calculate fluxes using combined states
-        FieldExchanger.import_combined_surface_fields!(cs.fields, cs.model_sims, cs.boundary_space, cs.turbulent_fluxes) # i.e. T_sfc, surface_albedo, z0, beta
+        FieldExchanger.import_combined_surface_fields!(cs.fields, cs.model_sims, cs.turbulent_fluxes) # i.e. T_sfc, surface_albedo, z0, beta
         if cs.turbulent_fluxes isa FluxCalculator.CombinedStateFluxes
             FluxCalculator.combined_turbulent_fluxes!(cs.model_sims, cs.fields, cs.turbulent_fluxes) # this updates the surface thermo state, sfc_ts, in ClimaAtmos (but also unnecessarily calculates fluxes)
         elseif cs.turbulent_fluxes isa FluxCalculator.PartitionedStateFluxes

--- a/experiments/AMIP/user_io/user_diagnostics.jl
+++ b/experiments/AMIP/user_io/user_diagnostics.jl
@@ -75,7 +75,7 @@ function Diagnostics.get_var(cs::Interfacer.CoupledSimulation, ::Val{:toa_fluxes
     )
 
     radiation_sources = @. -(LWd_TOA + SWd_TOA - LWu_TOA - SWu_TOA)
-    Utilities.swap_space!(zeros(cs.boundary_space), radiation_sources)
+    Utilities.swap_space!(cs.boundary_space, radiation_sources)
 end
 
 """
@@ -85,7 +85,7 @@ Precipitation rate (Kg m⁻² s⁻¹).
 """
 Diagnostics.get_var(cs::Interfacer.CoupledSimulation, ::Val{:precipitation_rate}) =
     .-Utilities.swap_space!(
-        zeros(cs.boundary_space),
+        cs.boundary_space,
         cs.model_sims.atmos_sim.integrator.p.precipitation.col_integrated_rain .+
         cs.model_sims.atmos_sim.integrator.p.precipitation.col_integrated_snow,
     )
@@ -97,7 +97,7 @@ Diagnostics.get_var(cs::Interfacer.CoupledSimulation, ::Val{:precipitation_rate}
 Combined surface temperature (K).
 """
 Diagnostics.get_var(cs::Interfacer.CoupledSimulation, ::Val{:T_sfc}) =
-    Utilities.swap_space!(zeros(cs.boundary_space), cs.fields.T_S)
+    Utilities.swap_space!(cs.boundary_space, cs.fields.T_S)
 
 """
     Diagnostics.get_var(cs::Interfacer.CoupledSimulation, ::Val{:tubulent_energy_fluxes})
@@ -105,6 +105,6 @@ Diagnostics.get_var(cs::Interfacer.CoupledSimulation, ::Val{:T_sfc}) =
 Combined aerodynamic turbulent energy surface fluxes (W m⁻²).
 """
 Diagnostics.get_var(cs::Interfacer.CoupledSimulation, ::Val{:tubulent_energy_fluxes}) =
-    Utilities.swap_space!(zeros(cs.boundary_space), cs.fields.F_turb_energy)
+    Utilities.swap_space!(cs.boundary_space, cs.fields.F_turb_energy)
 
 # land diagnotics

--- a/src/BCReader.jl
+++ b/src/BCReader.jl
@@ -67,7 +67,7 @@ Remap the values of a `field` onto the space of the
 - `bcf_info`: [BCFileInfo] contains a land_fraction to remap onto the space of.
 """
 no_scaling(field::CC.Fields.Field, bcf_info::BCFileInfo{FT}) where {FT} =
-    Utilities.swap_space!(zeros(axes(bcf_info.land_fraction)), field)
+    Utilities.swap_space!(axes(bcf_info.land_fraction), field)
 
 """
     bcfile_info_init(

--- a/src/ConservationChecker.jl
+++ b/src/ConservationChecker.jl
@@ -157,8 +157,7 @@ function check_conservation!(
 
     # net precipitation (for surfaces that don't collect water)
     PE_net =
-        coupler_sim.fields.P_net .+=
-            Utilities.swap_space!(zeros(boundary_space), surface_water_gain_from_rates(coupler_sim))
+        coupler_sim.fields.P_net .+= Utilities.swap_space!(boundary_space, surface_water_gain_from_rates(coupler_sim))
 
     # save surfaces
     for sim in model_sims

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -44,7 +44,7 @@ function import_atmos_fields!(csf, model_sims, boundary_space, turbulent_fluxes)
 end
 
 """
-    import_combined_surface_fields!(csf, model_sims, boundary_space, turbulent_fluxes)
+    import_combined_surface_fields!(csf, model_sims, turbulent_fluxes)
 
 Updates the coupler with the surface properties. The `Interfacer.get_field` functions for
 (`:surface_temperature`, `:surface_direct_albedo`, `:surface_diffuse_albedo`, `:roughness_momentum`, `:roughness_buoyancy`, `:beta`)
@@ -53,13 +53,12 @@ need to be specified for each surface model.
 # Arguments
 - `csf`: [NamedTuple] containing coupler fields.
 - `model_sims`: [NamedTuple] containing `ComponentModelSimulation`s.
-- `boundary_space`: [Spaces.AbstractSpace] the space of the coupler surface.
 - `turbulent_fluxes`: [TurbulentFluxPartition] denotes a flag for turbulent flux calculation.
 
 """
-function import_combined_surface_fields!(csf, model_sims, boundary_space, turbulent_fluxes)
+function import_combined_surface_fields!(csf, model_sims, turbulent_fluxes)
 
-    combined_field = zeros(boundary_space)
+    combined_field = csf.temp1
 
     # surface fields
     Regridder.combine_surfaces!(combined_field, model_sims, Val(:surface_temperature))

--- a/src/Regridder.jl
+++ b/src/Regridder.jl
@@ -487,7 +487,7 @@ function land_fraction(
     ClimaComms.barrier(comms_ctx)
     file_dates = JLD2.load(joinpath(REGRID_DIR, outfile_root * "_times.jld2"), "times")
     fraction = read_from_hdf5(REGRID_DIR, outfile_root, file_dates[1], varname, comms_ctx)
-    fraction = Utilities.swap_space!(zeros(boundary_space), fraction) # needed if we are reading from previous run
+    fraction = Utilities.swap_space!(boundary_space, fraction) # needed if we are reading from previous run
     return mono ? fraction : binary_mask.(fraction, threshold)
 end
 
@@ -556,7 +556,7 @@ surface simulations. THe result is saved in `combined_field`.
 - `field_name`: [Val] containing the name Symbol of the field t be extracted by the `Interfacer.get_field` functions.
 
 # Example
-- `combine_surfaces!(zeros(boundary_space), cs.model_sims, Val(:surface_temperature))`
+- `combine_surfaces!(temp_field, cs.model_sims, Val(:surface_temperature))`
 """
 function combine_surfaces!(combined_field::CC.Fields.Field, sims::NamedTuple, field_name::Val)
     combined_field .= eltype(combined_field)(0)

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -12,16 +12,17 @@ import ClimaCore as CC
 export swap_space!
 
 """
-    swap_space!(field_out::CC.Fields.Field, field_in::CC.Fields.Field)
+    swap_space!(space_out::CC.Spaces.AbstractSpace, field_in::CC.Fields.Field)
 
 Remap the values of a field onto a new space.
 
 # Arguments
+- `space_out`: [CC.Spaces.AbstractSpace] The axes of the space we want to remap onto
 - `field_in`: [CC.Fields.Field] to be remapped to new space.
-- `field_out`: [CC.Fields.Field] to remap `field_in` to.
 """
-function swap_space!(field_out, field_in::CC.Fields.Field)
-    field_out = CC.Fields.Field(CC.Fields.field_values(field_in), axes(field_out))
+function swap_space!(space_out::CC.Spaces.AbstractSpace, field_in::CC.Fields.Field)
+    field_out = CC.Fields.Field(CC.Fields.field_values(field_in), space_out)
+    return field_out
 end
 
 """

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -116,7 +116,7 @@ for FT in (Float32, Float64)
     @testset "import_combined_surface_fields! for FT=$FT" begin
         # coupler cache setup
         boundary_space = TestHelper.create_space(FT)
-        coupler_names = (:T_S, :z0m_S, :z0b_S, :surface_direct_albedo, :surface_diffuse_albedo, :beta, :q_sfc)
+        coupler_names = (:T_S, :z0m_S, :z0b_S, :surface_direct_albedo, :surface_diffuse_albedo, :beta, :q_sfc, :temp1)
 
         # coupler cache setup
         exchanged_fields = (
@@ -137,7 +137,7 @@ for FT in (Float32, Float64)
         for (i, t) in enumerate(flux_types)
             coupler_fields =
                 NamedTuple{coupler_names}(ntuple(i -> CC.Fields.zeros(boundary_space), length(coupler_names)))
-            FieldExchanger.import_combined_surface_fields!(coupler_fields, sims, boundary_space, t)
+            FieldExchanger.import_combined_surface_fields!(coupler_fields, sims, t)
             @test Array(parent(coupler_fields.T_S))[1] == results[1]
             @test Array(parent(coupler_fields.surface_direct_albedo))[1] == results[1]
             @test Array(parent(coupler_fields.surface_diffuse_albedo))[1] == results[1]

--- a/test/utilities_tests.jl
+++ b/test/utilities_tests.jl
@@ -13,7 +13,7 @@ for FT in (Float32, Float64)
         field1 = ones(space1)
         field2 = ones(space2)
 
-        field2 = Utilities.swap_space!(field2, field1)
+        field2 = Utilities.swap_space!(space2, field1)
 
         @test parent(field1) == parent(field2)
         @test axes(field2) == space2


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR aims to close #584 by reducing the allocations within the coupler. 


## To-do

- [x] import_combined_surface_fields (temp fields)
- [x] swap_space (updated function to take in space to swap to instead of field)
- [x] calculate_surface_air_density for atmos (swap_space! update to not need allocations)
- [x] get_field(bucket_sim::BucketSimulation, ::Val{:energy}) (e_per_area added to integrator fields)
- [x] check_conservation!(cc::WaterConservationCheck, coupler_sim::Interfacer.CoupledSimulation) (using new swap_space!)
- [x] anything else using Fields.ones or Fields.zeros (left mostly in init statements and tests)



## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
