### PR TITLE
Pass context to FiniteDifferenceSpace

### DIFF
--- a/experiments/ClimaCore/heat-diffusion/run.jl
+++ b/experiments/ClimaCore/heat-diffusion/run.jl
@@ -195,8 +195,13 @@ domain_atm = CC.Domains.IntervalDomain(
     CC.Geometry.ZPoint{FT}(parameters.zmax_atm);
     boundary_names = (:bottom, :top),
 );
+context = CC.ClimaComms.context()
 mesh_atm = CC.Meshes.IntervalMesh(domain_atm, nelems = parameters.n); # struct, allocates face boundaries to 5,6: atmos
-center_space_atm = CC.Spaces.CenterFiniteDifferenceSpace(mesh_atm); # collection of the above, discretises space into FD and provides coords
+if pkgversion(CC) >= v"0.14.10"
+    center_space_atm = CC.Spaces.CenterFiniteDifferenceSpace(context, mesh_atm) # collection of the above, discretises space into FD and provides coords
+else
+    center_space_atm = CC.Spaces.CenterFiniteDifferenceSpace(mesh_atm) # collection of the above, discretises space into FD and provides coords
+end
 
 # - initialize prognostic variables, either as ClimaCore's Field objects or as Arrays
 T_atm_0 = CC.Fields.ones(FT, center_space_atm) .* parameters.T_atm_ini; # initiates a spatially uniform atm progostic var

--- a/experiments/ClimaCore/sea_breeze/atmos_rhs.jl
+++ b/experiments/ClimaCore/sea_breeze/atmos_rhs.jl
@@ -109,6 +109,7 @@ import TerminalLoggers
 
 import ClimaCore as CC
 import ClimaCore.Geometry: ⊗
+import ClimaComms
 
 Logging.global_logger(TerminalLoggers.TerminalLogger())
 
@@ -123,8 +124,13 @@ function hvspace_2D(xlim = (-π, π), zlim = (0, 4π), helem = 20, velem = 20, n
         CC.Geometry.ZPoint{FT}(zlim[2]);
         boundary_names = (:bottom, :top),
     )
+    context = ClimaComms.context()
     vertmesh = CC.Meshes.IntervalMesh(vertdomain, nelems = velem)
-    vert_center_space = CC.Spaces.CenterFiniteDifferenceSpace(vertmesh)
+    if pkgversion(CC) >= v"0.14.10"
+        vert_center_space = CC.Spaces.CenterFiniteDifferenceSpace(context, vertmesh)
+    else
+        vert_center_space = CC.Spaces.CenterFiniteDifferenceSpace(vertmesh)
+    end
 
     horzdomain =
         CC.Domains.IntervalDomain(CC.Geometry.XPoint{FT}(xlim[1]) .. CC.Geometry.XPoint{FT}(xlim[2]), periodic = true)

--- a/src/Regridder.jl
+++ b/src/Regridder.jl
@@ -179,7 +179,7 @@ function hdwrite_regridfile_rll_to_cgll(
     space2d_undistributed = CC.Spaces.SpectralElementSpace2D(topology, CC.Spaces.Quadratures.GLL{Nq}())
 
     if space isa CC.Spaces.ExtrudedFiniteDifferenceSpace
-        vert_center_space = CC.Spaces.CenterFiniteDifferenceSpace(CC.Spaces.vertical_topology(space).mesh)
+        vert_center_space = CC.Spaces.CenterFiniteDifferenceSpace(CC.Spaces.vertical_topology(space))
         space_undistributed = CC.Spaces.ExtrudedFiniteDifferenceSpace(space2d_undistributed, vert_center_space)
     else
         space_undistributed = space2d_undistributed


### PR DESCRIPTION
This PR passes `context` to `FiniteDifferenceSpace` in preparation for the next (breaking) ClimaCore release.