### PR TITLE
Do not download bucket artifacts for ClimaLand > 0.15.1

### DIFF
--- a/artifacts/download_artifacts.jl
+++ b/artifacts/download_artifacts.jl
@@ -9,9 +9,11 @@ end
 # Download land artifacts
 module Land
 import ClimaLand
-include(joinpath(pkgdir(ClimaLand), "src", "standalone", "Bucket", "artifacts", "artifacts.jl"))
-@info "CESM", cesm2_albedo_dataset_path()
-@info "Bareground albedo", bareground_albedo_dataset_path()
+if pkgversion(ClimaLand) < v"0.15.2"
+    include(joinpath(pkgdir(ClimaLand), "src", "standalone", "Bucket", "artifacts", "artifacts.jl"))
+    @info "CESM", cesm2_albedo_dataset_path()
+    @info "Bareground albedo", bareground_albedo_dataset_path()
+end
 end
 
 


### PR DESCRIPTION
ClimaLand moved to ClimaArtifacts for the bucket artifacts, so that the files are automatically downloaded and there is no need anymore to force their download
