### PR TITLE
add downward sw fluxes to leaderboard

### DIFF
--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -932,12 +932,13 @@ if ClimaComms.iamroot(comms_ctx)
             include("user_io/leaderboard.jl")
             ClimaAnalysis = Leaderboard.ClimaAnalysis
 
-            compare_vars_biases = ["pr", "rsut", "rlut", "rsutcs", "rlutcs"]
+            compare_vars_biases = ["pr", "rsut", "rlut", "rsdt", "rsutcs", "rlutcs"]
 
             compare_vars_biases_plot_extrema = Dict(
                 "pr" => (-5.0, 5.0),
                 "rsut" => (-50.0, 50.0),
                 "rlut" => (-50.0, 50.0),
+                "rsdt" => (-10.0, 10.0),
                 "rsutcs" => (-20.0, 20.0),
                 "rlutcs" => (-20.0, 20.0),
             )

--- a/experiments/ClimaEarth/user_io/leaderboard/compare_with_obs.jl
+++ b/experiments/ClimaEarth/user_io/leaderboard/compare_with_obs.jl
@@ -56,6 +56,12 @@ OBS_DS["rsutcs"] = ObsDataSource(;
 )
 SIM_DS_KWARGS["rsutcs"] = (;)
 
+OBS_DS["rsdt"] = ObsDataSource(;
+    path = joinpath(@clima_artifact("radiation_obs"), "CERES_EBAF-TOA_Ed4.2_Subset_200003-202303.g025.nc"),
+    var_name = "solar_mon",
+)
+SIM_DS_KWARGS["rsdt"] = (;)
+
 OBS_DS["rlutcs"] = ObsDataSource(;
     path = joinpath(@clima_artifact("radiation_obs"), "CERES_EBAF-TOA_Ed4.2_Subset_200003-202303.g025.nc"),
     var_name = "toa_lw_clr_c_mon",

--- a/experiments/ClimaEarth/user_io/leaderboard/data_sources.jl
+++ b/experiments/ClimaEarth/user_io/leaderboard/data_sources.jl
@@ -24,6 +24,9 @@ struct ObsDataSource
 
     """The NCDataset associated to the file"""
     ncdataset::NCDatasets.NCDataset
+
+    """Shift dates so that they are at the end of month?"""
+    shift_to_end_of_month::Bool
 end
 
 function ObsDataSource(;
@@ -33,11 +36,21 @@ function ObsDataSource(;
     lon_name = "lon",
     lat_name = "lat",
     preprocess_data_fn = identity,
+    shift_to_end_of_month = true,
 )
 
     ncdataset = NCDatasets.NCDataset(path)
 
-    return ObsDataSource(path, var_name, time_name, lon_name, lat_name, preprocess_data_fn, ncdataset)
+    return ObsDataSource(
+        path,
+        var_name,
+        time_name,
+        lon_name,
+        lat_name,
+        preprocess_data_fn,
+        ncdataset,
+        shift_to_end_of_month,
+    )
 end
 
 """

--- a/experiments/ClimaEarth/user_io/leaderboard/utils.jl
+++ b/experiments/ClimaEarth/user_io/leaderboard/utils.jl
@@ -197,6 +197,10 @@ function find_and_resample(
 
     available_times = obs.ncdataset[observed_data.time_name]
 
+    if observed_data.shift_to_end_of_month
+        available_times = Dates.DateTime.(Dates.lastdayofmonth.(available_times))
+    end
+
     time_index = ClimaAnalysis.Utils.nearest_index(available_times, date)
 
     # NOTE: We are hardcoding that the time index is the last one and that there are three


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Also adds option to shift ObsDataSources to end of month. This helps with comparing with our model because observations are typically defined on the 15th, but our model is defined at the end of the month. Since we always find the closest data available, this can lead to comparisons across months.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
