### PR TITLE
fix artifacts dir paths

### DIFF
--- a/experiments/ClimaEarth/user_io/benchmarks.jl
+++ b/experiments/ClimaEarth/user_io/benchmarks.jl
@@ -113,8 +113,8 @@ function get_run_info(parsed_args, run_type)
     end
 
     # Construct CPU and GPU artifacts directories
-    cpu_artifacts_dir = joinpath(output_dir, mode_name, cpu_job_id) * "_artifacts"
-    gpu_artifacts_dir = joinpath(output_dir, mode_name, gpu_job_id) * "_artifacts"
+    cpu_artifacts_dir = joinpath(output_dir, mode_name, cpu_job_id, "artifacts")
+    gpu_artifacts_dir = joinpath(output_dir, mode_name, gpu_job_id, "artifacts")
 
     return (cpu_job_id, gpu_job_id, cpu_artifacts_dir, gpu_artifacts_dir)
 end

--- a/experiments/ClimaEarth/user_io/io_helpers.jl
+++ b/experiments/ClimaEarth/user_io/io_helpers.jl
@@ -5,12 +5,12 @@
 
 Create output directories for the experiment. If `comms_ctx` is provided, only the root process will create the directories.
 By default, the regrid directory is created as a temporary directory inside the output directory,
-and the artifacts directory is created inside the output directory with the suffix `_artifacts`.
+and the artifacts directory is created inside the output directory with the name `artifacts/`.
 
 # Arguments
 - `output_dir::String`: The directory where the output files will be stored. Default is the current directory.
 - `regrid_dir::String`: The directory where the regridded files will be stored. Default is `output_dir/regrid_tmp/`.
-- `artifacts_dir::String`: The directory where the artifacts will be stored. Default is `output_dir_artifacts/`.
+- `artifacts_dir::String`: The directory where the artifacts will be stored. Default is `output_dir/artifacts/`.
 - `comms_ctx::Union{Nothing, ClimaComms.AbstractCommsContext}`: The communicator context. If provided, only the root process will create the directories.
 
 # Returns

--- a/test/component_model_tests/climaatmos_standalone/atmos_driver.jl
+++ b/test/component_model_tests/climaatmos_standalone/atmos_driver.jl
@@ -53,7 +53,7 @@ else
 end
 
 # Specify atmos output directory to be inside the coupler output directory
-output_dir = joinpath(pkgdir(ClimaCoupler), "experiments", "ClimaEarth", "output", "climaatmos", job_id) * "_artifacts"
+output_dir = joinpath(pkgdir(ClimaCoupler), "experiments", "ClimaEarth", "output", "climaatmos", job_id, "artifacts")
 !isdir(output_dir) && mkpath(output_dir)
 config = merge(config, Dict("output_dir" => output_dir))
 atmos_config = CA.AtmosConfig(config)

--- a/test/mpi_tests/local_checks.sh
+++ b/test/mpi_tests/local_checks.sh
@@ -12,7 +12,7 @@ module load climacommon/2024_10_09
 export CC_PATH=$(pwd)/ # adjust this to the path of your ClimaCoupler.jl directory
 export JOB_ID=coarse_single_ft64_hourly_checkpoints_restart
 export CONFIG_FILE=${CC_PATH}config/ci_configs/${JOB_ID}.yml
-export RESTART_DIR=experiments/ClimaEarth/output/amip/${JOB_ID}_artifacts/
+export RESTART_DIR=experiments/ClimaEarth/output/amip/${JOB_ID}/artifacts/
 
 export OPENBLAS_NUM_THREADS=1
 export JULIA_NVTX_CALLBACKS=gc


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The default artifacts dir was changed in [#953](https://github.com/CliMA/ClimaCoupler.jl/pull/953/commits/e4bbc3008ab4a6fd0ea91bf184f589070d930849), but the changes weren't propagated to all instances of the artifacts directory. Notably the benchmarks artifacts dirs weren't updated, so those runs have been [failing](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/201#0192f10a-c851-4509-83e1-c31aafc69d8f). This PR finishes propagating those changes.