### PR TITLE
use 55km top and viscous sponge in nightly amip

### DIFF
--- a/config/amip_configs/amip.yml
+++ b/config/amip_configs/amip.yml
@@ -24,6 +24,6 @@ t_end: "1098days"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"
-viscous_sponge: false
+viscous_sponge: true
 z_elem: 63
 z_max: 55000.0

--- a/config/nightly_configs/amip_coarse.yml
+++ b/config/nightly_configs/amip_coarse.yml
@@ -3,8 +3,8 @@ albedo_model: "CouplerAlbedo"
 anim: false
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 coupler_toml_file: "toml/amip.toml"
-dt: "180secs"
-dt_cpl: 180
+dt: "240secs"
+dt_cpl: 240
 dt_save_state_to_disk: "30days"
 dt_save_to_sol: "30days"
 dz_bottom: 100.0
@@ -22,10 +22,10 @@ rayleigh_sponge: true
 smoothing_order: 10
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "549days"
+t_end: "732days"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"
-viscous_sponge: false
+viscous_sponge: true
 z_elem: 31
-z_max: 50000.0
+z_max: 55000.0

--- a/config/nightly_configs/amip_coarse_random.yml
+++ b/config/nightly_configs/amip_coarse_random.yml
@@ -3,8 +3,8 @@ albedo_model: "CouplerAlbedo"
 anim: false
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 coupler_toml_file: "toml/amip.toml"
-dt: "180secs"
-dt_cpl: 180
+dt: "240secs"
+dt_cpl: 240
 dt_save_state_to_disk: "30days"
 dt_save_to_sol: "30days"
 dz_bottom: 100.0
@@ -22,11 +22,11 @@ rayleigh_sponge: true
 smoothing_order: 10
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "549days"
+t_end: "732days"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"
 unique_seed: true
-viscous_sponge: false
+viscous_sponge: true
 z_elem: 31
-z_max: 50000.0
+z_max: 55000.0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
One failure mode in the nightly amip is the top layer becomes too cold with too large horizontal velocity. Adding a viscous sponge seems to help. I extended the top back to 55km and increased dt back to 240 seconds. This config works for 2 nightly amip runs: https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/111#_. I'll be a bit optimistic and get it in and see how it works.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
