### PR TITLE
change ocean roughness and ice albedo

### DIFF
--- a/config/nightly_configs/amip_coarse.yml
+++ b/config/nightly_configs/amip_coarse.yml
@@ -15,6 +15,7 @@ hourly_checkpoint_dt: 720
 land_albedo_type: "map_temporal"
 mode_name: "amip"
 mono_surface: false
+netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: true
 rayleigh_sponge: true

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -46,7 +46,7 @@ Base.@kwdef struct IceSlabParameters{FT <: AbstractFloat}
     z0b::FT = 1e-4          # roughness length for tracers [m]
     T_freeze::FT = 271.2    # freezing temperature of sea water [K]
     k_ice::FT = 2           # thermal conductivity of sea ice [W / m / K] (less in HM71)
-    α::FT = 0.8             # albedo of sea ice [0, 1]
+    α::FT = 0.65            # albedo of sea ice, roughly tuned to match observations
 end
 
 Interfacer.name(::IceSlabParameters) = "IceSlabParameters"

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -297,8 +297,10 @@ if mode_name == "amip"
     ocean_sim = Interfacer.SurfaceStub((;
         T_sfc = SST_init,
         ρ_sfc = CC.Fields.zeros(boundary_space),
-        z0m = FT(1e-3),
-        z0b = FT(1e-3),
+        # ocean roughness follows GFDL model 
+        # (https://github.com/NOAA-GFDL/ice_param/blob/main/ocean_rough.F90#L47)
+        z0m = FT(5.8e-5),
+        z0b = FT(5.8e-5),
         beta = FT(1),
         α_direct = CC.Fields.ones(boundary_space) .* FT(0.06),
         α_diffuse = CC.Fields.ones(boundary_space) .* FT(0.06),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Changes ocean roughness and sea ice albedo. Also change netcdf resolution to roughly match the raw grid for the nightly amip.

model - obs albedo before:
![image](https://github.com/user-attachments/assets/6cc1b1e4-9ce1-479a-802a-8cd7d83e4a05)

model - obs albedo after:
![image](https://github.com/user-attachments/assets/565b2d0b-d843-44d7-a465-0b5115b10a53)

I think it's slightly better for Antarctica. It might be too low for Arctic. We have a constant albedo right now and we may consider changing it to be e.g. temperature dependent in the future.

Ocean roughness doesn't has a strong effect but these values are more reasonable.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
