### PR TITLE
fix aquaplanet longruns

### DIFF
--- a/config/longrun_configs/slabplanet_aqua_atmos_sf_couple.yml
+++ b/config/longrun_configs/slabplanet_aqua_atmos_sf_couple.yml
@@ -16,4 +16,5 @@ start_date: "20100101"
 surface_setup: "DefaultMoninObukhov"
 t_end: "20days"
 turb_flux_partition: "CombinedStateFluxesMOST"
+use_land_diagnostics: false
 vert_diff: "FriersonDiffusion"

--- a/config/longrun_configs/slabplanet_aqua_atmos_sf_nocouple.yml
+++ b/config/longrun_configs/slabplanet_aqua_atmos_sf_nocouple.yml
@@ -16,4 +16,5 @@ start_date: "20100101"
 surface_setup: "DefaultMoninObukhov"
 t_end: "20days"
 turb_flux_partition: "CombinedStateFluxesMOST"
+use_land_diagnostics: false
 vert_diff: "FriersonDiffusion"

--- a/config/longrun_configs/slabplanet_aqua_coupler_sf.yml
+++ b/config/longrun_configs/slabplanet_aqua_coupler_sf.yml
@@ -16,4 +16,5 @@ start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "20days"
 turb_flux_partition: "CombinedStateFluxesMOST"
+use_land_diagnostics: false
 vert_diff: "FriersonDiffusion"

--- a/config/longrun_configs/slabplanet_aqua_coupler_sf_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_aqua_coupler_sf_evolve_ocn.yml
@@ -15,4 +15,5 @@ start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "20days"
 turb_flux_partition: "CombinedStateFluxesMOST"
+use_land_diagnostics: false
 vert_diff: "FriersonDiffusion"

--- a/config/longrun_configs/slabplanet_aqua_target.yml
+++ b/config/longrun_configs/slabplanet_aqua_target.yml
@@ -16,4 +16,5 @@ start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "120days"
 turb_flux_partition: "CombinedStateFluxesMOST"
+use_land_diagnostics: false
 vert_diff: "true"

--- a/config/longrun_configs/slabplanet_aqua_target_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_aqua_target_evolve_ocn.yml
@@ -16,4 +16,5 @@ start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "120days"
 turb_flux_partition: "CombinedStateFluxesMOST"
+use_land_diagnostics: false
 vert_diff: "true"

--- a/config/longrun_configs/slabplanet_aqua_target_nocouple.yml
+++ b/config/longrun_configs/slabplanet_aqua_target_nocouple.yml
@@ -16,4 +16,5 @@ start_date: "20100101"
 surface_setup: "DefaultMoninObukhov"
 t_end: "120days"
 turb_flux_partition: "CombinedStateFluxesMOST"
+use_land_diagnostics: false
 vert_diff: "true"

--- a/experiments/ClimaEarth/cli_options.jl
+++ b/experiments/ClimaEarth/cli_options.jl
@@ -116,6 +116,10 @@ function argparse_settings()
         help = "Type of temperature anomaly for bucket model. [`amip`, `aquaplanet` (default)]"
         arg_type = String
         default = "aquaplanet"
+        "--use_land_diagnostics"
+        help = "Boolean flag indicating whether to compute and output land model diagnostics [`true` (default), `false`]"
+        arg_type = Bool
+        default = true
     end
     return s
 end

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -134,6 +134,7 @@ land_sim_name = "bucket"
 t_end = Float64(time_to_seconds(config_dict["t_end"]))
 t_start = 0.0
 tspan = (t_start, t_end)
+Δt_component = Float64(time_to_seconds(config_dict["dt"]))
 Δt_cpl = Float64(config_dict["dt_cpl"])
 saveat = Float64(time_to_seconds(config_dict["dt_save_to_sol"]))
 date0 = date = Dates.DateTime(config_dict["start_date"], Dates.dateformat"yyyymmdd")
@@ -272,7 +273,7 @@ if mode_name == "amip"
         config_dict["land_albedo_type"],
         config_dict["land_temperature_anomaly"],
         dir_paths;
-        dt = Δt_cpl,
+        dt = Δt_component,
         space = boundary_space,
         saveat = saveat,
         area_fraction = land_area_fraction,
