### PR TITLE
remove ediff diagnostics

### DIFF
--- a/config/ci_configs/slabplanet_atmos_diags.yml
+++ b/config/ci_configs/slabplanet_atmos_diags.yml
@@ -15,6 +15,6 @@ rad: "gray"
 t_end: "10days"
 vert_diff: "true"
 diagnostics:
-  - short_name: [mse, lr, ediff, ts, mass_strf, stab, vt, egr]
+  - short_name: [mse, lr, edt, evu, ts, mass_strf, stab, vt, egr]
     reduction_time: average
     period: 1days

--- a/config/ci_configs/slabplanet_default.yml
+++ b/config/ci_configs/slabplanet_default.yml
@@ -14,5 +14,5 @@ t_end: "10days"
 vert_diff: "true"
 output_default_diagnostics: false
 diagnostics:
- - short_name: [mse, lr, ediff, hfes, evspsbl, ts]
+ - short_name: [mse, lr, edt, evu, hfes, evspsbl, ts]
    period: 1days

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos_extra_diags.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos_extra_diags.jl
@@ -55,29 +55,6 @@ CAD.add_diagnostic_variable!(
 )
 
 CAD.add_diagnostic_variable!(
-    short_name = "ediff",
-    long_name = "Eddy diffusivity",
-    standard_name = "eddy_diffusivity",
-    units = "m^2 s^-1",
-    comments = "Eddy diffusivity consistent with the VerticalDiffusion scheme in ClimaAtmos.",
-    compute! = (out, state, cache, time) -> begin
-        (; ᶜp) = cache.precomputed
-        (; C_E) = cache.atmos.vert_diff
-        interior_uₕ = CC.Fields.level(state.c.uₕ, 1)
-        ᶠp = ᶠK_E = cache.scratch.ᶠtemp_scalar
-        @. ᶠp = CAD.ᶠinterp(ᶜp)
-        ᶜΔz_surface = CC.Fields.Δz_field(interior_uₕ)
-        @. ᶠK_E = CA.eddy_diffusivity_coefficient(C_E, CA.norm(interior_uₕ), ᶜΔz_surface / 2, ᶠp)
-        if isnothing(out)
-            return CAD.ᶜinterp.(ᶠK_E)
-        else
-            out .= CAD.ᶜinterp.(ᶠK_E)
-        end
-
-    end,
-)
-
-CAD.add_diagnostic_variable!(
     short_name = "mass_strf",
     long_name = "Meridional Mass Streamfunction",
     standard_name = "meridional_mass_streamfunction",

--- a/experiments/ClimaEarth/user_io/ci_plots.jl
+++ b/experiments/ClimaEarth/user_io/ci_plots.jl
@@ -164,7 +164,7 @@ function make_plots(
     simdirs = CAN.SimDir.(output_paths)
 
     # Default output diagnostics
-    short_names_3D = ["mse", "lr", "ediff"]
+    short_names_3D = ["mse", "lr", "edt"]
     short_names_2D = ["ts"]
 
     available_periods = CAN.available_periods(simdirs[1]; short_name = short_names_3D[1], reduction)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Eddy diffusivity is in atmos diagnostics (`edt` and `evu`) so we don't need extra diagnostics here. The atmos diagnostics are also more correct as we get them directly from the cache.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
