### PR TITLE
Change artifact path for heat-diffusion on buildkite

### DIFF
--- a/experiments/ClimaCore/heat-diffusion/run.jl
+++ b/experiments/ClimaCore/heat-diffusion/run.jl
@@ -304,7 +304,7 @@ ENV["GKSwstype"] = "nul"
 import Plots
 Plots.GRBackend()
 
-ARTIFACTS_DIR = joinpath("experiments/ClimaCore/output/heat-diffusion_artifacts")
+ARTIFACTS_DIR = joinpath("experiments/ClimaCore/output/heat-diffusion/artifacts")
 mkpath(ARTIFACTS_DIR)
 
 # - Vertical profile at start and end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Save the output plots of the heat-diffusion experiment on buildkite.
closes #1095 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
- changed artifact path to match output path
- Now build kite heat-diffusion shows 3 saved artifacts vs 0 before
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
