### PR TITLE
Update precipitation artifact hash and filename

### DIFF
--- a/experiments/ClimaEarth/Artifacts.toml
+++ b/experiments/ClimaEarth/Artifacts.toml
@@ -12,10 +12,10 @@ git-tree-sha1 = "53a27731c0a2ec60756af24e4c60ac37da4a32bc"
     url = "https://caltech.box.com/shared/static/lmzvnjkxctlb0fanieeqxll0vdrbei9e.gz"
 
 [precipitation_obs]
-git-tree-sha1 = "7486bf32e9352493f69364aead26f01eaf90d2af"
+git-tree-sha1 = "5f0075f042bc83b580d2c4f725f851d8e0b9c20a"
 
     [[precipitation_obs.download]]
-    sha256 = "463ebc1886c4e0be9656656da699f2cbb87d7c2568d5e81277c0c8a415dc8143"
+    sha256 = "1aea361ee1c2636bd5c4cc343202dab814d246a7e0356a9caac9fd9c7cf3821c"
     url = "https://caltech.box.com/shared/static/j63uak557kw7tlzb3dgwifoaeczekzm4.gz"
 
 [radiation_obs]

--- a/experiments/ClimaEarth/leaderboard/data_sources.jl
+++ b/experiments/ClimaEarth/leaderboard/data_sources.jl
@@ -67,7 +67,7 @@ obs_var_dict = Dict{String, Any}(
     "pr" =>
         (start_date) -> begin
             obs_var = ClimaAnalysis.OutputVar(
-                joinpath(@clima_artifact("precipitation_obs"), "gpcp.precip.mon.mean.197901-202305.nc"),
+                joinpath(@clima_artifact("precipitation_obs"), "precip.mon.mean.nc"),
                 "precip",
                 new_start_date = start_date,
                 shift_by = Dates.firstdayofmonth,

--- a/test/Artifacts.toml
+++ b/test/Artifacts.toml
@@ -6,8 +6,8 @@ git-tree-sha1 = "53a27731c0a2ec60756af24e4c60ac37da4a32bc"
     url = "https://caltech.box.com/shared/static/lmzvnjkxctlb0fanieeqxll0vdrbei9e.gz"
 
 [precipitation_obs]
-git-tree-sha1 = "7486bf32e9352493f69364aead26f01eaf90d2af"
+git-tree-sha1 = "5f0075f042bc83b580d2c4f725f851d8e0b9c20a"
 
     [[precipitation_obs.download]]
-    sha256 = "463ebc1886c4e0be9656656da699f2cbb87d7c2568d5e81277c0c8a415dc8143"
+    sha256 = "1aea361ee1c2636bd5c4cc343202dab814d246a7e0356a9caac9fd9c7cf3821c"
     url = "https://caltech.box.com/shared/static/j63uak557kw7tlzb3dgwifoaeczekzm4.gz"

--- a/test/experiment_tests/Artifacts.toml
+++ b/test/experiment_tests/Artifacts.toml
@@ -2,8 +2,8 @@
 git-tree-sha1 = "945e31f8028a581f7e8435cb691462124484567a"
 
 [precipitation_obs]
-git-tree-sha1 = "7486bf32e9352493f69364aead26f01eaf90d2af"
+git-tree-sha1 = "5f0075f042bc83b580d2c4f725f851d8e0b9c20a"
 
     [[precipitation_obs.download]]
-    sha256 = "463ebc1886c4e0be9656656da699f2cbb87d7c2568d5e81277c0c8a415dc8143"
+    sha256 = "1aea361ee1c2636bd5c4cc343202dab814d246a7e0356a9caac9fd9c7cf3821c"
     url = "https://caltech.box.com/shared/static/j63uak557kw7tlzb3dgwifoaeczekzm4.gz"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose
The precipitation-obs artifact is updated in this [pr](https://github.com/CliMA/ClimaArtifacts/pull/60)
This updates the usage of the artifact (filename changed) and the hashes.
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
