### PR TITLE
remove anim config option

### DIFF
--- a/config/amip_configs/amip.yml
+++ b/config/amip_configs/amip.yml
@@ -1,6 +1,5 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
-anim: false
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 coupler_toml_file: "toml/amip.toml"
 dt: "120secs"

--- a/config/ci_configs/amip_coarse_ft32.yml
+++ b/config/ci_configs/amip_coarse_ft32.yml
@@ -1,5 +1,4 @@
 FLOAT_TYPE: "Float32"
-anim: true
 apply_limiter: false
 dt: "400secs"
 dt_cpl: 400

--- a/config/ci_configs/amip_coarse_ft64_hourly_checkpoints.yml
+++ b/config/ci_configs/amip_coarse_ft64_hourly_checkpoints.yml
@@ -1,4 +1,3 @@
-anim: true
 apply_limiter: false
 dt: "400secs"
 dt_cpl: 400

--- a/config/ci_configs/amip_coarse_ft64_hourly_checkpoints_restart.yml
+++ b/config/ci_configs/amip_coarse_ft64_hourly_checkpoints_restart.yml
@@ -1,4 +1,3 @@
-anim: false
 apply_limiter: false
 dt: "400secs"
 dt_cpl: 400

--- a/config/ci_configs/amip_coarse_mpi.yml
+++ b/config/ci_configs/amip_coarse_mpi.yml
@@ -1,4 +1,3 @@
-anim: true
 apply_limiter: false
 dt: "400secs"
 dt_cpl: 400

--- a/config/ci_configs/amip_target_topo_diagedmf_shortrun.yml
+++ b/config/ci_configs/amip_target_topo_diagedmf_shortrun.yml
@@ -1,5 +1,4 @@
 FLOAT_TYPE: "Float32"
-anim: false
 apply_limiter: false
 atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml"
 dt: "100secs"

--- a/config/ci_configs/interactive_debug.yml
+++ b/config/ci_configs/interactive_debug.yml
@@ -1,4 +1,3 @@
-anim: true
 apply_limiter: false
 coupler_output_dir: "experiments/ClimaEarth/output"
 dt: "200secs"

--- a/config/ci_configs/slabplanet_atmos_diags.yml
+++ b/config/ci_configs/slabplanet_atmos_diags.yml
@@ -1,4 +1,3 @@
-anim: true
 apply_limiter: false
 ci_plots: true
 dt: "200secs"

--- a/config/ci_configs/slabplanet_default.yml
+++ b/config/ci_configs/slabplanet_default.yml
@@ -1,4 +1,3 @@
-anim: true
 apply_limiter: false
 dt: "200secs"
 dt_cpl: 200

--- a/config/ci_configs/slabplanet_dry_norad.yml
+++ b/config/ci_configs/slabplanet_dry_norad.yml
@@ -1,4 +1,3 @@
-anim: false
 apply_limiter: false
 conservation_softfail: true
 dt: "200secs"

--- a/config/ci_configs/slabplanet_eisenman.yml
+++ b/config/ci_configs/slabplanet_eisenman.yml
@@ -1,4 +1,3 @@
-anim: true
 apply_limiter: false
 conservation_softfail: true
 dt: "200secs"

--- a/config/ci_configs/slabplanet_ft32.yml
+++ b/config/ci_configs/slabplanet_ft32.yml
@@ -1,5 +1,4 @@
 FLOAT_TYPE: "Float32"
-anim: true
 apply_limiter: false
 dt: "200secs"
 dt_cpl: 200

--- a/config/ci_configs/slabplanet_nonmono.yml
+++ b/config/ci_configs/slabplanet_nonmono.yml
@@ -1,4 +1,3 @@
-anim: true
 apply_limiter: false
 dt: "200secs"
 dt_cpl: 200

--- a/config/ci_configs/slabplanet_partitioned_fluxes.yml
+++ b/config/ci_configs/slabplanet_partitioned_fluxes.yml
@@ -1,4 +1,3 @@
-anim: true
 apply_limiter: false
 dt: "200secs"
 dt_cpl: 200

--- a/config/longrun_configs/slabplanet_aqua_atmos_sf_couple.yml
+++ b/config/longrun_configs/slabplanet_aqua_atmos_sf_couple.yml
@@ -1,4 +1,3 @@
-anim: true
 conservation_softfail: true
 dt: "200secs"
 dt_cpl: 200

