### PR TITLE
specify grid in amip config

### DIFF
--- a/config/amip_configs/amip.yml
+++ b/config/amip_configs/amip.yml
@@ -2,11 +2,14 @@ FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 anim: false
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
+coupler_toml_file: "toml/amip.toml"
 dt: "120secs"
 dt_cpl: 120
 dt_save_state_to_disk: "30days"
 dt_save_to_sol: "30days"
+dz_bottom: 30.0
 energy_check: false
+h_elem: 16
 hourly_checkpoint: true
 hourly_checkpoint_dt: 720
 land_albedo_type: "map_temporal"
@@ -19,5 +22,6 @@ surface_setup: "PrescribedSurface"
 t_end: "1098days"
 topo_smoothing: true
 topography: "Earth"
-coupler_toml_file: "toml/amip.toml"
 turb_flux_partition: "CombinedStateFluxesMOST"
+z_elem: 63
+z_max: 55000.0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
I think it might be helpful to add a bit redundancy and specify the grid in the amip config, so the amip simulation won't be affected while we modify the grid setup in the corresponding atmos yaml. What do others think?

The coupler yaml file seems alphabetic, so I kept the order. Is this required? I find it a bit annoying as e.g. the grid configs are not together, but I'm fine with it.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
