### PR TITLE
Fix downstream test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,8 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
+      # Run own downstream test
+      - run: |
+          julia --color=yes --project=experiments/ClimaEarth -e 'using Pkg; Pkg.instantiate()'
+          julia --color=yes --project=experiments/ClimaEarth -e 'using Pkg; Pkg.develop(; path = ".")'
+          julia --color=yes --project=experiments/ClimaEarth experiments/ClimaEarth/test/runtests.jl

--- a/experiments/ClimaEarth/test/amip_test.yml
+++ b/experiments/ClimaEarth/test/amip_test.yml
@@ -22,7 +22,7 @@ rayleigh_sponge: true
 smoothing_order: 10
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "549days"
+t_end: "540secs"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"


### PR DESCRIPTION
The downstream test was running for 549 days and was not being run in this repo. This commit fixes both issues.