--- a/config/longrun_configs/slabplanet_aqua_atmos_sf_nocouple.yml
+++ b/config/longrun_configs/slabplanet_aqua_atmos_sf_nocouple.yml
@@ -1,4 +1,3 @@
-anim: true
 conservation_softfail: true
 dt: "200secs"
 dt_cpl: 1728000

--- a/config/longrun_configs/slabplanet_aqua_coupler_sf.yml
+++ b/config/longrun_configs/slabplanet_aqua_coupler_sf.yml
@@ -1,4 +1,3 @@
-anim: true
 conservation_softfail: true
 dt: "200secs"
 dt_cpl: 200

--- a/config/longrun_configs/slabplanet_aqua_coupler_sf_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_aqua_coupler_sf_evolve_ocn.yml
@@ -1,4 +1,3 @@
-anim: true
 dt: "200secs"
 dt_cpl: 200
 dt_save_to_sol: "10days"

--- a/config/longrun_configs/slabplanet_aqua_target.yml
+++ b/config/longrun_configs/slabplanet_aqua_target.yml
@@ -1,4 +1,3 @@
-anim: true
 atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_0M.yml"
 dt: "120secs"
 dt_cloud_fraction: "1hours"

--- a/config/longrun_configs/slabplanet_aqua_target_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_aqua_target_evolve_ocn.yml
@@ -1,4 +1,3 @@
-anim: true
 atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_0M.yml"
 dt: "120secs"
 dt_cloud_fraction: "1hours"

--- a/config/longrun_configs/slabplanet_aqua_target_nocouple.yml
+++ b/config/longrun_configs/slabplanet_aqua_target_nocouple.yml
@@ -1,4 +1,3 @@
-anim: true
 atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_0M.yml"
 dt: "120secs"
 dt_cloud_fraction: "1hours"

--- a/config/longrun_configs/slabplanet_coupler_sf_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_coupler_sf_evolve_ocn.yml
@@ -1,4 +1,3 @@
-anim: true
 dt: "200secs"
 dt_cpl: 200
 dt_save_to_sol: "10days"

--- a/config/longrun_configs/slabplanet_target.yml
+++ b/config/longrun_configs/slabplanet_target.yml
@@ -1,4 +1,3 @@
-anim: true
 atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_0M.yml"
 dt: "120secs"
 dt_cloud_fraction: "1hours"

--- a/config/longrun_configs/slabplanet_target_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_target_evolve_ocn.yml
@@ -1,4 +1,3 @@
-anim: true
 atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_0M.yml"
 dt: "120secs"
 dt_cloud_fraction: "1hours"

--- a/config/longrun_configs/slabplanet_terra.yml
+++ b/config/longrun_configs/slabplanet_terra.yml
@@ -1,4 +1,3 @@
-anim: true
 conservation_softfail: true
 dt: "200secs"
 dt_cpl: 200

--- a/config/nightly_configs/amip_coarse.yml
+++ b/config/nightly_configs/amip_coarse.yml
@@ -1,6 +1,5 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
-anim: false
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 coupler_toml_file: "toml/amip.toml"
 dt: "240secs"

--- a/config/nightly_configs/amip_coarse_random.yml
+++ b/config/nightly_configs/amip_coarse_random.yml
@@ -1,6 +1,5 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
-anim: false
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 coupler_toml_file: "toml/amip.toml"
 dt: "240secs"

--- a/experiments/ClimaEarth/cli_options.jl
+++ b/experiments/ClimaEarth/cli_options.jl
@@ -19,10 +19,6 @@ function argparse_settings()
         "--dt_seaice"
         help = " Sea Ice simulation time step"
         arg_type = String
-        "--anim"
-        help = "Boolean flag indicating whether to make animations"
-        arg_type = Bool
-        default = false
         "--energy_check"
         help = "Boolean flag indicating whether to check energy conservation"
         arg_type = Bool

--- a/experiments/ClimaEarth/test/amip_test.yml
+++ b/experiments/ClimaEarth/test/amip_test.yml
@@ -1,6 +1,5 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
-anim: false
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 coupler_toml_file: "toml/amip.toml"
 dt: "180secs"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In https://github.com/CliMA/ClimaCoupler.jl/pull/1070 we deleted the `viz_explorer.jl` file, so we can no longer make animations. We should have also removed the animation flag in that PR, but we forgot so it's removed here instead.
