### PR TITLE
Use try catch directly for artifact

### DIFF
--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -174,19 +174,16 @@ original sources.
 =#
 include(joinpath(pkgdir(ClimaCoupler), "artifacts", "artifact_funcs.jl"))
 
-if Utilities.artifact_exists("historical_sst_sic")
-    sst_data =
-        joinpath(@clima_artifact("historical_sst_sic", comms_ctx), "MODEL.SST.HAD187001-198110.OI198111-202206.nc")
-    sic_data =
-        joinpath(@clima_artifact("historical_sst_sic", comms_ctx), "MODEL.ICE.HAD187001-198110.OI198111-202206.nc")
-else
-    ClimaComms.iamroot(comms_ctx) &&
-        @warn "Using lowres sst sic. If you want the higher resolution version, you have to obtain it from ClimaArtifacts"
-    sst_data = joinpath(
+sst_data, sic_data = try
+    joinpath(@clima_artifact("historical_sst_sic", comms_ctx), "MODEL.SST.HAD187001-198110.OI198111-202206.nc"),
+    joinpath(@clima_artifact("historical_sst_sic", comms_ctx), "MODEL.ICE.HAD187001-198110.OI198111-202206.nc")
+catch error
+    @warn "Using lowres sst sic. If you want the higher resolution version, you have to obtain it from ClimaArtifacts"
+    joinpath(
         @clima_artifact("historical_sst_sic_lowres", comms_ctx),
         "MODEL.SST.HAD187001-198110.OI198111-202206_lowres.nc",
-    )
-    sic_data = joinpath(
+    ),
+    joinpath(
         @clima_artifact("historical_sst_sic_lowres", comms_ctx),
         "MODEL.ICE.HAD187001-198110.OI198111-202206_lowres.nc",
     )

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -14,24 +14,6 @@ import Logging
 export swap_space!
 
 """
-    artifact_exists(name)
-
-Return whether the artifact with the given name exists and is available to use.
-"""
-function artifact_exists(name)
-    # There seems to be no easy way to determine if an artifact exists from the name
-    # only...
-    return try
-        # We need to macroexpand because we only want to resolve @artifact_str when
-        # we call this function
-        @macroexpand Artifacts.@artifact_str(name)
-        true
-    catch error
-        false
-    end
-end
-
-"""
     swap_space!(space_out::CC.Spaces.AbstractSpace, field_in::CC.Fields.Field)
 
 Remap the values of a field onto a new space.


### PR DESCRIPTION
The artifact_exists function didn't really work as expected. This is because the Artifacts.toml file that was being used is the one for ClimaCoupler (ie, not existing). The Artifacts.toml file used is the one associated to the macro call, so the macro has to be next to its Artifacts.toml. So, I just explicitly call try catch instead of moving it into a function.
