### PR TITLE
delete `cgll2latlonz` function

### DIFF
--- a/docs/src/regridder.md
+++ b/docs/src/regridder.md
@@ -18,7 +18,6 @@ ClimaCoupler.Regridder.remap_field_cgll_to_rll
 ClimaCoupler.Regridder.land_fraction
 ClimaCoupler.Regridder.update_surface_fractions!
 ClimaCoupler.Regridder.combine_surfaces!
-ClimaCoupler.Regridder.cgll2latlonz
 ClimaCoupler.Regridder.combine_surfaces_from_sol!
 ```
 

--- a/src/Regridder.jl
+++ b/src/Regridder.jl
@@ -25,7 +25,6 @@ export write_to_hdf5,
     combine_surfaces_from_sol!,
     binary_mask,
     nans_to_zero,
-    cgll2latlonz,
     truncate_dataset
 
 
@@ -610,31 +609,6 @@ function read_remapped_field(name::Symbol, datafile_latlon::String, lev_name = "
     end
 
     return out
-end
-
-
-"""
-    function cgll2latlonz(field; DIR = "cgll2latlonz_dir", nlat = 360, nlon = 720, clean_dir = true)
-
-Regrids a field from CGLL to an RLL array using TempestRemap. It can hanlde multiple other dimensions, such as time and level.
-
-# Arguments
-- `field`: [CC.Fields.Field] to be remapped.
-- `DIR`: [String] directory used for remapping.
-- `nlat`: [Int] number of latitudes of the regridded array.
-- `nlon`: [Int] number of longitudes of the regridded array.
-- `clean_dir`: [Bool] flag to delete the temporary directory after remapping.
-
-# Returns
-- Tuple containing the remapped field and its coordinates.
-"""
-function cgll2latlonz(field; DIR = "cgll2latlonz_dir", nlat = 360, nlon = 720, clean_dir = true)
-    isdir(DIR) ? nothing : mkpath(DIR)
-    datafile_latlon = DIR * "/remapped_" * string(Interfacer.name) * ".nc"
-    remap_field_cgll_to_rll(:var, field, DIR, datafile_latlon, nlat = nlat, nlon = nlon)
-    new_data, coords = read_remapped_field(:var, datafile_latlon)
-    clean_dir && rm(DIR; recursive = true)
-    return new_data, coords
 end
 
 """

--- a/test/regridder_tests.jl
+++ b/test/regridder_tests.jl
@@ -296,7 +296,11 @@ for FT in (Float32, Float64)
             Base.close(hdfreader)
 
             # regrid back to lat-lon
-            T_rll, _ = Regridder.cgll2latlonz(T_cgll)
+            datafile_latlon = joinpath(REGRID_DIR, "remapped_latlon.nc")
+            nlat = 360
+            nlon = 720
+            Regridder.remap_field_cgll_to_rll(:var, T_cgll, REGRID_DIR, datafile_latlon, nlat = nlat, nlon = nlon)
+            T_rll, _ = Regridder.read_remapped_field(:var, datafile_latlon)
 
             # check consistency across z-levels
             @test T_rll[:, :, 1] == T_rll[:, :, 2]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We have a function `Regridder.cgll2latlonz` that is a wrapper around wrappers around ClimaCoreTempestRemap functions. We have no use for it in source, and it is only called in a single test. This commit deletes the function, and calls the CCTR wrappers directly from the test where `cgll2latlonz` was called before.

closes https://github.com/CliMA/ClimaCoupler.jl/issues/833

## Content
- [x] delete function
- [x] update docs
- [x] update test to call CCTR wrappers directly


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
