### PR TITLE
specify dt in benchmark configs

### DIFF
--- a/config/benchmark_configs/amip_diagedmf.yml
+++ b/config/benchmark_configs/amip_diagedmf.yml
@@ -1,6 +1,7 @@
 FLOAT_TYPE: "Float32"
 atmos_config_file: "config/benchmark_configs/climaatmos_diagedmf.yml"
 atmos_config_repo: "ClimaCoupler"
+dt: "120secs"
 dt_cpl: 120
 dt_save_state_to_disk: "Inf"
 dt_save_to_sol: "Inf"

--- a/config/benchmark_configs/amip_diagedmf_io.yml
+++ b/config/benchmark_configs/amip_diagedmf_io.yml
@@ -1,6 +1,7 @@
 FLOAT_TYPE: "Float32"
 atmos_config_file: "config/benchmark_configs/climaatmos_diagedmf_io.yml"
 atmos_config_repo: "ClimaCoupler"
+dt: "120secs"
 dt_cpl: 120
 dt_save_state_to_disk: "12hours"
 dt_save_to_sol: "12hours"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The benchmark runs failed this weekend because `dt` was not specified correctly (see error [here](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/203#01931517-49b3-4eae-8db2-d86031ce1725)).

The benchmark AMIP config files (e.g. `config/benchmark_configs/amip_diagedmf.yml`) were previously relying on `dt` being specified in the atmos config files they use (e.g. `config/benchmark_configs/climaatmos_diagedmf.yml`), rather than specifying `dt` explicitly in the AMIP configs. When the configs were merged in `get_atmos_config_dict`, the atmos config's `dt` was inherited by the coupled config file ([here](https://github.com/CliMA/ClimaCoupler.jl/pull/1059/files#diff-f45f364a1336ac9f09399589b402d600f85f73e2080d2203523268229d7874aaL353)). After https://github.com/CliMA/ClimaCoupler.jl/pull/1059, we overwrite the `dt` entry in the atmos config with the entry in the coupler config ([here](https://github.com/CliMA/ClimaCoupler.jl/pull/1059/files#diff-f45f364a1336ac9f09399589b402d600f85f73e2080d2203523268229d7874aaR356)). This requires that the coupler config does have an entry for `dt` (or all component dts), so we can no longer rely on the atmos dt.

This is a change in behavior, but the previous behavior was not necessarily desired. It seems reasonable to me that the config file requires that `dt` is specified there, rather than inherited from an atmosphere config, so I think we can keep the current setup and just add `dt` entries to the coupled configs that didn't have it before.

## To Do
- [x] Add a `dt` entry to AMIP benchmark configs
- [x] Verify that all configs specify `dt` or component model dts