### PR TITLE
fix atmos_config_file in longrun config

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -222,7 +222,6 @@ steps:
           slurm_mem_per_cpu: 16G
         soft_fail: true
 
-
   - group: "Current target tests: AMIP surfaces"
 
     steps:

--- a/config/longrun_configs/amip_target.yml
+++ b/config/longrun_configs/amip_target.yml
@@ -10,6 +10,7 @@ dt_save_state_to_disk: "20days"
 dt_save_to_sol: "10days"
 energy_check: false
 hourly_checkpoint: true
+insolation: "timevarying"
 land_albedo_type: "map_temporal"
 mode_name: "amip"
 mono_surface: false

--- a/config/longrun_configs/amip_target_topo.yml
+++ b/config/longrun_configs/amip_target_topo.yml
@@ -11,6 +11,7 @@ dt_save_state_to_disk: "20days"
 dt_save_to_sol: "10days"
 energy_check: false
 hourly_checkpoint: true
+insolation: "timevarying"
 land_albedo_type: "map_temporal"
 mode_name: "amip"
 mono_surface: false

--- a/config/longrun_configs/amip_target_topo_diagedmf_cpu.yml
+++ b/config/longrun_configs/amip_target_topo_diagedmf_cpu.yml
@@ -1,12 +1,15 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 anim: false
-atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
+atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml"
 dt: "120secs"
+dt_cloud_fraction: "1hours"
 dt_cpl: 120
+dt_rad: "1hours"
 dt_save_state_to_disk: "20days"
 dt_save_to_sol: "10days"
 energy_check: false
+insolation: "timevarying"
 hourly_checkpoint: false
 land_albedo_type: "map_temporal"
 mode_name: "amip"

--- a/config/longrun_configs/amip_target_topo_diagedmf_gpu.yml
+++ b/config/longrun_configs/amip_target_topo_diagedmf_gpu.yml
@@ -1,12 +1,15 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 anim: false
-atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
+atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml"
 dt: "120secs"
+dt_cloud_fraction: "1hours"
 dt_cpl: 120
+dt_rad: "1hours"
 dt_save_state_to_disk: "20days"
 dt_save_to_sol: "10days"
 energy_check: false
+insolation: "timevarying"
 hourly_checkpoint: false
 land_albedo_type: "map_temporal"
 mode_name: "amip"

--- a/config/longrun_configs/slabplanet_aqua_target_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_aqua_target_evolve_ocn.yml
@@ -1,6 +1,6 @@
 anim: true
 apply_limiter: false
-atmos_config_file: "config/longrun_configs/longrun_aquaplanet_rhoe_equil_allsky_0M.yml"
+atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_0M.yml"
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_cpl: 120

--- a/config/longrun_configs/slabplanet_aqua_target_nocouple.yml
+++ b/config/longrun_configs/slabplanet_aqua_target_nocouple.yml
@@ -1,6 +1,6 @@
 anim: true
 apply_limiter: false
-atmos_config_file: "config/longrun_configs/longrun_aquaplanet_rhoe_equil_allsky_0M.yml"
+atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_0M.yml"
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_cpl: 8639800


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
missed in #906. Also fixes an error in the config of amip_target and amip_target_topo (insolation was not set to time-varying). FYI @akshaysridhar we should use this config to test the simulation's stability.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
