### PR TITLE
Add option to shift ObsDataSources to end of month

### DIFF
--- a/experiments/ClimaEarth/user_io/leaderboard/data_sources.jl
+++ b/experiments/ClimaEarth/user_io/leaderboard/data_sources.jl
@@ -24,6 +24,9 @@ struct ObsDataSource
 
     """The NCDataset associated to the file"""
     ncdataset::NCDatasets.NCDataset
+
+    """Shift dates so that they are at the end of month?"""
+    shift_to_end_of_month::Bool
 end
 
 function ObsDataSource(;
@@ -33,11 +36,21 @@ function ObsDataSource(;
     lon_name = "lon",
     lat_name = "lat",
     preprocess_data_fn = identity,
+    shift_to_end_of_month = true,
 )
 
     ncdataset = NCDatasets.NCDataset(path)
 
-    return ObsDataSource(path, var_name, time_name, lon_name, lat_name, preprocess_data_fn, ncdataset)
+    return ObsDataSource(
+        path,
+        var_name,
+        time_name,
+        lon_name,
+        lat_name,
+        preprocess_data_fn,
+        ncdataset,
+        shift_to_end_of_month,
+    )
 end
 
 """

--- a/experiments/ClimaEarth/user_io/leaderboard/utils.jl
+++ b/experiments/ClimaEarth/user_io/leaderboard/utils.jl
@@ -197,6 +197,10 @@ function find_and_resample(
 
     available_times = obs.ncdataset[observed_data.time_name]
 
+    if observed_data.shift_to_end_of_month
+        available_times = Dates.DateTime.(Dates.lastdayofmonth.(available_times))
+    end
+
     time_index = ClimaAnalysis.Utils.nearest_index(available_times, date)
 
     # NOTE: We are hardcoding that the time index is the last one and that there are three


### PR DESCRIPTION
This helps with comparing with our model because observations are typically defined on the 15th, but our model is defined at the end of the month. Since we always find the closest data available, this can lead to comparisons across months.
