### PR TITLE
make restart run soft fail

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -511,6 +511,7 @@ steps:
         command: "test/mpi_tests/test_sbatch_script.sh"
         agents:
           slurm_ntasks: 1
+        soft_fail: true
 
   - wait
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Our restart run nondeterministically fails, due to issues with our output directory infrastructure. This delays the merge of unrelated PRs (e.g. [this build](https://buildkite.com/clima/climacoupler-ci/builds/3929#_)), so I want to make it a soft fail.

