### PR TITLE
fix nightly AMIP diagnostics

### DIFF
--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -126,8 +126,8 @@ function get_period(t_start, t_end)
     secs_per_day = 86400
     if sim_duration >= 90 * secs_per_day
         # if duration >= 90 days, take monthly means
-        period = "30days"
-        calendar_dt = Dates.Day(30)
+        period = "1months"
+        calendar_dt = Dates.Month(1)
     elseif sim_duration >= 30 * secs_per_day
         # if duration >= 30 days, take means over 10 days
         period = "10days"

--- a/test/regridder_tests.jl
+++ b/test/regridder_tests.jl
@@ -320,7 +320,7 @@ end
         NCDatasets.defVar(ds, "time", dates, ("time",);)
         NCDatasets.defVar(ds, "lat", 1:32, ("lat",);)
         NCDatasets.defVar(ds, "lon", 1:64, ("lon",);)
-        dummy_data = reshape(1:(32 * 64 * 100), 64, 32, 100)
+        dummy_data = reshape(1:(32*64*100), 64, 32, 100)
         NCDatasets.defVar(ds, "dummy_var", dummy_data, ("lon", "lat", "time"))
         ds.attrib["title"] = "dummy dataset"
         close(ds)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The nightly AMIP runs are failing because diagnostics are saved with multiple periods, and in the recent diagnostics PR we removed the period selection in the case of having multiple. This is the error produced ([build](https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/102#0192930e-b7df-4e8c-825c-9ae70f37ac8b)):
```
ERROR: LoadError: Found multiple periods for ta: Set(Any["30d", "1M"]). You have to specify it.
...
```

Previously, for simulations running longer than 90 days, we specified the monthly mean for diagnostics from ClimaCoupler using a period of `30days`. I'm not sure where the `1M` diagnostics came from - maybe atmos? Here I exchange the period of `30days` for `1months` to produce only one diagnostic output period.

[passing build](https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/108#_) - ran one tiny AMIP for 91 days to recreate issue with shorter turnaround time