### PR TITLE
don't add atmos default diags in coupler

### DIFF
--- a/.dev/Project.toml
+++ b/.dev/Project.toml
@@ -2,4 +2,4 @@
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 
 [compat]
-JuliaFormatter = "2"
+JuliaFormatter = "1"

--- a/experiments/ClimaCore/heat-diffusion/run.jl
+++ b/experiments/ClimaCore/heat-diffusion/run.jl
@@ -256,7 +256,7 @@ function coupler_solve!(stepping, ics, parameters)
 
 
     ## coupler stepping
-    for t in ((t_start+Δt_coupler):Δt_coupler:t_end)
+    for t in ((t_start + Δt_coupler):Δt_coupler:t_end)
 
         ## STEP ATMOS
         ## pre_atmos

--- a/experiments/ClimaCore/sea_breeze/run.jl
+++ b/experiments/ClimaCore/sea_breeze/run.jl
@@ -269,7 +269,7 @@ function cpl_run(simulation::AOLCoupledSim)
     (; atmos, ocean, land, coupler) = simulation
     Δt_coupled = coupler.Δt_coupled
     ## coupler stepping
-    for t in ((t_start+Δt_coupled):Δt_coupled:t_end)
+    for t in ((t_start + Δt_coupled):Δt_coupled:t_end)
         ## Atmos
         coupler_pull!(atmos, coupler)
         step!(atmos, t)

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -234,7 +234,8 @@ function Interfacer.update_field!(sim::ClimaAtmosSimulation, ::Val{:turbulent_fl
     vec_ct12_ct2 = @. CA.CT12(CA.CT2(CA.unit_basis_vector_data(CA.CT2, surface_local_geometry)), surface_local_geometry)
 
     sim.integrator.p.precomputed.sfc_conditions.ρ_flux_uₕ .= (
-        surface_normal .⊗ CA.C12.(
+        surface_normal .⊗
+        CA.C12.(
             Utilities.swap_space!(axes(vec_ct12_ct1), F_turb_ρτxz) .* vec_ct12_ct1 .+
             Utilities.swap_space!(axes(vec_ct12_ct2), F_turb_ρτyz) .* vec_ct12_ct2,
             surface_local_geometry,

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -152,7 +152,7 @@ if mode_name == "amip" && use_coupler_diagnostics
     push!(
         config_dict["diagnostics"],
         Dict(
-            "short_name" => ["ta", "ua", "hus", "clw", "pr", "ts", "toa_fluxes_net"],
+            "short_name" => ["toa_fluxes_net"],
             "reduction_time" => "average",
             "period" => period,
         ),

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -151,11 +151,7 @@ if mode_name == "amip" && use_coupler_diagnostics
     !haskey(config_dict, "diagnostics") && (config_dict["diagnostics"] = Vector{Dict{Any, Any}}())
     push!(
         config_dict["diagnostics"],
-        Dict(
-            "short_name" => ["toa_fluxes_net"],
-            "reduction_time" => "average",
-            "period" => period,
-        ),
+        Dict("short_name" => ["toa_fluxes_net"], "reduction_time" => "average", "period" => period),
     )
 end
 
@@ -732,7 +728,7 @@ function solve_coupler!(cs)
 
     @info("Starting coupling loop")
     ## step in time
-    for t in ((tspan[begin]+Δt_cpl):Δt_cpl:tspan[end])
+    for t in ((tspan[begin] + Δt_cpl):Δt_cpl:tspan[end])
 
         cs.dates.date[1] = TimeManager.current_date(cs, t)
 

--- a/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
@@ -312,7 +312,7 @@ function solve_coupler!(cs)
 
     @info("Starting coupling loop")
     ## step in time
-    for t in ((tspan[begin]+Δt_cpl):Δt_cpl:tspan[end])
+    for t in ((tspan[begin] + Δt_cpl):Δt_cpl:tspan[end])
 
         cs.dates.date[1] = TimeManager.current_date(cs, t)
 

--- a/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
@@ -326,7 +326,7 @@ function solve_coupler!(cs)
 
     @info("Starting coupling loop")
     ## step in time
-    for t in ((tspan[begin]+Δt_cpl):Δt_cpl:tspan[end])
+    for t in ((tspan[begin] + Δt_cpl):Δt_cpl:tspan[end])
 
         cs.dates.date[1] = TimeManager.current_date(cs, t)
 

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -191,9 +191,18 @@ This is a static field that contains the area fraction of land and sea, ranging 
 Note that land-sea area fraction is different to the land-sea mask, which is a binary field (masks are used internally by the coupler to indicate passive cells that are not populated by a given component model).
 =#
 
-land_area_fraction = FT.(
-    Regridder.land_fraction(FT, dir_paths.regrid, comms_ctx, land_mask_data, "LSMASK", boundary_space, mono = false),
-)
+land_area_fraction =
+    FT.(
+        Regridder.land_fraction(
+            FT,
+            dir_paths.regrid,
+            comms_ctx,
+            land_mask_data,
+            "LSMASK",
+            boundary_space,
+            mono = false,
+        ),
+    )
 
 #=
 ### Surface Model: Bucket Land and Slab Ocean
@@ -370,7 +379,7 @@ function solve_coupler!(cs)
 
     @info("Starting coupling loop")
     ## step in time
-    for t in ((tspan[begin]+Δt_cpl):Δt_cpl:tspan[end])
+    for t in ((tspan[begin] + Δt_cpl):Δt_cpl:tspan[end])
 
         cs.dates.date[1] = TimeManager.current_date(cs, t)
 

--- a/experiments/ClimaEarth/run_dry_held_suarez.jl
+++ b/experiments/ClimaEarth/run_dry_held_suarez.jl
@@ -233,7 +233,7 @@ function solve_coupler!(cs)
     @info("Starting coupling loop")
 
     ## step in time
-    walltime = @elapsed for t in ((tspan[begin]+Δt_cpl):Δt_cpl:tspan[end])
+    walltime = @elapsed for t in ((tspan[begin] + Δt_cpl):Δt_cpl:tspan[end])
 
         cs.dates.date[1] = TimeManager.current_date(cs, t)
 

--- a/experiments/ClimaEarth/run_moist_held_suarez.jl
+++ b/experiments/ClimaEarth/run_moist_held_suarez.jl
@@ -308,7 +308,7 @@ function solve_coupler!(cs)
 
     @info("Starting coupling loop")
     ## step in time
-    for t in ((tspan[begin]+Δt_cpl):Δt_cpl:tspan[end])
+    for t in ((tspan[begin] + Δt_cpl):Δt_cpl:tspan[end])
 
         cs.dates.date[1] = TimeManager.current_date(cs, t)
 

--- a/src/Regridder.jl
+++ b/src/Regridder.jl
@@ -25,7 +25,7 @@ export write_to_hdf5,
     combine_surfaces_from_sol!,
     binary_mask,
     nans_to_zero,
-    truncate_dataset#= Converts NaNs to zeros of the same type. =#
+    truncate_dataset #= Converts NaNs to zeros of the same type. =#
 
 
 

--- a/test/TestHelper.jl
+++ b/test/TestHelper.jl
@@ -94,8 +94,8 @@ function gen_ncdata(FT, path, varname, val)
     v = NCDatasets.defVar(nc, varname, FT, ("lon", "lat"))
 
     # Populate lon and lat
-    lon[:] = [i for i in 0.0:(360/64):(360-(360/64))]
-    lat[:] = [i for i in (-90+(180/64)):(180/32):(90-(180/64))]
+    lon[:] = [i for i in 0.0:(360 / 64):(360 - (360 / 64))]
+    lat[:] = [i for i in (-90 + (180 / 64)):(180 / 32):(90 - (180 / 64))]
 
     # Generate some example data and write it to v
     v[:, :] = [val for i in 1:nc.dim["lon"], j in 1:nc.dim["lat"]]

--- a/test/component_model_tests/eisenman_seaice_tests.jl
+++ b/test/component_model_tests/eisenman_seaice_tests.jl
@@ -36,7 +36,7 @@ for FT in (Float32, Float64)
         Y.T_ml .= params_ice.T_base
 
         # no atmos fluxes, F_a
-        Ya.∂F_turb_energy∂T_sfc .= .- get_∂F_rad_energy∂T_sfc.(Y.T_sfc, Ref(params_ice)) # ∂F_turb_energy∂T_sfc + ∂F_rad_energy∂T_sfc = 0
+        Ya.∂F_turb_energy∂T_sfc .= .-get_∂F_rad_energy∂T_sfc.(Y.T_sfc, Ref(params_ice)) # ∂F_turb_energy∂T_sfc + ∂F_rad_energy∂T_sfc = 0
         Ya.F_rad .= 0
         Ya.F_turb .= 0
 
@@ -251,7 +251,7 @@ for FT in (Float32, Float64)
         Y.T_sfc .= params_ice.T_base
 
         # zero atmos fluxes and their derivatives
-        Ya.∂F_turb_energy∂T_sfc .= .- get_∂F_rad_energy∂T_sfc.(Y.T_sfc, Ref(params_ice)) # ∂F_turb_energy∂T_sfc + ∂F_rad_energy∂T_sfc = 0
+        Ya.∂F_turb_energy∂T_sfc .= .-get_∂F_rad_energy∂T_sfc.(Y.T_sfc, Ref(params_ice)) # ∂F_turb_energy∂T_sfc + ∂F_rad_energy∂T_sfc = 0
         Ya.F_turb .= 0
         Ya.F_rad .= 0
 
@@ -283,7 +283,7 @@ for FT in (Float32, Float64)
         T_ml_0 = deepcopy(Y.T_ml)
 
         # no atmos fluxes or their derivatives
-        Ya.∂F_turb_energy∂T_sfc .= .- get_∂F_rad_energy∂T_sfc.(Y.T_sfc, Ref(params_ice)) # ∂F_turb_energy∂T_sfc + ∂F_rad_energy∂T_sfc = 0
+        Ya.∂F_turb_energy∂T_sfc .= .-get_∂F_rad_energy∂T_sfc.(Y.T_sfc, Ref(params_ice)) # ∂F_turb_energy∂T_sfc + ∂F_rad_energy∂T_sfc = 0
         Ya.F_turb .= 0
         Ya.F_rad .= 0
 

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -107,7 +107,7 @@ for FT in (Float32, Float64)
 
         # analytical solution
         tot_energy_an = sum(FT.(F_r .* 3Δt .+ 1e6 .* 1.25))
-        tot_water_an = sum(FT.(.- P .* 3Δt .* 0.5 .+ CC.Fields.ones(space)))
+        tot_water_an = sum(FT.(.-P .* 3Δt .* 0.5 .+ CC.Fields.ones(space)))
 
         # run check_conservation!
         ConservationChecker.check_conservation!(cs, runtime_check = true)

--- a/test/regridder_tests.jl
+++ b/test/regridder_tests.jl
@@ -320,7 +320,7 @@ end
         NCDatasets.defVar(ds, "time", dates, ("time",);)
         NCDatasets.defVar(ds, "lat", 1:32, ("lat",);)
         NCDatasets.defVar(ds, "lon", 1:64, ("lon",);)
-        dummy_data = reshape(1:(32*64*100), 64, 32, 100)
+        dummy_data = reshape(1:(32 * 64 * 100), 64, 32, 100)
         NCDatasets.defVar(ds, "dummy_var", dummy_data, ("lon", "lat", "time"))
         ds.attrib["title"] = "dummy dataset"
         close(ds)

--- a/test/time_manager_tests.jl
+++ b/test/time_manager_tests.jl
@@ -34,7 +34,7 @@ for FT in (Float32, Float64)
             nothing, # amip_diags_handler
         )
 
-        for t in ((tspan[1]+Δt_cpl):Δt_cpl:tspan[end])
+        for t in ((tspan[1] + Δt_cpl):Δt_cpl:tspan[end])
             @test TimeManager.current_date(cs, t) == date0 + Dates.Second(t)
         end
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Currently, the nightly AMIP runs are broken because we're outputting duplicate diagnostics. This is because we're saving diagnostics via the coupler that are already output by atmos.

Also reverts JuliaFormatter to v1 after 2.0.0 release was yanked, so that formatter check will pass

## To-do
- [x] only specify additional atmos diagnostics defined in the coupler, not diagnostics we get from atmos
- [ ] check outputs in CI
- [x] revert formatter
