### PR TITLE
clipping sea ice tendencies

### DIFF
--- a/config/nightly_configs/amip_coarse.yml
+++ b/config/nightly_configs/amip_coarse.yml
@@ -3,8 +3,8 @@ albedo_model: "CouplerAlbedo"
 anim: false
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 coupler_toml_file: "toml/amip.toml"
-dt: "240secs"
-dt_cpl: 240
+dt: "180secs"
+dt_cpl: 180
 dt_save_state_to_disk: "30days"
 dt_save_to_sol: "30days"
 dz_bottom: 100.0
@@ -22,7 +22,7 @@ rayleigh_sponge: true
 smoothing_order: 10
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "732days"
+t_end: "549days"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"

--- a/test/component_model_tests/prescr_seaice_tests.jl
+++ b/test/component_model_tests/prescr_seaice_tests.jl
@@ -48,9 +48,10 @@ for FT in (Float32, Float64)
         dT_expected = -1.0 / (p.params.h * p.params.ρ * p.params.c)
         @test sum([i for i in extrema(dY)] .≈ [FT(dT_expected), FT(dT_expected)]) == 2
 
-        # check that tendency not added if T of ice would have done above freezing
+        # check that tendency will not result in above freezing T
         dY, Y, p = test_sea_ice_rhs(F_radiative = 0.0, T_base = 330.0) # Float32 requires a large number here!
-        @test sum([i for i in extrema(dY)] .≈ [FT(0.0), FT(0.0)]) == 2
+        dT_maximum = @. (p.params.T_freeze - Y.T_sfc) / p.dt
+        @test minimum(dT_maximum .- dY.T_sfc) >= FT(0.0)
 
         # check that the correct tendency was added due to basal flux
         dY, Y, p = test_sea_ice_rhs(F_radiative = 0.0, T_base = 269.2, global_mask = 1.0)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
In Holloway and Manabe 1971 it says

> If the solution to this heat balance equation results in a value of T* above freezing, this value is set back to freezing with the implicit assumption that the excess heat is used for melting pack ice.

The current code sets the tendency to zero if it results in T above freezing, which differs from the paper. I change it to clip the tendency to (T_freeze - T) / dt, which should match the paper more closely. I also remove a comment about sublimation which doesn't seem to be true in the code.

Edit: One out of four simulations break with dt 240 in the latest nightly build: https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/73. So I change dt back to 180 in this PR, and change t_end to one and a half years.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
I will revert the change in nightly pipeline before merging.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
