### PR TITLE
change amip to 60km

### DIFF
--- a/config/amip_configs/amip.yml
+++ b/config/amip_configs/amip.yml
@@ -27,4 +27,4 @@ topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"
 viscous_sponge: true
 z_elem: 63
-z_max: 55000.0
+z_max: 60000.0

--- a/config/nightly_configs/amip_coarse.yml
+++ b/config/nightly_configs/amip_coarse.yml
@@ -22,10 +22,10 @@ radiation_reset_rng_seed: true
 rayleigh_sponge: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "732days"
+t_end: "549days"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"
 viscous_sponge: true
-z_elem: 31
-z_max: 55000.0
+z_elem: 39
+z_max: 60000.0

--- a/config/nightly_configs/amip_coarse_random.yml
+++ b/config/nightly_configs/amip_coarse_random.yml
@@ -21,11 +21,11 @@ output_default_diagnostics: true
 rayleigh_sponge: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "732days"
+t_end: "549days"
 topo_smoothing: true
 topography: "Earth"
 turb_flux_partition: "CombinedStateFluxesMOST"
 unique_seed: true
 viscous_sponge: true
-z_elem: 31
-z_max: 55000.0
+z_elem: 39
+z_max: 60000.0

--- a/toml/amip.toml
+++ b/toml/amip.toml
@@ -2,10 +2,10 @@
 value = 10.0
 
 [zd_rayleigh]
-value = 35000.0
+value = 40000.0
 
 [zd_viscous]
-value = 35000.0
+value = 40000.0
 
 [precipitation_timescale]
 value = 600


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Changes the amip top to 60km. I have to increase vertical levels to make the coarse amip stable, and as a result I reduce t_end so that it can finish in 12 hours. It runs for a year here: https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/143#0192fd7b-fa55-4a47-97c9-2016c06180f1. We'll see how the nightly amip goes:)

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
