### PR TITLE
Make `modules` uniform across buildkite pipelines

### DIFF
--- a/.buildkite/amip/pipeline.yml
+++ b/.buildkite/amip/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 96:00:00
-  modules: common
+  modules: climacommon
 
 env:
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100

--- a/.buildkite/benchmarks/pipeline.yml
+++ b/.buildkite/benchmarks/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 24:00:00
-  modules: common
+  modules: climacommon
 
 env:
   JULIA_NVTX_CALLBACKS: gc

--- a/.buildkite/hierarchies/pipeline.yml
+++ b/.buildkite/hierarchies/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_time: 24:00:00
-  modules: climacommon/2024_05_27
+  modules: climacommon
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"

--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_time: 24:00:00
-  modules: climacommon/2024_05_27
+  modules: climacommon
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"

--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 14:00:00
-  modules: common
+  modules: climacommon
 
 env:
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_time: 4:00:00
-  modules: climacommon/2024_05_27
+  modules: climacommon
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"


### PR DESCRIPTION
Update to use `climacommon` (auto latest)
```
	modified:   .buildkite/amip/pipeline.yml
	modified:   .buildkite/benchmarks/pipeline.yml
	modified:   .buildkite/hierarchies/pipeline.yml
	modified:   .buildkite/longruns/pipeline.yml
	modified:   .buildkite/nightly/pipeline.yml
	modified:   .buildkite/pipeline.yml
```