### PR TITLE
Fix a bug in P_snow in bucket

### DIFF
--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -203,8 +203,8 @@ function Interfacer.update_field!(sim::BucketSimulation, ::Val{:turbulent_energy
     parent(sim.integrator.p.bucket.turbulent_fluxes.shf) .= parent(field)
 end
 function Interfacer.update_field!(sim::BucketSimulation, ::Val{:snow_precipitation}, field)
-    ρ_ice = (LP.ρ_cloud_ice(sim.model.parameters.earth_param_set))
-    parent(sim.integrator.p.drivers.P_snow) .= parent(field ./ ρ_ice)
+    ρ_liq = (LP.ρ_cloud_liq(sim.model.parameters.earth_param_set))
+    parent(sim.integrator.p.drivers.P_snow) .= parent(field ./ ρ_liq)
 end
 function Interfacer.update_field!(sim::BucketSimulation, ::Val{:turbulent_moisture_flux}, field)
     ρ_liq = (LP.ρ_cloud_liq(sim.model.parameters.earth_param_set))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
ClimaLand uses snow water equivalent, so the mass flux should be divided by the density of liquid water instead of ice.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
