### PR TITLE
Fix more test warnings

### DIFF
--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -149,8 +149,8 @@ following properties:
 | `snow_precipitation` | snow precipitation at the surface | kg m^-2 s^-1 |
 | `turbulent_energy_flux` | aerodynamic turbulent surface fluxes of energy (sensible and latent heat) | W m^-2 |
 | `turbulent_moisture_flux` | aerodynamic turbulent surface fluxes of energy (evaporation) | kg m^-2 s^-1 |
-| `surface_direct albedo`    | bulk direct surface albedo; needed if calculated externally of the surface model (e.g. ocean albedo from the atmospheric state) | |
-| `surface_diffuse albedo`    | bulk diffuse surface albedo; needed if calculated externally of the surface model (e.g. ocean albedo from the atmospheric state) | |
+| `surface_direct_albedo`    | bulk direct surface albedo; needed if calculated externally of the surface model (e.g. ocean albedo from the atmospheric state) | |
+| `surface_diffuse_albedo`    | bulk diffuse surface albedo; needed if calculated externally of the surface model (e.g. ocean albedo from the atmospheric state) | |
 
 ### SurfaceModelSimulation - optional functions
 - `update_turbulent_fluxes!(::ComponentModelSimulation, fields::NamedTuple)`:

--- a/src/surface_stub.jl
+++ b/src/surface_stub.jl
@@ -54,6 +54,11 @@ end
 function update_field!(sim::SurfaceStub, ::Val{:surface_diffuse_albedo}, field::CC.Fields.Field)
     sim.cache.α_diffuse .= field
 end
