### PR TITLE
run benchmarks for 24h simulation time

### DIFF
--- a/config/benchmark_configs/amip_diagedmf.yml
+++ b/config/benchmark_configs/amip_diagedmf.yml
@@ -11,6 +11,6 @@ mode_name: "amip"
 mono_surface: false
 monthly_checkpoint: false
 start_date: "19790301"
-t_end: "12hours"
+t_end: "1days"
 turb_flux_partition: "CombinedStateFluxesMOST"
 use_coupler_diagnostics: false

--- a/config/benchmark_configs/climaatmos.yml
+++ b/config/benchmark_configs/climaatmos.yml
@@ -14,7 +14,7 @@ precip_model: 0M
 prognostic_tke: true
 rad: allskywithclear
 surface_setup: DefaultMoninObukhov
-t_end: 12hours
+t_end: 1days
 turb_flux_partition: "CombinedStateFluxesMOST"
 vert_diff: "true"
 z_elem: 63

--- a/config/benchmark_configs/climaatmos_diagedmf.yml
+++ b/config/benchmark_configs/climaatmos_diagedmf.yml
@@ -22,7 +22,7 @@ precip_model: 0M
 prognostic_tke: true
 rad: allskywithclear
 surface_setup: DefaultMoninObukhov
-t_end: 12hours
+t_end: 1days
 toml: [toml/diagnostic_edmfx.toml]
 turbconv: diagnostic_edmfx
 z_elem: 63


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The benchmark runs have been set to run for 12 hours, but it looks like there's still some variability in SYPD at that point. Since we're iterating on the table output itself less now, it's probably worth it to increase the simulation length from 12 hours to 1 day.

The 2 original runs, AMIP and ClimaAtmos with diagnostic EDMF, seem to have a stable SYPD after 12 hours, but the newest ClimaAtmos without diagnostic EDMF seems to still have variability at 12 hours.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
