### PR TITLE
fix amip_diags_handler close

### DIFF
--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -960,5 +960,5 @@ if ClimaComms.iamroot(comms_ctx)
     # end #hide
 
     ## close all AMIP diagnostics file writers
-    mode_name == "amip" && map(diag -> close(diag.output_writer), amip_diags_handler.scheduled_diagnostics)
+    !isnothing(amip_diags_handler) && map(diag -> close(diag.output_writer), amip_diags_handler.scheduled_diagnostics)
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This weekend's diagnostic EDMF benchmark runs [failed](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/195#_) because we tried to close the `amip_diags_handler` when it was never created. This PR fixes the check to see if it needs to be closed so we only close if it exists.
