### PR TITLE
Fix random seed in run_amip

### DIFF
--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -63,6 +63,10 @@ import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput, evaluate!
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
 import Interpolations
 
+# Random is used by RRMTGP for some cloud properties
+import Random
+Random.seed!(1234)
+
 pkg_dir = pkgdir(ClimaCoupler)
 
 #=


### PR DESCRIPTION
RRMTGP uses `Random.rand` for some cloud properties. Just in case, let's set fix it to a given number.
