### PR TITLE
remove `surface_fractions`

### DIFF
--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -613,7 +613,6 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     atmos_sim.integrator.t,
     Δt_cpl,
-    (; land = land_area_fraction, ocean = zeros(boundary_space), ice = zeros(boundary_space)),
     model_sims,
     mode_specifics,
     diagnostics,

--- a/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
@@ -265,7 +265,6 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     atmos_sim.integrator.t,
     Δt_cpl,
-    (; land = zeros(boundary_space), ocean = ones(boundary_space), ice = zeros(boundary_space)),
     model_sims,
     (;), # mode_specifics
     (), # coupler diagnostics

--- a/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
@@ -279,7 +279,6 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     atmos_sim.integrator.t,
     Δt_cpl,
-    (; land = zeros(boundary_space), ocean = ones(boundary_space), ice = zeros(boundary_space)),
     model_sims,
     (;), # mode_specifics
     (), # coupler diagnostics

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -332,7 +332,6 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     atmos_sim.integrator.t,
     Δt_cpl,
-    (; land = zeros(boundary_space), ocean = ones(boundary_space), ice = zeros(boundary_space)),
     model_sims,
     (;), # mode_specifics
     (), # coupler diagnostics

--- a/experiments/ClimaEarth/run_dry_held_suarez.jl
+++ b/experiments/ClimaEarth/run_dry_held_suarez.jl
@@ -202,7 +202,6 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     atmos_sim.integrator.t,
     Δt_cpl,
-    (;),
     model_sims,
     (;), # mode_specifics
     (), # coupler diagnostics

--- a/experiments/ClimaEarth/run_moist_held_suarez.jl
+++ b/experiments/ClimaEarth/run_moist_held_suarez.jl
@@ -261,7 +261,6 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     atmos_sim.integrator.t,
     Δt_cpl,
-    (; land = zeros(boundary_space), ocean = ones(boundary_space), ice = zeros(boundary_space)),
     model_sims,
     (;), # mode_specifics
     (), # coupler diagnostics

--- a/experiments/ClimaEarth/user_io/viz_explorer.jl
+++ b/experiments/ClimaEarth/user_io/viz_explorer.jl
@@ -30,6 +30,12 @@ function plot_anim(cs, out_dir = ".")
     end
     Plots.mp4(anim, joinpath(out_dir, "anim_qt.mp4"), fps = 10)
 
+    # get all surface fractions and package into a named tuple
+    land_fraction = Interfacer.get_field(land_sim, Val(:area_fraction))
+    ocean_fraction = Interfacer.get_field(ocean_sim, Val(:area_fraction))
+    ice_fraction = Interfacer.get_field(ice_sim, Val(:area_fraction))
+    surface_fractions = (; land = land_fraction, ocean = ocean_fraction, ice = ice_fraction)
+
     # plot combined surfaces
     combined_field = zeros(boundary_space)
     sol_slab = slab_land_sim.integrator.sol
@@ -40,7 +46,7 @@ function plot_anim(cs, out_dir = ".")
             land_T_sfc = get_land_temp_from_state(cs.model_sims.land_sim, bucketu)
             Regridder.combine_surfaces_from_sol!(
                 combined_field,
-                cs.surface_fractions,
+                surface_fractions,
                 (; land = land_T_sfc, ocean = oceanu.T_sfc, ice = FT(0)),
             )
             Plots.plot(combined_field)
@@ -51,7 +57,7 @@ function plot_anim(cs, out_dir = ".")
             land_T_sfc = get_land_temp_from_state(cs.model_sims.land_sim, bucketu)
             Regridder.combine_surfaces_from_sol!(
                 combined_field,
-                cs.surface_fractions,
+                surface_fractions,
                 (; land = land_T_sfc, ocean = FT(0), ice = iceu.T_sfc),
             )
             Plots.plot(combined_field)
