### PR TITLE
use ClimaAtmos aquaplanet_diagedmf.yml

### DIFF
--- a/config/longrun_configs/amip_target_topo_diagedmf.yml
+++ b/config/longrun_configs/amip_target_topo_diagedmf.yml
@@ -2,7 +2,7 @@ FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 anim: false
 apply_limiter: false
-atmos_config_file: "config/gpu_configs/gpu_aquaplanet_diagedmf.yml"
+atmos_config_file: "config/model_configs/aquaplanet_diagedmf.yml"
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_cpl: 120

--- a/config/longrun_configs/gpu_amip_target_topo_diagedmf.yml
+++ b/config/longrun_configs/gpu_amip_target_topo_diagedmf.yml
@@ -2,7 +2,7 @@ FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 anim: false
 apply_limiter: false
-atmos_config_file: "config/gpu_configs/gpu_aquaplanet_diagedmf.yml"
+atmos_config_file: "config/model_configs/aquaplanet_diagedmf.yml"
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_cpl: 120


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #800

`gpu_aquaplanet_diagedmf.yml` no longer exists in atmos and should be replaced with `aquaplanet_diagedmf.yml`.

## ClimaAtmos configs used in ClimaCoupler (as of 20 May 2024, after this PR)
- config/model_configs/aquaplanet_diagedmf.yml
- config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_allsky_diagedmf_0M.yml
- config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M_earth.yml
- config/longrun_configs/longrun_aquaplanet_rhoe_equil_55km_nz63_clearsky_0M.yml
- config/longrun_configs/longrun_aquaplanet_dyamond.yml
