### PR TITLE
debug land albedo regridding

### DIFF
--- a/src/Regridder.jl
+++ b/src/Regridder.jl
@@ -169,11 +169,9 @@ function hdwrite_regridfile_rll_to_cgll(
     # If doesn't make sense to regrid with GPUs/MPI processes
     cpu_singleton_context = ClimaComms.SingletonCommsContext(ClimaComms.CPUSingleThreaded())
 
-    topology = CC.Topologies.Topology2D(
-        cpu_singleton_context,
-        CC.Spaces.topology(space2d).mesh,
-        CC.Topologies.spacefillingcurve(CC.Spaces.topology(space2d).mesh),
-    )
+    # Note: this topology gives us `space == space_undistributed` in the undistributed
+    # case (as desired), which wouldn't hold if we used `spacefillingcurve` here.
+    topology = CC.Topologies.Topology2D(cpu_singleton_context, CC.Spaces.topology(space2d).mesh)
     Nq = CC.Spaces.Quadratures.polynomial_degree(CC.Spaces.quadrature_style(space2d)) + 1
 
     space2d_undistributed = CC.Spaces.SpectralElementSpace2D(topology, CC.Spaces.Quadratures.GLL{Nq}())

--- a/test/TestHelper.jl
+++ b/test/TestHelper.jl
@@ -41,9 +41,9 @@ function create_space(
     mesh = CC.Meshes.EquiangularCubedSphere(domain, ne)
 
     if comms_ctx isa ClimaComms.SingletonCommsContext
-        topology = CC.Topologies.Topology2D(comms_ctx, mesh, CC.Topologies.spacefillingcurve(mesh))
+        topology = CC.Topologies.Topology2D(comms_ctx, mesh)
     else
-        topology = CC.Topologies.DistributedTopology2D(comms_ctx, mesh, CC.Topologies.spacefillingcurve(mesh))
+        topology = CC.Topologies.DistributedTopology2D(comms_ctx, mesh)
     end
 
     Nq = polynomial_degree + 1

--- a/test/bcreader_tests.jl
+++ b/test/bcreader_tests.jl
@@ -6,7 +6,7 @@ import Dates
 import NCDatasets
 import ClimaComms
 import ClimaCore as CC
-import ClimaCoupler: Regridder, BCReader, TimeManager, Interfacer
+import ClimaCoupler: Regridder, BCReader, TimeManager, Interfacer, TestHelper
 
 # get the paths to the necessary data files - sst map, land sea mask
 include(joinpath(@__DIR__, "..", "artifacts", "artifact_funcs.jl"))
@@ -148,14 +148,15 @@ for FT in (Float32, Float64)
             tspan = (Int(1), Int(90 * 86400)) # Jan-Mar
             Δt = Int(1 * 3600)
 
-            radius = FT(6731e3)
-            Nq = 4
-            domain = CC.Domains.SphereDomain(radius)
-            mesh = CC.Meshes.EquiangularCubedSphere(domain, 4)
-            topology = CC.Topologies.DistributedTopology2D(comms_ctx, mesh, CC.Topologies.spacefillingcurve(mesh))
-            quad = CC.Spaces.Quadratures.GLL{Nq}()
-            boundary_space_t = CC.Spaces.SpectralElementSpace2D(topology, quad)
+            # radius = FT(6731e3)
+            # Nq = 4
+            # domain = CC.Domains.SphereDomain(radius)
+            # mesh = CC.Meshes.EquiangularCubedSphere(domain, 4)
+            # topology = CC.Topologies.DistributedTopology2D(comms_ctx, mesh)
+            # quad = CC.Spaces.Quadratures.GLL{Nq}()
+            # boundary_space_t = CC.Spaces.SpectralElementSpace2D(topology, quad)
 
+            boundary_space_t = TestHelper.create_space(FT, comms_ctx = comms_ctx, nz = 1)
             land_fraction_t = CC.Fields.zeros(boundary_space_t)
             dummy_data = (; test_data = zeros(axes(land_fraction_t)))
 

--- a/test/mpi_tests/bcreader_mpi_tests.jl
+++ b/test/mpi_tests/bcreader_mpi_tests.jl
@@ -26,13 +26,14 @@ ClimaComms.barrier(comms_ctx)
 @testset "test bcf_info_init with MPI" begin
     for FT in (Float32, Float64)
         # setup for test
-        radius = FT(6731e3)
-        Nq = 4
-        domain = CC.Domains.SphereDomain(radius)
-        mesh = CC.Meshes.EquiangularCubedSphere(domain, 4)
-        topology = CC.Topologies.DistributedTopology2D(comms_ctx, mesh, CC.Topologies.spacefillingcurve(mesh))
-        quad = CC.Spaces.Quadratures.GLL{Nq}()
-        boundary_space_t = CC.Spaces.SpectralElementSpace2D(topology, quad)
+        # radius = FT(6731e3)
+        # Nq = 4
+        # domain = CC.Domains.SphereDomain(radius)
+        # mesh = CC.Meshes.EquiangularCubedSphere(domain, 4)
+        # topology = CC.Topologies.DistributedTopology2D(comms_ctx, mesh)
+        # quad = CC.Spaces.Quadratures.GLL{Nq}()
+        # boundary_space_t = CC.Spaces.SpectralElementSpace2D(topology, quad)
+        boundary_space_t = TestHelper.create_space(FT, comms_ctx = comms_ctx, nz = 1)
         land_fraction_t = CC.Fields.zeros(boundary_space_t)
 
         datafile_rll = sst_data
@@ -91,13 +92,14 @@ end
         tspan = (1, 90 * 86400) # Jan-Mar
         Δt = 1 * 3600
 
-        radius = FT(6731e3)
-        Nq = 4
-        domain = CC.Domains.SphereDomain(radius)
-        mesh = CC.Meshes.EquiangularCubedSphere(domain, 4)
-        topology = CC.Topologies.DistributedTopology2D(comms_ctx, mesh, CC.Topologies.spacefillingcurve(mesh))
-        quad = CC.Spaces.Quadratures.GLL{Nq}()
-        boundary_space_t = CC.Spaces.SpectralElementSpace2D(topology, quad)
+        # radius = FT(6731e3)
+        # Nq = 4
+        # domain = CC.Domains.SphereDomain(radius)
+        # mesh = CC.Meshes.EquiangularCubedSphere(domain, 4)
+        # topology = CC.Topologies.DistributedTopology2D(comms_ctx, mesh, CC.Topologies.spacefillingcurve(mesh))
+        # quad = CC.Spaces.Quadratures.GLL{Nq}()
+        # boundary_space_t = CC.Spaces.SpectralElementSpace2D(topology, quad)
+        boundary_space_t = TestHelper.create_space(FT, comms_ctx = comms_ctx, nz = 1)
 
         land_fraction_t = CC.Fields.zeros(boundary_space_t)
         dummy_data = (; test_data = zeros(axes(land_fraction_t)))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
see #764 description and thread for details


what we know:
- changing the `regridder_type` passed to the albedo constructor between InterpolationRegridder and TempestRegridder changes the quality of the plot produced (only tempest is messed up)
- tempest produces an unrealistic plot for both the temporal and static maps,
  - this is true whether we use a space constructed with `spacefillingcurve` in ClimaCoupler or not

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

## Plots
- AMIP and slabplanet look the same
- plot looks the same after init and after 1day simulation
- mostly using `slabplanet_temporal_map.yml` config with `h_elem: 16`, but tested with AMIP too
### Interpolations regridder
![albedo_init_amip](https://github.com/CliMA/ClimaCoupler.jl/assets/51397186/3a18878f-55cf-4e0b-9299-b7d6b9ec6cc6)

### Tempest regridder
looks the same with or without `spacefillingcurve` in ClimaCoupler
![slabplanet_tempest_albedo_before_step](https://github.com/CliMA/ClimaCoupler.jl/assets/51397186/61a5a14e-5981-410e-b9ef-870a79d8ce40)

### Static map
#### Interpolation regridder
![static_map_helem16_before_solve](https://github.com/CliMA/ClimaCoupler.jl/assets/51397186/e7e2b0d9-2f94-42d4-9682-e528bce1a1fb)

#### Tempest regridder
![tempest_static_map_before_solve](https://github.com/CliMA/ClimaCoupler.jl/assets/51397186/5147de3a-eabf-4efc-b9e1-3d68254b1fc3)


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
