### PR TITLE
add 2 GPU runs to benchmarks

### DIFF
--- a/.buildkite/benchmarks/pipeline.yml
+++ b/.buildkite/benchmarks/pipeline.yml
@@ -102,7 +102,7 @@ steps:
         agents:
           slurm_gpus_per_task: 1
           slurm_cpus_per_task: 4
-          slurm_ntasks: 4
+          slurm_ntasks: 2
           slurm_mem: 16GB
 
       - label: "GPU ClimaAtmos with diagnostic EDMF"
@@ -115,7 +115,7 @@ steps:
         agents:
           slurm_gpus_per_task: 1
           slurm_cpus_per_task: 4
-          slurm_ntasks: 4
+          slurm_ntasks: 2
           slurm_mem: 16GB
 
       - label: "GPU AMIP with diagnostic EDMF"
@@ -128,7 +128,7 @@ steps:
         agents:
           slurm_gpus_per_task: 1
           slurm_cpus_per_task: 4
-          slurm_ntasks: 4
+          slurm_ntasks: 2
           slurm_mem: 16GB
 
       - label: "GPU AMIP with diagnostic EDMF and IO"
@@ -141,7 +141,7 @@ steps:
         agents:
           slurm_gpus_per_task: 1
           slurm_cpus_per_task: 4
-          slurm_ntasks: 4
+          slurm_ntasks: 2
           slurm_mem: 16GB
 
   - group: "Generate output table"

--- a/experiments/ClimaEarth/user_io/benchmarks.jl
+++ b/experiments/ClimaEarth/user_io/benchmarks.jl
@@ -177,15 +177,15 @@ run_info_atmos_diagedmf = get_run_info(parsed_args, "atmos_diagedmf")
 run_info_atmos = get_run_info(parsed_args, "atmos")
 
 # Set up info for PrettyTables.jl
-headers = [build_id_str, "Horiz. res.: 30 elems", "CPU Run [64 processes]", "GPU Run [4 A100s]"]
+headers = [build_id_str, "Horiz. res.: 30 elems", "CPU Run [64 processes]", "GPU Run [2 A100s]"]
 data = [
     ["" "Vert. res.: 63 levels" "" ""]
     ["" "dt: 120secs" "" ""]
 ]
 
 # Append data to the table for each of the cases we want to compare
-data = append_table_data(data, "Coupled", run_info_coupled...)
-data = append_table_data(data, "Coupled with IO", run_info_coupled_io...)
+data = append_table_data(data, "Coupled with diag. EDMF + IO", run_info_coupled_io...)
+data = append_table_data(data, "Coupled with diag. EDMF", run_info_coupled...)
 data = append_table_data(data, "Atmos with diag. EDMF", run_info_atmos_diagedmf...)
 data = append_table_data(data, "Atmos without diag. EDMF", run_info_atmos...)
 
@@ -196,5 +196,5 @@ table_output_dir = joinpath(output_dir, "compare_amip_climaatmos_$(cpu_job_id_co
 table_path = joinpath(table_output_dir, "table.txt")
 open(table_path, "w") do f
     # Output the table, including lines before and after the header
-    PrettyTables.pretty_table(f, data, header = headers, hlines = [0, 3, 6, 9, 12]) # TODO don't hardcode hlines
+    PrettyTables.pretty_table(f, data, header = headers, hlines = [0, 3, 6, 9, 12, 15])
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
https://github.com/CliMA/ClimaCore.jl/pull/2106 should have fixed the 2 GPU error described in https://github.com/CliMA/ClimaCoupler.jl/issues/687 (see that PR and issue for more details).

This PR changes the benchmark GPU runs to use 2 GPUs each, instead of 4, to test the behavior in coupled simulations. See [this run](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/218#_) for results (note that all CPU jobs were cancelled to reduce resource usage). All 2 GPU runs passed, except for the AMIP + diag EDMF run, which failed due to a CTS version error. I think this is evidence enough that 2 GPU runs are reliable, and we can switch benchmark runs from 4 to 2 GPUs to reduce resource usage.

## SYPD changes [4 GPU](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/217#_) -> [2 GPU](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/218#_)
- Atmos without diagnostic EDMF: 4.112 -> 2.350
- Atmos with diagnostic EDMF: 1.003 -> - (failed with CTS versioning error)
- AMIP with diagnostic EDMF: 0.965 -> 0.618
- AMIP with diagnostic EDMF + IO: 0.868 -> 0.587


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
