### PR TITLE
modify nightly amip config

### DIFF
--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -56,7 +56,7 @@ steps:
           - echo "--- Run simulation"
           - "julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse.yml --job_id amip_coarse1"
         artifact_paths: "experiments/ClimaEarth/output/amip/amip_coarse1_artifacts/*"
-        timeout_in_minutes: 1080
+        timeout_in_minutes: 840
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:

--- a/config/nightly_configs/amip_coarse.yml
+++ b/config/nightly_configs/amip_coarse.yml
@@ -3,11 +3,11 @@ albedo_model: "CouplerAlbedo"
 anim: false
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 coupler_toml_file: "toml/amip.toml"
-dt: "120secs"
-dt_cpl: 120
+dt: "180secs"
+dt_cpl: 180
 dt_save_state_to_disk: "30days"
 dt_save_to_sol: "30days"
-dz_bottom: 30.0
+dz_bottom: 100.0
 energy_check: false
 h_elem: 8
 hourly_checkpoint: true
@@ -18,6 +18,7 @@ mono_surface: false
 netcdf_output_at_levels: true
 output_default_diagnostics: true
 rayleigh_sponge: true
+smoothing_order: 10
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "366days"
@@ -27,4 +28,4 @@ turb_flux_partition: "CombinedStateFluxesMOST"
 unique_seed: true
 viscous_sponge: false
 z_elem: 31
-z_max: 55000.0
+z_max: 50000.0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This config runs for 180 days. Now the failure mode looks similar to the one in the target amip. The major change is the smoothing order, which helps with unrealistic surface fluxes. This is not ideal, but I still think it is good to have a setup that runs for longer. @akshaysridhar @juliasloan25 What do you think? Akshay may have ideas why the smoothing order matters for surface fluxes. I also changed dz_bottom as I think it makes sense to make it coarser when z_elem is smaller. This is not necessarily needed, we can explore the grids further once the current setup becomes stable.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