+update_field!(::SurfaceStub, ::Val{:liquid_precipitation}, field) = nothing
+update_field!(::SurfaceStub, ::Val{:radiative_energy_flux_sfc}, field) = nothing
+update_field!(::SurfaceStub, ::Val{:snow_precipitation}, field) = nothing
+update_field!(::SurfaceStub, ::Val{:turbulent_energy_flux}, field) = nothing
+update_field!(::SurfaceStub, ::Val{:turbulent_moisture_flux}, field) = nothing
 
 """
     name(::ComponentModelSimulation)

--- a/test/TestHelper.jl
+++ b/test/TestHelper.jl
@@ -86,7 +86,7 @@ function gen_ncdata(FT, path, varname, val)
     # Define dataset information
     NCDatasets.defDim(nc, "lon", 64)
     NCDatasets.defDim(nc, "lat", 32)
-    nc.attrib["title"] = "this is an NCDataset containing all 1s on a lat/lon grid"
+    nc.attrib["title"] = "this is an NCDataset containing the same value at each point on a lat/lon grid"
 
     # Define variables
     lon = NCDatasets.defVar(nc, "lon", FT, ("lon",))
@@ -99,6 +99,36 @@ function gen_ncdata(FT, path, varname, val)
 
     # Generate some example data and write it to v
     v[:, :] = [val for i in 1:nc.dim["lon"], j in 1:nc.dim["lat"]]
+
+    close(nc)
+end
+
+function gen_ncdata_time(FT, path, varname, val)
+    isfile(path) && rm(path)
+
+    # Create dataset of all ones
+    nc = NCDatasets.NCDataset(path, "c")
+
+    # Define dataset information
+    NCDatasets.defDim(nc, "lon", 64)
+    NCDatasets.defDim(nc, "lat", 32)
+    NCDatasets.defDim(nc, "time", 2)
+    nc.attrib["title"] = "this is an NCDataset containing the same value at each point on a lat/lon grid at two times"
+
+    # Define variables
+    lon = NCDatasets.defVar(nc, "lon", FT, ("lon",))
+    lat = NCDatasets.defVar(nc, "lat", FT, ("lat",))
+    time = NCDatasets.defVar(nc, "time", Float64, ("time",))
+    v = NCDatasets.defVar(nc, varname, FT, ("lon", "lat", "time"))
+
+    # Populate lon and lat
+    lon[:] = [i for i in 0.0:(360 / 64):(360 - (360 / 64))]
+    lat[:] = [i for i in (-90 + (180 / 64)):(180 / 32):(90 - (180 / 64))]
+    time[:] = [Float64(i) for i in 1:2]
+
+    # Generate some example data and write it to v
+    v[:, :, 1] = [val * 0 for i in 1:nc.dim["lon"], j in 1:nc.dim["lat"]]
+    v[:, :, 2] = [val for i in 1:nc.dim["lon"], j in 1:nc.dim["lat"]]
 
     close(nc)
 end

--- a/test/debug/debug_amip_plots.jl
+++ b/test/debug/debug_amip_plots.jl
@@ -1,11 +1,13 @@
 # testing functions used to produce user-defined debugging plots for AMIP experiments
-import Test: @test, @testset
+import Test: @test, @testset, @test_logs
 import ClimaCore as CC
 import ClimaCoupler: Interfacer
 
 include(joinpath("..", "TestHelper.jl"))
 import .TestHelper
 
+# Prevent GKS headless operation mode warning
+ENV["GKSwstype"] = "nul"
 FT = Float64
 
 struct ClimaAtmosSimulation{C} <: Interfacer.AtmosModelSimulation
@@ -53,9 +55,9 @@ plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
     surface_names = (:surface_field,)
     stub_names = (:stub_field,)
 
-    atmos_fields = NamedTuple{atmos_names}(ntuple(i -> CC.Fields.ones(boundary_space), length(atmos_names)))
-    surface_fields = NamedTuple{surface_names}(ntuple(i -> CC.Fields.ones(boundary_space), length(surface_names)))
-    stub_fields = NamedTuple{stub_names}(ntuple(i -> CC.Fields.ones(boundary_space), length(stub_names)))
+    atmos_fields = NamedTuple{atmos_names}(ntuple(i -> CC.Fields.zeros(boundary_space), length(atmos_names)))
+    surface_fields = NamedTuple{surface_names}(ntuple(i -> CC.Fields.zeros(boundary_space), length(surface_names)))
+    stub_fields = NamedTuple{stub_names}(ntuple(i -> CC.Fields.zeros(boundary_space), length(stub_names)))
     coupler_fields = NamedTuple{coupler_names}(ntuple(i -> CC.Fields.zeros(boundary_space), length(coupler_names)))
 
     model_sims = (;
@@ -83,7 +85,7 @@ plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
     )
 
     output_plots = "test_debug"
-    debug(cs, output_plots)
+    @test_logs (:info, "plotting debug in test_debug") debug(cs, output_plots)
     @test isfile("test_debug/debug_ClimaAtmosSimulation.png")
     @test isfile("test_debug/debug_BucketSimulation.png")
     @test isfile("test_debug/debug_SurfaceStub.png")
@@ -91,5 +93,4 @@ plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
 
     # remove output
     rm(output_plots; recursive = true)
-
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Removes test warnings due to FieldExchanger tests, Regridder tests, and debug_plots tests. Also adds a TODO to remove ClimaCoupler's `set_surface_albedo!` method after https://github.com/CliMA/ClimaAtmos.jl/pull/3400 is merged + released, which will fix an additional warning.

almost closes #933 (see todo)

## To-do
- (separate PR) remove `CA.set_surface_albedo!` after https://github.com/CliMA/ClimaAtmos.jl/pull/3400 is merged + ClimaAtmos released

## Content
- field_exchanger_tests.jl: extend `update_field!` function for all variables we expect it for
- debug_amip_plots.jl: 
  - include `climaatmos.jl` and `climaland_bucket.jl` in `exp/ClimaEarth/user/debug_plots.jl`, since types defined in those files are used in that file. This is done conditionally so that running `runtests.jl` doesn't produce warnings from including these multiple times (from separate test files).
    - these includes could also be moved into the test file, but I think it's most logical to include them in the file that uses them
  - set `GKSwstype` environment variable to prevent warning in setting without display
  - set dummy fields to 0 instead of 1 to avoid precision warning
- regridder_tests.jl:
  - add tests for `get_time` which test the 2 cases of an NCDataset containing or not containing a time dimension
  - update the `land_fraction` test to use an NCDataset containing a time dimension, to avoid warning output


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
