### PR TITLE
Add walltime per atmos step

### DIFF
--- a/.buildkite/amip/pipeline.yml
+++ b/.buildkite/amip/pipeline.yml
@@ -72,3 +72,4 @@ steps:
             find experiments/ClimaEarth/output/amip/amip_artifacts/ -type f -name 'bias*.png' -print0 | while IFS= read -r -d '' file; do
               slack-upload -c "#coupler-report" -f "$$file" -m png -n "$$(basename "$$file" .png)" -x "$$(basename "$$file" .png)"
             done
+          - SYPD="$(cat experiments/ClimaEarth/output/amip/amip_artifacts/sypd.txt)"; WALL="$(cat experiments/ClimaEarth/output/amip/amip_artifacts/walltime_per_atmos_step.txt)"; slack-message -c "#coupler-report" -x "SYPD: $SYPD Walltime per Atmos step: $WALL"

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -836,12 +836,18 @@ ClimaComms.iamroot(comms_ctx) && @show(walltime)
 ## Use ClimaAtmos calculation to show the simulated years per day of the simulation (SYPD)
 es = CA.EfficiencyStats(tspan, walltime)
 sypd = CA.simulated_years_per_day(es)
+n_atmos_steps = atmos_sim.integrator.step
+walltime_per_atmos_step = es.walltime / n_atmos_steps
 @info "SYPD: $sypd"
+@info "Walltime per Atmos step: $(walltime_per_atmos_step)"
 
 ## Save the SYPD and allocation information
 if ClimaComms.iamroot(comms_ctx)
     sypd_filename = joinpath(dir_paths.artifacts, "sypd.txt")
     write(sypd_filename, "$sypd")
+
+    walltime_per_atmos_step_filename = joinpath(dir_paths.artifacts, "walltime_per_atmos_step.txt")
+    write(walltime_per_atmos_step_filename, "$(walltime_per_atmos_step)")
 
     cpu_max_rss_GB = Utilities.show_memory_usage(comms_ctx)
     cpu_max_rss_filename = joinpath(dir_paths.artifacts, "max_rss_cpu.txt")


### PR DESCRIPTION
Our long AMIP run is the most robust way we have to test performance. With this PR, the SYPD and walltime per step are saved and sent to the coupler-report channel.