### PR TITLE
use 65km top in amip

### DIFF
--- a/config/amip_configs/amip.yml
+++ b/config/amip_configs/amip.yml
@@ -26,4 +26,4 @@ topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"
 viscous_sponge: true
 z_elem: 63
-z_max: 55000.0
+z_max: 65000.0

--- a/config/nightly_configs/amip_coarse.yml
+++ b/config/nightly_configs/amip_coarse.yml
@@ -23,10 +23,10 @@ rayleigh_sponge: true
 smoothing_order: 10
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "732days"
+t_end: "549days"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"
 viscous_sponge: true
-z_elem: 31
-z_max: 55000.0
+z_elem: 39
+z_max: 65000.0

--- a/config/nightly_configs/amip_coarse_random.yml
+++ b/config/nightly_configs/amip_coarse_random.yml
@@ -22,11 +22,11 @@ rayleigh_sponge: true
 smoothing_order: 10
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "732days"
+t_end: "549days"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"
 unique_seed: true
 viscous_sponge: true
-z_elem: 31
-z_max: 55000.0
+z_elem: 39
+z_max: 65000.0

--- a/toml/amip.toml
+++ b/toml/amip.toml
@@ -2,10 +2,10 @@
 value = 10.0
 
 [zd_rayleigh]
-value = 35000.0
+value = 45000.0
 
 [zd_viscous]
-value = 35000.0
+value = 45000.0
 
 [precipitation_timescale]
 value = 600


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Moves model top to 65km in amip configs. For the coarse resolution one I have to increase the number of levels to have enough levels in the sponge to stabilize it, and as a result I reduce t_end. It is stable for a year: https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/124. It may still be finicky and I may need to fine-tune the grids in the future.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
