### PR TITLE
remove use_reference_state from the config

### DIFF
--- a/config/ci_configs/gpu_amip_target_topo_diagedmf_shortrun.yml
+++ b/config/ci_configs/gpu_amip_target_topo_diagedmf_shortrun.yml
@@ -21,4 +21,3 @@ t_end: "200secs"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"
-use_reference_state: false

--- a/config/longrun_configs/amip_target_topo_diagedmf_cpu.yml
+++ b/config/longrun_configs/amip_target_topo_diagedmf_cpu.yml
@@ -20,4 +20,3 @@ topo_smoothing: true
 topography: "Earth"
 coupler_toml_file: "toml/amip_target_topo_diagedmf.toml"
 turb_flux_partition: "CombinedStateFluxesMOST"
-use_reference_state: false

--- a/config/longrun_configs/amip_target_topo_diagedmf_gpu.yml
+++ b/config/longrun_configs/amip_target_topo_diagedmf_gpu.yml
@@ -20,4 +20,3 @@ topo_smoothing: true
 topography: "Earth"
 coupler_toml_file: "toml/amip_target_topo_diagedmf.toml"
 turb_flux_partition: "CombinedStateFluxesMOST"
-use_reference_state: false


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
As it is not supported in ClimaAtmos anymore.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
