### PR TITLE
fix simulation length

### DIFF
--- a/experiments/ClimaEarth/test/amip_test.yml
+++ b/experiments/ClimaEarth/test/amip_test.yml
@@ -1,3 +1,5 @@
+# This configuration is similar to the coarse "tiny" AMIP configuration,
+# but with a shorter simulation length
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 anim: false
@@ -22,7 +24,7 @@ rayleigh_sponge: true
 smoothing_order: 10
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "549days"
+t_end: "360secs"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The downstream coupler test is meant to run for only two timesteps, but I had accidentally copied the tiny AMIP config without changing `t_end`. It is fixed here