@@ -63,7 +69,7 @@ function plot_anim(cs, out_dir = ".")
             land_T_sfc = get_land_temp_from_state(cs.model_sims.land_sim, bucketu)
             Regridder.combine_surfaces_from_sol!(
                 combined_field,
-                cs.surface_fractions,
+                surface_fractions,
                 (; land = land_T_sfc, ocean = SST, ice = iceu.T_sfc),
             )
             Plots.plot(combined_field)
@@ -75,7 +81,7 @@ function plot_anim(cs, out_dir = ".")
     anim = Plots.@animate for bucketu in sol_slab.u
         Regridder.combine_surfaces_from_sol!(
             combined_field,
-            cs.surface_fractions,
+            surface_fractions,
             (; land = bucketu.bucket.W, ocean = 0.0, ice = 0.0),
         )
         Plots.plot(combined_field)
@@ -86,7 +92,7 @@ function plot_anim(cs, out_dir = ".")
     anim = Plots.@animate for bucketu in sol_slab.u
         Regridder.combine_surfaces_from_sol!(
             combined_field,
-            cs.surface_fractions,
+            surface_fractions,
             (; land = bucketu.bucket.σS, ocean = 0.0, ice = 0.0),
         )
         Plots.plot(combined_field)
@@ -99,7 +105,7 @@ function plot_anim(cs, out_dir = ".")
         anim = Plots.@animate for sol_iceu in sol_ice.u
             Regridder.combine_surfaces_from_sol!(
                 combined_field,
-                cs.surface_fractions,
+                surface_fractions,
                 (; land = 0.0, ocean = 0.0, ice = sol_iceu.h_ice),
             )
             Plots.plot(combined_field)

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -48,7 +48,6 @@ struct CoupledSimulation{
     TS,
     TI <: Real,
     DTI <: Real,
-    NTSM <: NamedTuple,
     NTMS <: NamedTuple,
     NTM <: NamedTuple,
     TD <: Tuple,
@@ -66,7 +65,6 @@ struct CoupledSimulation{
     tspan::TS
     t::TI
     Δt_cpl::DTI
-    surface_fractions::NTSM
     model_sims::NTMS
     mode::NTM
     diagnostics::TD

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -91,7 +91,6 @@ for FT in (Float32, Float64)
             (Int(0), Int(1000)), # tspan
             Int(200), # t
             Int(200), # Δt_cpl
-            (;), # surface_masks
             model_sims, # model_sims
             (;), # mode
             (), # diagnostics
@@ -174,7 +173,6 @@ for FT in (Float32, Float64)
             (Int(0), Int(1000)), # tspan
             Int(200), # t
             Int(200), # Δt_cpl
-            (;), # surface_masks
             model_sims, # model_sims
             (;), # mode
             (), # diagnostics

--- a/test/debug/debug_amip_plots.jl
+++ b/test/debug/debug_amip_plots.jl
@@ -73,7 +73,6 @@ plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
         (Int(0), Int(1)), # tspan
         Int(200), # t
         Int(200), # Δt_cpl
-        (;), # surface_masks
         model_sims, # model_sims
         (;), # mode
         (), # diagnostics

--- a/test/diagnostics_tests.jl
+++ b/test/diagnostics_tests.jl
@@ -44,7 +44,6 @@ for FT in (Float32, Float64)
                 (Int(0), Int(1000)), # tspan
                 Int(100), # t
                 Int(100), # Δt_cpl
-                (;), # surface_masks
                 (;), # model_sims
                 (;), # mode
                 (dg_2d,),
@@ -85,7 +84,6 @@ for FT in (Float32, Float64)
                 (Int(0), Int(1000)),# tspan
                 Int(100), # t
                 Int(100), # Δt_cpl
-                (;), # surface_masks
                 (;), # model_sims
                 (;), # mode
                 (dg_2d,), # diagnostics
@@ -132,7 +130,6 @@ for FT in (Float32, Float64)
                 (Int(0), Int(1000)), # tspan
                 Int(100), # t
                 Int(100), # Δt_cpl
-                (;), # surface_masks
                 (;), # model_sims
                 (;), # mode
                 (dg_2d,),

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -311,7 +311,6 @@ for FT in (Float32, Float64)
             (Int(0), Int(1)), # tspan
             0, # t
             0, # Δt_cpl
-            (;), # surface_masks
             model_sims, # model_sims
             (;), # mode
             (), # diagnostics

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -42,7 +42,6 @@ for FT in (Float32, Float64)
             (Int(0), Int(1000)), # tspan
             Int(200), # t
             Int(200), # Δt_cpl
-            (;), # surface_masks
             (;), # model_sims
             (;), # mode
             (), # diagnostics

--- a/test/regridder_tests.jl
+++ b/test/regridder_tests.jl
@@ -77,10 +77,10 @@ for FT in (Float32, Float64)
             (Int(0), Int(1000)), # tspan
             Int(200), # t
             Int(200), # Δt_cpl
-            (; land = land_fraction, ice = CC.Fields.zeros(test_space), ocean = CC.Fields.zeros(test_space)), # surface_fractions
             (;
                 ice_sim = DummyStub((; area_fraction = ice_d)),
                 ocean_sim = Interfacer.SurfaceStub((; area_fraction = ocean_d)),
+                land_sim = DummyStub((; area_fraction = land_fraction)),
             ), # model_sims
             (;), # mode
             (), # diagnostics
@@ -93,7 +93,9 @@ for FT in (Float32, Float64)
         Regridder.update_surface_fractions!(cs)
 
         # Test that sum of fractions is 1 everywhere
-        @test all(parent(cs.surface_fractions.ice .+ cs.surface_fractions.land .+ cs.surface_fractions.ocean) .== FT(1))
+        ice_fraction = Interfacer.get_field(cs.model_sims.ice_sim, Val(:area_fraction))
+        ocean_fraction = Interfacer.get_field(cs.model_sims.ocean_sim, Val(:area_fraction))
+        @test all(parent(ice_fraction .+ ocean_fraction .+ land_fraction) .== FT(1))
     end
 
     @testset "test combine_surfaces_from_sol!" begin

--- a/test/time_manager_tests.jl
+++ b/test/time_manager_tests.jl
@@ -25,7 +25,6 @@ for FT in (Float32, Float64)
             tspan, # tspan
             Int(0), # t
             Int(Δt_cpl), # Δt_cpl
-            (;), # surface_masks
             (;), # model_sims
             (;), # mode
             (), # diagnostics
@@ -66,7 +65,6 @@ end
         (Int(0), Int(1000)), # tspan
         Int(200), # t
         Int(200), # Δt_cpl
-        (;), # surface_masks
         (;), # model_sims
         (;), # mode
         (), # diagnostics
@@ -103,7 +101,6 @@ end
         (Int(0), Int(1000)), # tspan
         Int(200), # t
         Int(200), # Δt_cpl
-        (;), # surface_masks
         (;), # model_sims
         (;), # mode
         (), # diagnostics
@@ -172,7 +169,6 @@ end
         (Int(0), Int(1000)), # tspan
         Int(200), # t
         Int(200), # Δt_cpl
-        (;), # surface_masks
         (;), # model_sims
         (;), # mode
         (), # diagnostics


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR removes `surface_fractions` from the `CoupledSimulation` object, and instead accesses it from the surface models themselves. Since this information is available in the component models, it doesn't make sense to redundantly store them in the `CoupledSimulation` object too

closes #807

## To-do
- [x] remove `surface_fractions` from `CoupledSimulation` object
- [x] replace `surface_fractions` access with `get_field(sim, Val(:area_fraction))`
- [x] verify no behavioral changes
  - compared [previous main](https://buildkite.com/clima/climacoupler-ci/builds/4806#01927c14-dc29-4d3e-b5ff-94db4aa721c1) with [this PR](https://buildkite.com/clima/climacoupler-ci/builds/4814#01927cc1-5537-4ae0-ac80-9613e6b6bd93) (before squashing commits)

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
