### PR TITLE
Tr/move co2 to clima artifacts

### DIFF
--- a/artifacts/Artifacts.toml
+++ b/artifacts/Artifacts.toml
@@ -1,10 +1,3 @@
-[co2_dataset]
-git-tree-sha1 = "9c3bd05b68e820fceb43d130ce6b4e86ce788e4e"
-
-    [[co2_dataset.download]]
-    sha256 = "46923ec3e1f9028a11899c47e6b13d675d84daa9db2f37351a19ec9187f87865"
-    url = "https://caltech.box.com/shared/static/fuwajscgyblccy8y9aq01d0pgy91gwut.gz"
-
 [land_mask]
 git-tree-sha1 = "e41bc8c44124f867b64a9d70f1599515ae27f38a"
 

--- a/artifacts/Artifacts.toml
+++ b/artifacts/Artifacts.toml
@@ -1,5 +1,9 @@
-[co2]
-git-tree-sha1 = "0c6039bfcc39f6c6cb20fb331a71f6a381d93f24"
+[co2_dataset]
+git-tree-sha1 = "9c3bd05b68e820fceb43d130ce6b4e86ce788e4e"
+
+    [[co2_dataset.download]]
+    sha256 = "46923ec3e1f9028a11899c47e6b13d675d84daa9db2f37351a19ec9187f87865"
+    url = "https://caltech.box.com/shared/static/fuwajscgyblccy8y9aq01d0pgy91gwut.gz"
 
 [land_mask]
 git-tree-sha1 = "e41bc8c44124f867b64a9d70f1599515ae27f38a"

--- a/artifacts/artifact_funcs.jl
+++ b/artifacts/artifact_funcs.jl
@@ -1,5 +1,4 @@
 import ArtifactWrappers as AW
-import ClimaUtilities.ClimaArtifacts: @clima_artifact
 
 function mask_dataset_path()
     mask_dataset = AW.ArtifactWrapper(

--- a/artifacts/artifact_funcs.jl
+++ b/artifacts/artifact_funcs.jl
@@ -1,10 +1,6 @@
 import ArtifactWrappers as AW
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
 
-function co2_dataset_path(; context = nothing)
-    return @clima_artifact("co2_dataset", context)
-end
-
 function mask_dataset_path()
     mask_dataset = AW.ArtifactWrapper(
         @__DIR__,

--- a/artifacts/artifact_funcs.jl
+++ b/artifacts/artifact_funcs.jl
@@ -1,15 +1,8 @@
 import ArtifactWrappers as AW
+import ClimaUtilities.ClimaArtifacts: @clima_artifact
 
-function co2_dataset_path()
-    co2_dataset = AW.ArtifactWrapper(
-        @__DIR__,
-        "co2",
-        AW.ArtifactFile[AW.ArtifactFile(
-            url = "https://caltech.box.com/shared/static/xg028wnsn57wam6euwrh98fe43ibei8g.nc",
-            filename = "mauna_loa_co2.nc",
-        ),],
-    )
-    return AW.get_data_folder(co2_dataset)
+function co2_dataset_path(; context = nothing)
+    return @clima_artifact("co2_dataset", context)
 end
 
 function mask_dataset_path()

--- a/artifacts/download_artifacts.jl
+++ b/artifacts/download_artifacts.jl
@@ -21,7 +21,6 @@ include(joinpath(@__DIR__, "artifact_funcs.jl"))
 
 # Trigger download if data doesn't exist locally
 function trigger_download()
-    @info "co2 dataset path: `$(co2_dataset_path())`"
     @info "mask dataset path: `$(mask_dataset_path())`"
     return nothing
 end

--- a/experiments/ClimaEarth/Artifacts.toml
+++ b/experiments/ClimaEarth/Artifacts.toml
@@ -30,3 +30,10 @@ git-tree-sha1 = "7f7b6d4ae6055c4c2b6a6dfba5be8b4e6ca1b0be"
     [[historical_sst_sic_lowres.download]]
     sha256 = "b68c0ce6ea682c38e29cb87c9c6ced6736ecac32d0d32dbaba78beb66046a06c"
     url = "https://caltech.box.com/shared/static/ufnesb00zkvlc3sxzhnnmqc3zbatxkb9.gz"
+
+[co2_dataset]
+git-tree-sha1 = "9c3bd05b68e820fceb43d130ce6b4e86ce788e4e"
+
+    [[co2_dataset.download]]
+    sha256 = "46923ec3e1f9028a11899c47e6b13d675d84daa9db2f37351a19ec9187f87865"
+    url = "https://caltech.box.com/shared/static/fuwajscgyblccy8y9aq01d0pgy91gwut.gz"

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -196,7 +196,7 @@ catch error
         "MODEL.ICE.HAD187001-198110.OI198111-202206_lowres.nc",
     )
 end
-co2_data = joinpath(co2_dataset_path(), "co2_mm_mlo.txt")
+co2_data = joinpath(@clima_artifact("co2_dataset", comms_ctx), "co2_mm_mlo.txt")
 land_mask_data = joinpath(mask_dataset_path(), "seamask.nc")
 
 #=
@@ -340,9 +340,11 @@ if mode_name == "amip"
     ## CO2 concentration from temporally varying file
     CO2_text = DelimitedFiles.readdlm(co2_data, Float64; comments = true)
     # The text file only has month and year, so we set the day to 15th of the month
-    CO2_dates = Dates.DateTime.(CO2_text[:, 1], CO2_text[:, 2]) + Dates.Day(14)
+    years = CO2_text[:, 1]
+    months = CO2_text[:, 2]
+    CO2_dates = Dates.DateTime.(years, months) + Dates.Day(14)
     CO2_times = period_to_seconds_float.(CO2_dates .- date0)
-    # convert from ppm to fraction
+    # convert from ppm to fraction, data is in fourth column of the text file
     CO2_vals = CO2_text[:, 4] .* 10^(-6)
     CO2_timevaryinginput = TimeVaryingInput(CO2_times, CO2_vals;)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Reduce usage of ArtifactWrapper
Closes #997 
Relates to ClimaArtifact [PR 51](https://github.com/CliMA/ClimaArtifacts/pull/51)


## To-do
- Check that this does not change results of run_amip.jl 


## Content
- Replace ArtifactWrapper in co2_dataset_path with a clima artifact
- The new co2 artifact contains a text file with co2 monthly means and a text file with daily means
- The old co2 artifact was a NetCDF file generated from the monthly means text file
- run_amip.jl now uses the monthly txt file and parses it into a TimeVaryingInput. 
There are several differences between the old data in the artifact and the new data. First,
the new data does not have lat/lon, but the old Netcdf file did not vary in space even though the dimensions existed.
Second, the dates in the new file all fall exactly on the 15th of the month, while the old file varied by a few hours in each direction.  Third the mean co2 is very slightly off (greatest diff is .01%) due to floating points during unit conversion, but this also seems like an issue in the old data file. 
- Change truncate test to not rely on old NetCDF file

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
