### PR TITLE
rm bycolumn

### DIFF
--- a/docs/src/fluxcalculator.md
+++ b/docs/src/fluxcalculator.md
@@ -22,8 +22,8 @@ Fluxes over a heterogeneous surface (e.g., from a gridpoint where atmospheric ce
     ClimaCoupler.FluxCalculator.get_surface_params
     ClimaCoupler.FluxCalculator.partitioned_turbulent_fluxes!
     ClimaCoupler.FluxCalculator.differentiate_turbulent_fluxes!
-    ClimaCoupler.FluxCalculator.get_surface_fluxes_point!
-    ClimaCoupler.FluxCalculator.update_turbulent_fluxes_point!
+    ClimaCoupler.FluxCalculator.get_surface_fluxes!
+    ClimaCoupler.FluxCalculator.update_turbulent_fluxes!
     ClimaCoupler.FluxCalculator.extrapolate_ρ_to_sfc
     ClimaCoupler.FluxCalculator.surface_thermo_state
     ClimaCoupler.FluxCalculator.water_albedo_from_atmosphere!

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -153,7 +153,7 @@ following properties:
 | `surface_diffuse albedo`    | bulk diffuse surface albedo; needed if calculated externally of the surface model (e.g. ocean albedo from the atmospheric state) | |
 
 ### SurfaceModelSimulation - optional functions
-- `update_turbulent_fluxes_point!(::ComponentModelSimulation, fields::NamedTuple, colidx)`:
+- `update_turbulent_fluxes!(::ComponentModelSimulation, fields::NamedTuple)`:
 This function updates the turbulent fluxes of the component model simulation
 at this point in horizontal space. The values are updated using the energy
 and moisture turbulent fluxes stored in fields which are calculated by the

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos_extra_diags.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos_extra_diags.jl
@@ -65,16 +65,9 @@ CAD.add_diagnostic_variable!(
         (; C_E) = cache.atmos.vert_diff
         interior_uₕ = CC.Fields.level(state.c.uₕ, 1)
         ᶠp = ᶠK_E = cache.scratch.ᶠtemp_scalar
-        CC.Fields.bycolumn(axes(ᶜp)) do colidx
-            @. ᶠp[colidx] = CAD.ᶠinterp(ᶜp[colidx])
-            ᶜΔz_surface = CC.Fields.Δz_field(interior_uₕ)
-            @. ᶠK_E[colidx] = CA.eddy_diffusivity_coefficient(
-                C_E,
-                CA.norm(interior_uₕ[colidx]),
-                ᶜΔz_surface[colidx] / 2,
-                ᶠp[colidx],
-            )
-        end
+        @. ᶠp = CAD.ᶠinterp(ᶜp)
+        ᶜΔz_surface = CC.Fields.Δz_field(interior_uₕ)
+        @. ᶠK_E = CA.eddy_diffusivity_coefficient(C_E, CA.norm(interior_uₕ), ᶜΔz_surface / 2, ᶠp)
         if isnothing(out)
             return CAD.ᶜinterp.(ᶠK_E)
         else

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -131,13 +131,9 @@ Interfacer.step!(sim::PrescribedIceSimulation, t) = Interfacer.step!(sim.integra
 Interfacer.reinit!(sim::PrescribedIceSimulation) = Interfacer.reinit!(sim.integrator)
 
 # extensions required by FluxCalculator (partitioned fluxes)
-function FluxCalculator.update_turbulent_fluxes_point!(
-    sim::PrescribedIceSimulation,
-    fields::NamedTuple,
-    colidx::CC.Fields.ColumnIndex,
-)
+function FluxCalculator.update_turbulent_fluxes!(sim::PrescribedIceSimulation, fields::NamedTuple)
     (; F_turb_energy) = fields
-    @. sim.integrator.p.F_turb_energy[colidx] = F_turb_energy
+    @. sim.integrator.p.F_turb_energy = F_turb_energy
 end
 
 """

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -151,13 +151,9 @@ Interfacer.step!(sim::SlabOceanSimulation, t) = Interfacer.step!(sim.integrator,
 Interfacer.reinit!(sim::SlabOceanSimulation) = Interfacer.reinit!(sim.integrator)
 
 # extensions required by FluxCalculator (partitioned fluxes)
-function FluxCalculator.update_turbulent_fluxes_point!(
-    sim::SlabOceanSimulation,
-    fields::NamedTuple,
-    colidx::CC.Fields.ColumnIndex,
-)
+function FluxCalculator.update_turbulent_fluxes!(sim::SlabOceanSimulation, fields::NamedTuple)
     (; F_turb_energy) = fields
-    @. sim.integrator.p.F_turb_energy[colidx] = F_turb_energy
+    @. sim.integrator.p.F_turb_energy = F_turb_energy
 end
 
 """

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -24,7 +24,7 @@ export PartitionedStateFluxes,
     BulkScheme,
     partitioned_turbulent_fluxes!,
     get_surface_params,
-    update_turbulent_fluxes_point!,
+    update_turbulent_fluxes!,
     water_albedo_from_atmosphere!
 
 """
@@ -107,7 +107,7 @@ end
     partitioned_turbulent_fluxes!(model_sims::NamedTuple, fields::NamedTuple, boundary_space::CC.Spaces.AbstractSpace, surface_scheme, thermo_params::TD.Parameters.ThermodynamicsParameters)
 
 The current setup calculates the aerodynamic fluxes in the coupler (assuming no regridding is needed)
-using adapter function `get_surface_fluxes_point!`, which calls `SurfaceFluxes.jl`. The coupler saves
+using adapter function `get_surface_fluxes!`, which calls `SurfaceFluxes.jl`. The coupler saves
 the area-weighted sums of the fluxes.
 
 Args:
@@ -143,70 +143,65 @@ function partitioned_turbulent_fluxes!(
     csf.F_turb_energy .*= FT(0)
     csf.F_turb_moisture .*= FT(0)
 
-    # iterate over all columns (when regridding, this will need to change)
-    CC.Fields.bycolumn(boundary_space) do colidx
-        # atmos state of center level 1
-        z_int = Interfacer.get_field(atmos_sim, Val(:height_int), colidx)
-        uₕ_int = Interfacer.get_field(atmos_sim, Val(:uv_int), colidx)
-        thermo_state_int = Interfacer.get_field(atmos_sim, Val(:thermo_state_int), colidx)
-        z_sfc = Interfacer.get_field(atmos_sim, Val(:height_sfc), colidx)
+    # atmos state of center level 1
+    z_int = Interfacer.get_field(atmos_sim, Val(:height_int))
+    uₕ_int = Interfacer.get_field(atmos_sim, Val(:uv_int))
+    thermo_state_int = Interfacer.get_field(atmos_sim, Val(:thermo_state_int))
+    z_sfc = Interfacer.get_field(atmos_sim, Val(:height_sfc))
 
-        for sim in model_sims
-            # iterate over all surface models with non-zero area fractions
-            if sim isa Interfacer.SurfaceModelSimulation
-                # get area fraction (min = 0, max = 1)
-                area_fraction = Interfacer.get_field(sim, Val(:area_fraction), colidx)
-                # get area mask [0, 1], where area_mask = 1 if area_fraction > 0
-                area_mask = Regridder.binary_mask.(area_fraction)
+    for sim in model_sims
+        # iterate over all surface models
+        if sim isa Interfacer.SurfaceModelSimulation
+            # get area fraction (min = 0, max = 1)
+            area_fraction = Interfacer.get_field(sim, Val(:area_fraction))
+            # get area mask [0, 1], where area_mask = 1 if area_fraction > 0
+            area_mask = Regridder.binary_mask.(area_fraction)
 
-                if !iszero(parent(area_mask))
+            thermo_state_sfc = FluxCalculator.surface_thermo_state(sim, thermo_params, thermo_state_int)
 
-                    thermo_state_sfc = surface_thermo_state(sim, thermo_params, thermo_state_int, colidx)
+            # set inputs based on whether the surface_scheme is `MoninObukhovScheme` or `BulkScheme`
+            surface_params = FluxCalculator.get_surface_params(atmos_sim)
+            scheme_properties = FluxCalculator.get_scheme_properties(surface_scheme, sim)
 
-                    # set inputs based on whether the surface_scheme is `MoninObukhovScheme` or `BulkScheme`
-                    surface_params = get_surface_params(atmos_sim)
-                    scheme_properties = get_scheme_properties(surface_scheme, sim, colidx)
-                    input_args = (;
-                        thermo_state_sfc,
-                        thermo_state_int,
-                        uₕ_int,
-                        z_int,
-                        z_sfc,
-                        scheme_properties,
-                        surface_params,
-                        surface_scheme,
-                        colidx,
-                    )
-                    inputs = surface_inputs(surface_scheme, input_args)
+            input_args = (;
+                thermo_state_sfc,
+                thermo_state_int,
+                uₕ_int,
+                z_int,
+                z_sfc,
+                scheme_properties,
+                surface_params,
+                surface_scheme,
+                boundary_space,
+            )
+            inputs = FluxCalculator.surface_inputs(surface_scheme, input_args)
 
-                    # calculate the surface fluxes
-                    fluxes = get_surface_fluxes_point!(inputs, surface_params)
-                    (; F_turb_ρτxz, F_turb_ρτyz, F_shf, F_lhf, F_turb_moisture) = fluxes
+            # calculate the surface fluxes
+            fluxes = FluxCalculator.get_surface_fluxes!(inputs, surface_params)
+            (; F_turb_ρτxz, F_turb_ρτyz, F_shf, F_lhf, F_turb_moisture) = fluxes
 
-                    # perform additional diagnostics if required
-                    differentiate_turbulent_fluxes!(sim, (thermo_params, input_args, fluxes))
+            # perform additional diagnostics if required
+            FluxCalculator.differentiate_turbulent_fluxes!(sim, (thermo_params, input_args, fluxes))
 
-                    # update fluxes in the coupler
-                    fields = (;
-                        F_turb_ρτxz = F_turb_ρτxz,
-                        F_turb_ρτyz = F_turb_ρτyz,
-                        F_turb_energy = F_shf .+ F_lhf,
-                        F_turb_moisture = F_turb_moisture,
-                    )
+            # update fluxes in the coupler
+            fields = (;
+                F_turb_ρτxz = F_turb_ρτxz,
+                F_turb_ρτyz = F_turb_ρτyz,
+                F_turb_energy = F_shf .+ F_lhf,
+                F_turb_moisture = F_turb_moisture,
+            )
 
-                    # update the fluxes of this surface model
-                    update_turbulent_fluxes_point!(sim, fields, colidx)
+            # update the fluxes of this surface model
+            FluxCalculator.update_turbulent_fluxes!(sim, fields)
 
-                    # add the flux contributing from this surface to the coupler field
-                    @. csf.F_turb_ρτxz[colidx] += F_turb_ρτxz * area_fraction * area_mask
-                    @. csf.F_turb_ρτyz[colidx] += F_turb_ρτyz * area_fraction * area_mask
-                    @. csf.F_turb_energy[colidx] += (F_shf .+ F_lhf) * area_fraction * area_mask
-                    @. csf.F_turb_moisture[colidx] += F_turb_moisture * area_fraction * area_mask
-
-                end
-            end
+            # add the flux contributing from this surface to the coupler field
+            # note that the fluxes are area-weighted, so if a surface model is
+            #  not present at this point, the fluxes are zero
+            @. csf.F_turb_ρτxz += F_turb_ρτxz * area_fraction * area_mask
+            @. csf.F_turb_ρτyz += F_turb_ρτyz * area_fraction * area_mask
+            @. csf.F_turb_energy += (F_shf .+ F_lhf) * area_fraction * area_mask
+            @. csf.F_turb_moisture += F_turb_moisture * area_fraction * area_mask
         end
-
     end
 
     # TODO: add allowable bounds here, check explicitly that all fluxes are equal
@@ -218,25 +213,21 @@ struct BulkScheme <: AbstractSurfaceFluxScheme end
 struct MoninObukhovScheme <: AbstractSurfaceFluxScheme end
 
 """
-    get_scheme_properties(scheme::AbstractSurfaceFluxScheme, sim::Interfacer.SurfaceModelSimulation, colidx::CC.Fields.ColumnIndex)
+    get_scheme_properties(scheme::AbstractSurfaceFluxScheme, sim::Interfacer.SurfaceModelSimulation)
 
 Returns the scheme-specific properties for the surface model simulation `sim`.
 """
-function get_scheme_properties(::BulkScheme, sim::Interfacer.SurfaceModelSimulation, colidx::CC.Fields.ColumnIndex)
-    Ch = Interfacer.get_field(sim, Val(:heat_transfer_coefficient), colidx)
-    Cd = Interfacer.get_field(sim, Val(:drag_coefficient), colidx)
-    beta = Interfacer.get_field(sim, Val(:beta), colidx)
+function get_scheme_properties(::BulkScheme, sim::Interfacer.SurfaceModelSimulation)
+    Ch = Interfacer.get_field(sim, Val(:heat_transfer_coefficient))
+    Cd = Interfacer.get_field(sim, Val(:drag_coefficient))
+    beta = Interfacer.get_field(sim, Val(:beta))
     FT = eltype(Ch)
     return (; z0b = FT(0), z0m = FT(0), Ch = Ch, Cd = Cd, beta = beta, gustiness = FT(1))
 end
-function get_scheme_properties(
-    ::MoninObukhovScheme,
-    sim::Interfacer.SurfaceModelSimulation,
-    colidx::CC.Fields.ColumnIndex,
-)
-    z0m = Interfacer.get_field(sim, Val(:roughness_momentum), colidx)
-    z0b = Interfacer.get_field(sim, Val(:roughness_buoyancy), colidx)
-    beta = Interfacer.get_field(sim, Val(:beta), colidx)
+function get_scheme_properties(::MoninObukhovScheme, sim::Interfacer.SurfaceModelSimulation)
+    z0m = Interfacer.get_field(sim, Val(:roughness_momentum))
+    z0b = Interfacer.get_field(sim, Val(:roughness_buoyancy))
+    beta = Interfacer.get_field(sim, Val(:beta))
     FT = eltype(z0m)
     return (; z0b = z0b, z0m = z0m, Ch = FT(0), Cd = FT(0), beta = beta, gustiness = FT(1))
 end
@@ -248,61 +239,87 @@ Returns the inputs for the surface model simulation `sim`.
 """
 function surface_inputs(::BulkScheme, input_args::NamedTuple)
 
-    (; thermo_state_sfc, thermo_state_int, uₕ_int, z_int, z_sfc, scheme_properties) = input_args
+    (; thermo_state_sfc, thermo_state_int, uₕ_int, z_int, z_sfc, scheme_properties, boundary_space) = input_args
     FT = CC.Spaces.undertype(axes(z_sfc))
+    (; Ch, Cd, beta, gustiness) = scheme_properties
 
-    (; z0b, z0m, Ch, Cd, beta, gustiness) = scheme_properties
+    # Extract the underlying data layouts of each field
+    # Note: this is a bit "dangerous" because it circumvents ClimaCore, but
+    #  it allows us to broadcast over fields on slightly different spaces
+    fv = CC.Fields.field_values
+    z_int_fv = fv(z_int)
+    uₕ_int_fv = fv(uₕ_int)
+    thermo_state_int_fv = fv(thermo_state_int)
+    z_sfc_fv = fv(z_sfc)
+    thermo_state_sfc_fv = fv(thermo_state_sfc)
+    beta_fv = fv(beta)
+
     # wrap state values
-    return @. SF.Coefficients(
-        SF.StateValues(z_int, uₕ_int, thermo_state_int), # state_in
+    result = @. SF.Coefficients(
+        SF.StateValues(z_int_fv, uₕ_int_fv, thermo_state_int_fv), # state_in
         SF.StateValues(                                   # state_sfc
-            z_sfc,
+            z_sfc_fv,
             StaticArrays.SVector(FT(0), FT(0)),
-            thermo_state_sfc,
+            thermo_state_sfc_fv,
         ),
         Cd,                                     # Cd
         Ch,                                     # Ch
         gustiness,                              # gustiness
-        beta,                                   # beta
+        beta_fv,                                # beta
     )
+
+    # Put the result data layout back onto the surface space
+    return CC.Fields.Field(result, boundary_space)
 end
 function surface_inputs(::MoninObukhovScheme, input_args::NamedTuple)
-    (; thermo_state_sfc, thermo_state_int, uₕ_int, z_int, z_sfc, scheme_properties) = input_args
+    (; thermo_state_sfc, thermo_state_int, uₕ_int, z_int, z_sfc, scheme_properties, boundary_space) = input_args
     FT = CC.Spaces.undertype(axes(z_sfc))
-    (; z0b, z0m, Ch, Cd, beta, gustiness) = scheme_properties
+    (; z0b, z0m, beta, gustiness) = scheme_properties
 
-    # wrap state values
-    return @. SF.ValuesOnly(
-        SF.StateValues(z_int, uₕ_int, thermo_state_int), # state_in
+    # Extract the underlying data layouts of each field
+    # Note: this is a bit "dangerous" because it circumvents ClimaCore, but
+    #  it allows us to broadcast over fields on slightly different spaces
+    fv = CC.Fields.field_values
+    z_int_fv = fv(z_int)
+    uₕ_int_fv = uₕ_int isa CC.Fields.Field ? fv(uₕ_int) : uₕ_int
+    thermo_state_int_fv = fv(thermo_state_int)
+    z_sfc_fv = fv(z_sfc)
+    thermo_state_sfc_fv = fv(thermo_state_sfc)
+    beta_fv = beta isa CC.Fields.Field ? fv(beta) : beta
+
+    # Compute state values
+    result = @. SF.ValuesOnly(
+        SF.StateValues(z_int_fv, uₕ_int_fv, thermo_state_int_fv), # state_in
         SF.StateValues(                                  # state_sfc
-            z_sfc,
+            z_sfc_fv,
             StaticArrays.SVector(FT(0), FT(0)),
-            thermo_state_sfc,
+            thermo_state_sfc_fv,
         ),
-        z0m,                                    # z0m
-        z0b,                                    # z0b
+        z0m,                                   # z0m
+        z0b,                                   # z0b
         gustiness,                             # gustiness
-        beta,                                   # beta
+        beta_fv,                               # beta
     )
 
+    # Put the result data layout back onto the surface space
+    return CC.Fields.Field(result, boundary_space)
 end
 
 """
-    surface_thermo_state(sim::Interfacer.SurfaceModelSimulation, thermo_params::TD.Parameters.ThermodynamicsParameters, thermo_state_int, colidx::CC.Fields.ColumnIndex)
+    surface_thermo_state(sim::Interfacer.SurfaceModelSimulation, thermo_params::TD.Parameters.ThermodynamicsParameters, thermo_state_int)
 
 Returns the surface parameters for the surface model simulation `sim`. The default is assuming saturated surfaces, unless an extension is defined for the given `SurfaceModelSimulation`.
 """
 function surface_thermo_state(
     sim::Interfacer.SurfaceModelSimulation,
     thermo_params::TD.Parameters.ThermodynamicsParameters,
-    thermo_state_int,
-    colidx::CC.Fields.ColumnIndex;
+    thermo_state_int;
     δT_sfc = 0,
 )
     FT = eltype(parent(thermo_state_int))
     @warn("Simulation " * Interfacer.name(sim) * " uses the default thermo (saturated) surface state", maxlog = 10)
     # get surface temperature (or perturbed surface temperature for differentiation)
-    T_sfc = Interfacer.get_field(sim, Val(:surface_temperature), colidx) .+ FT(δT_sfc)
+    T_sfc = Interfacer.get_field(sim, Val(:surface_temperature)) .+ FT(δT_sfc)
     ρ_sfc = extrapolate_ρ_to_sfc.(thermo_params, thermo_state_int, T_sfc) # ideally the # calculate elsewhere, here just getter...
     q_sfc = TD.q_vap_saturation_generic.(thermo_params, T_sfc, ρ_sfc, TD.Liquid()) # default: saturated liquid surface
     @. TD.PhaseEquil_ρTq.(thermo_params, ρ_sfc, T_sfc, q_sfc)
@@ -323,14 +340,13 @@ function extrapolate_ρ_to_sfc(thermo_params, ts_in, T_sfc)
 end
 
 """
-    get_surface_fluxes_point!(inputs, surface_params::SF.Parameters.SurfaceFluxesParameters)
+    get_surface_fluxes!(inputs, surface_params::SF.Parameters.SurfaceFluxesParameters)
 
 Uses SurfaceFluxes.jl to calculate turbulent surface fluxes. It should be atmos model agnostic, and columnwise.
 """
-function get_surface_fluxes_point!(inputs, surface_params::SF.Parameters.SurfaceFluxesParameters)
-
+function get_surface_fluxes!(inputs, surface_params::SF.Parameters.SurfaceFluxesParameters)
     # calculate all fluxes (saturated surface conditions)
-    outputs = @. SF.surface_conditions(surface_params, inputs)
+    outputs = SF.surface_conditions.(surface_params, inputs)
 
     # drag
     F_turb_ρτxz = outputs.ρτxz
@@ -341,7 +357,15 @@ function get_surface_fluxes_point!(inputs, surface_params::SF.Parameters.Surface
     F_lhf = outputs.lhf
 
     # moisture
-    F_turb_moisture = @. SF.evaporation(surface_params, inputs, outputs.Ch)
+    F_turb_moisture = SF.evaporation.(surface_params, inputs, outputs.Ch)
+
+    # At locations where this surface model is not evaluated, we get `NaN` for
+    # surface fluxes. In that case, we replace the values with 0.
+    @. F_turb_ρτxz = ifelse(isnan(F_turb_ρτxz), zero(F_turb_ρτxz), F_turb_ρτxz)
+    @. F_turb_ρτyz = ifelse(isnan(F_turb_ρτyz), zero(F_turb_ρτyz), F_turb_ρτyz)
+    @. F_shf = ifelse(isnan(F_shf), zero(F_shf), F_shf)
+    @. F_lhf = ifelse(isnan(F_lhf), zero(F_lhf), F_lhf)
+    @. F_turb_moisture = ifelse(isnan(F_turb_moisture), zero(F_turb_moisture), F_turb_moisture)
 
     return (;
         F_turb_ρτxz = F_turb_ρτxz,
@@ -368,21 +392,17 @@ function get_surface_params(atmos_sim::Interfacer.AtmosModelSimulation)
 end
 
 """
-    update_turbulent_fluxes_point!(sim::Interfacer.SurfaceModelSimulation, fields::NamedTuple, colidx::CC.Fields.ColumnIndex)
+    update_turbulent_fluxes!(sim::Interfacer.SurfaceModelSimulation, fields::NamedTuple)
 
 Updates the fluxes in the surface model simulation `sim` with the fluxes in `fields`.
 """
-function update_turbulent_fluxes_point!(
-    sim::Interfacer.SurfaceModelSimulation,
-    fields::NamedTuple,
-    colidx::CC.Fields.ColumnIndex,
-)
+function update_turbulent_fluxes!(sim::Interfacer.SurfaceModelSimulation, fields::NamedTuple)
     return error(
-        "update_turbulent_fluxes_point! is required to be dispatched on" *
-        Interfacer.name(sim) *
-        ", but no method defined",
+        "update_turbulent_fluxes! is required to be dispatched on" * Interfacer.name(sim) * ", but no method defined",
     )
 end
+
+update_turbulent_fluxes!(sim::Interfacer.SurfaceStub, fields::NamedTuple) = nothing
 
 """
     differentiate_turbulent_fluxes!(sim::Interfacer.SurfaceModelSimulation, args)

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -169,19 +169,6 @@ get_field(sim::ComponentModelSimulation, val::Val) = get_field_error(sim, val)
 get_field_error(sim, val::Val{X}) where {X} = error("undefined field `$X` for " * name(sim))
 
 """
-    get_field(::ComponentModelSimulation, ::Val, colidx::CC.Fields.ColumnIndex)
-
-Extension of `get_field(::ComponentModelSimulation, ::Val)`, indexing into the specified colum index.
-"""
-function get_field(sim::ComponentModelSimulation, val::Val, colidx::CC.Fields.ColumnIndex)
-    if get_field(sim, val) isa AbstractFloat
-        get_field(sim, val)
-    else
-        get_field(sim, val)[colidx]
-    end
-end
-
-"""
     update_field!(::AtmosModelSimulation, ::Val, _...)
 
 Default functions for updating fields at each timestep in an atmosphere

--- a/src/surface_stub.jl
+++ b/src/surface_stub.jl
@@ -87,8 +87,3 @@ reinit!(::SurfaceStub) = nothing
 The stub surface simulation is not updated by this function. Extends `SciMLBase.step!`.
 """
 step!(::SurfaceStub, _) = nothing
-
-
-## Extensions of FluxCalculator.jl functions
-
-update_turbulent_fluxes_point!(sim::SurfaceStub, fields::NamedTuple, colidx::CC.Fields.ColumnIndex) = nothing

--- a/test/component_model_tests/eisenman_seaice_tests.jl
+++ b/test/component_model_tests/eisenman_seaice_tests.jl
@@ -36,9 +36,8 @@ for FT in (Float32, Float64)
         Ya.F_rad .= 0
         Ya.F_turb .= 0
 
-        CC.Fields.bycolumn(boundary_space) do colidx
-            solve_eisenman_model!(Y[colidx], Ya[colidx], params, thermo_params, Δt)
-        end
+        solve_eisenman_model!(Y, Ya, params, thermo_params, Δt)
+
         @test all(parent(Ya.e_base) .≈ 0)
         @test all(parent(Y.T_ml) .≈ params_ice.T_base)
         @test all(parent(Y.T_sfc) .≈ params_ice.T_base)
@@ -62,9 +61,7 @@ for FT in (Float32, Float64)
         ∂F_atm∂T_sfc = get_∂F_rad_energy∂T_sfc(Y.T_sfc, params_ice) .+ Ya.∂F_turb_energy∂T_sfc
         @. Ya.F_rad = (1 - params_ice.α) * params_ice.σ * Y.T_sfc .^ 4 # outgoing longwave
 
-        CC.Fields.bycolumn(boundary_space) do colidx
-            solve_eisenman_model!(Y[colidx], Ya[colidx], params, thermo_params, Δt)
-        end
+        solve_eisenman_model!(Y, Ya, params, thermo_params, Δt)
 
         F_atm = @. Ya.F_rad + Ya.F_turb
 
@@ -93,9 +90,7 @@ for FT in (Float32, Float64)
         Y.T_sfc .= params_ice.T_base
         Y.T_ml .= params_ice.T_base
 
-        CC.Fields.bycolumn(boundary_space) do colidx
-            solve_eisenman_model!(Y[colidx], Ya[colidx], params, thermo_params, Δt)
-        end
+        solve_eisenman_model!(Y, Ya, params, thermo_params, Δt)
 
         F_atm = @. Ya.F_rad + Ya.F_turb
         ∂F_atm∂T_sfc = 0
@@ -128,9 +123,7 @@ for FT in (Float32, Float64)
         Y.T_sfc .= params_ice.T_base .- 1
         T_sfc_0 = deepcopy(Y.T_sfc)
 
-        CC.Fields.bycolumn(boundary_space) do colidx
-            solve_eisenman_model!(Y[colidx], Ya[colidx], params, thermo_params, Δt)
-        end
+        solve_eisenman_model!(Y, Ya, params, thermo_params, Δt)
 
         F_atm = @. Ya.F_rad + Ya.F_turb
         ∂F_atm∂T_sfc = 0
@@ -163,9 +156,7 @@ for FT in (Float32, Float64)
         Y.T_ml .= params_ice.T_base
         T_ml_0 = deepcopy(Y.T_ml)
 
-        CC.Fields.bycolumn(boundary_space) do colidx
-            solve_eisenman_model!(Y[colidx], Ya[colidx], params, thermo_params, Δt)
-        end
+        solve_eisenman_model!(Y, Ya, params, thermo_params, Δt)
 
         F_atm = @. Ya.F_rad + Ya.F_turb
 
@@ -193,9 +184,7 @@ for FT in (Float32, Float64)
         Ya.F_turb .= 0
         Ya.F_rad .= @. (1 - params_ice.α) * params_ice.σ * Y.T_sfc^4 - 300
 
-        CC.Fields.bycolumn(boundary_space) do colidx
-            solve_eisenman_model!(Y[colidx], Ya[colidx], params, thermo_params, Δt)
-        end
+        solve_eisenman_model!(Y, Ya, params, thermo_params, Δt)
 
         F_atm = @. Ya.F_rad + Ya.F_turb
 
@@ -223,9 +212,7 @@ for FT in (Float32, Float64)
         # net outgoing longwave
         Ya.F_rad .= @. (1 - params_ice.α) * params_ice.σ * Y.T_sfc^4
 
-        CC.Fields.bycolumn(boundary_space) do colidx
-            solve_eisenman_model!(Y[colidx], Ya[colidx], params, thermo_params, Δt)
-        end
+        solve_eisenman_model!(Y, Ya, params, thermo_params, Δt)
 
         F_atm = @. Ya.F_rad + Ya.F_turb
         ∂F_atm∂T_sfc = get_∂F_rad_energy∂T_sfc(T_sfc_0, params_ice) .+ Ya.∂F_turb_energy∂T_sfc
@@ -264,9 +251,7 @@ for FT in (Float32, Float64)
         Ya.F_turb .= 0
         Ya.F_rad .= 0
 
-        CC.Fields.bycolumn(boundary_space) do colidx
-            solve_eisenman_model!(Y[colidx], Ya[colidx], params, thermo_params, Δt)
-        end
+        solve_eisenman_model!(Y, Ya, params, thermo_params, Δt)
 
         @test all(parent(Ya.e_base) .≈ params_ice.C0_base * ΔT_ml * FT(Δt)) # non-zero contribution from basal flux
         T_ml_new = T_ml_0 .- params_ice.C0_base .* ΔT_ml * FT(Δt) / (params_ocean.h * params_ocean.ρ * params_ocean.c)
@@ -298,9 +283,7 @@ for FT in (Float32, Float64)
         Ya.F_turb .= 0
         Ya.F_rad .= 0
 
-        CC.Fields.bycolumn(boundary_space) do colidx
-            solve_eisenman_model!(Y[colidx], Ya[colidx], params, thermo_params, Δt)
-        end
+        solve_eisenman_model!(Y, Ya, params, thermo_params, Δt)
 
         @test all(parent(Ya.e_base) .≈ 0) # no contribution from basal flux
         T_ml_new = @. T_ml_0 + Ya.ocean_qflux * FT(Δt) / (params_ocean.h * params_ocean.ρ * params_ocean.c)

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -56,10 +56,9 @@ for FT in (Float32, Float64)
         space = TestHelper.create_space(FT)
         for sim in (DummySimulation(space), DummySimulation2(space), DummySimulation3(space))
             # field
-            colidx = CC.Fields.ColumnIndex{2}((1, 1), 73)
-            @test Array(parent(Interfacer.get_field(sim, Val(:var), colidx)))[1] == FT(1)
+            @test Array(parent(Interfacer.get_field(sim, Val(:var))))[1] == FT(1)
             # float
-            @test Interfacer.get_field(sim, Val(:var_float), colidx) == FT(2)
+            @test Interfacer.get_field(sim, Val(:var_float)) == FT(2)
         end
     end
 
@@ -252,30 +251,3 @@ end
     FT = Float32
     @test isnothing(Interfacer.reinit!(Interfacer.SurfaceStub(FT(0))))
 end
-
-@testset "SurfaceStub update_turbulent_fluxes_point!" begin
-    FT = Float32
-    colidx = CC.Fields.ColumnIndex{2}((1, 1), 73) # arbitrary index
-    @test isnothing(Interfacer.update_turbulent_fluxes_point!(Interfacer.SurfaceStub(FT(0)), (;), colidx))
-end
-
-# # Test that update_field! gives correct warnings for unextended fields
-# for value in (
-#     :air_density,
-#     :air_temperature,
-#     :energy,
-#     :height_int,
-#     :height_sfc,
-#     :liquid_precipitation,
-#     :radiative_energy_flux_sfc,
-#     :radiative_energy_flux_toa,
-#     :snow_precipitation,
-#     :turbulent_energy_flux,
-#     :turbulent_moisture_flux,
-#     :thermo_state_int,
-#     :uv_int,
-#     :water,
-# )
-#     val = Val(value)
-#     @test_throws ErrorException("undefined field `$value` for " * name(sim)) get_field(sim, val)
-# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ end
 @safetestset "FieldExchanger tests" begin
     include("field_exchanger_tests.jl")
 end
-gpu_broken || @safetestset "FluxCalculator tests" begin
+@safetestset "FluxCalculator tests" begin
     include("flux_calculator_tests.jl")
 end
 gpu_broken || @safetestset "Diagnostics tests" begin


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #736

## Results
- SYPD for partitioned turbulent fluxes run increased from ~2.5 to ~3.7 on CPU (not running long enough for consistent SYPD estimates, but definitely increased)
- partitioned turbulent fluxes now GPU-compatible
- results are identical to main


## Content: `bycolumn` removed from
- [x] `experiments/ClimaEarth/components/atmosphere/climaatmos_extra_diags.jl`
- [x] `src/FluxCalculator.jl.update_turbulent_fluxes` (used for partitioned turbulent fluxes)
  - and extended methods for component models
- [x] `get_field`, `update_field!` methods for component models
- [x] `experiments/ClimaEarth/components/ocean/eisenman_seaice.jl` `solve_eisenman_model`


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