@@ -325,7 +326,7 @@ if mode_name == "amip"
     ice_sim = ice_init(
         FT;
         tspan = tspan,
-        dt = Δt_cpl,
+        dt = Δt_component,
         space = boundary_space,
         saveat = saveat,
         area_fraction = ice_fraction,
@@ -361,7 +362,7 @@ elseif mode_name in ("slabplanet", "slabplanet_aqua", "slabplanet_terra")
         config_dict["land_albedo_type"],
         config_dict["land_temperature_anomaly"],
         dir_paths;
-        dt = Δt_cpl,
+        dt = Δt_component,
         space = boundary_space,
         saveat = saveat,
         area_fraction = land_area_fraction,
@@ -375,7 +376,7 @@ elseif mode_name in ("slabplanet", "slabplanet_aqua", "slabplanet_terra")
     ocean_sim = ocean_init(
         FT;
         tspan = tspan,
-        dt = Δt_cpl,
+        dt = Δt_component,
         space = boundary_space,
         saveat = saveat,
         area_fraction = (FT(1) .- land_area_fraction), ## NB: this ocean fraction includes areas covered by sea ice (unlike the one contained in the cs)
@@ -410,7 +411,7 @@ elseif mode_name == "slabplanet_eisenman"
         config_dict["land_albedo_type"],
         config_dict["land_temperature_anomaly"],
         dir_paths;
-        dt = Δt_cpl,
+        dt = Δt_component,
         space = boundary_space,
         saveat = saveat,
         area_fraction = land_area_fraction,
@@ -424,7 +425,7 @@ elseif mode_name == "slabplanet_eisenman"
     ocean_sim = ocean_init(
         FT;
         tspan = tspan,
-        dt = Δt_cpl,
+        dt = Δt_component,
         space = boundary_space,
         saveat = saveat,
         area_fraction = CC.Fields.zeros(boundary_space), # zero, since ML is calculated below
@@ -437,7 +438,7 @@ elseif mode_name == "slabplanet_eisenman"
         tspan,
         space = boundary_space,
         area_fraction = (FT(1) .- land_area_fraction),
-        dt = Δt_cpl,
+        dt = Δt_component,
         saveat = saveat,
         thermo_params = thermo_params,
     )

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -146,6 +146,7 @@ restart_t = Int(config_dict["restart_t"])
 evolving_ocean = config_dict["evolving_ocean"]
 dt_rad = config_dict["dt_rad"]
 use_coupler_diagnostics = config_dict["use_coupler_diagnostics"]
+use_land_diagnostics = config_dict["use_land_diagnostics"]
 
 #=
 ## Setup Communication Context
@@ -281,6 +282,7 @@ if mode_name == "amip"
         t_start = t_start,
         energy_check = energy_check,
         surface_elevation,
+        use_land_diagnostics,
     )
 
     ## ocean stub
@@ -370,6 +372,7 @@ elseif mode_name in ("slabplanet", "slabplanet_aqua", "slabplanet_terra")
         t_start = t_start,
         energy_check = energy_check,
         surface_elevation,
+        use_land_diagnostics,
     )
 
     ## ocean model
@@ -419,6 +422,7 @@ elseif mode_name == "slabplanet_eisenman"
         t_start = t_start,
         energy_check = energy_check,
         surface_elevation,
+        use_land_diagnostics,
     )
 
     ## ocean stub (here set to zero area coverage)

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -235,6 +235,7 @@ land_sim = bucket_init(
     t_start = tspan[1],
     energy_check = false,
     surface_elevation,
+    use_land_diagnostics = true,
 )
 
 ocean_sim = ocean_init(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
See failing longruns [here](https://buildkite.com/clima/climacoupler-longruns/builds/811#019260a2-381a-4dc5-900e-ebe035810e89)

We have some longruns that evolve the atmos and surface states independently without coupling, so that we can independently test the infrastructure in the coupler that constructs and steps component models, and have a hierarchy of increasingly-complex runs. These `nocouple` runs are set up with a large coupling timestep (> t_end) so coupling never occurs.

This caused an error in the bucket diagnostics because the (very large) coupling timestep was being passed to the bucket model and used as its timestep. We actually have separate quantities `dt` and `dt_cpl` in our config files, where one is the component model timestep and the other is coupling timestep, but `dt` isn't being used except for in `ClimaAtmos.get_simulation`

There are a few things that should be done differently here
- We want an option to turn off bucket diagnostics, or compute at a different frequency
- We want each component model to use independent timesteps, so our configs should have options to specify each of them. Right now we just have dt and dt_cpl
- The failing longrun is an "aquaplanet" experiment, which runs the ocean component over the entire surface. This is fine, but the land is actually evaluated everywhere too, and just zeroed out. I imagine this might be why bucket_init was taking in the large dt_cpl value before - it wouldn't actually ever get evaluated using such a large step. If we know that the land model isn't being used, we should be able to avoid initializing it at all. The same applies in reverse for slabplanet_terra runs, which run land over the entire surface and zero out ocean. I'm not sure what the best short-term solution is, but I think in the medium-term we should separate AMIP and slabplanet drivers

The first point is addressed in this PR, the second is partially addressed here, and the third will be addressed separately.

## Content
- [x] add a flag to optionally output bucket diagnostics: set true by default, false for all aquaplanet runs
- [x] parse `dt` from the config dict and pass this to component models instead of `dt_cpl`

## To-do (in separate PRs)
- separate AMIP and slabplanet drivers; don't run land/ocean when they aren't used, instead of just masking them out
- add options for unique dts for each component model (atmos, land, ocean, sea ice)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
