### PR TITLE
Use depression-filled landsea mask

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -236,7 +236,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 4
-          slurm_mem: 32GB
+          slurm_mem: 48GB
 
       # short high-res performance test
       - label: "Unthreaded AMIP FINE" # also reported by longruns with a flame graph

--- a/experiments/ClimaEarth/Artifacts.toml
+++ b/experiments/ClimaEarth/Artifacts.toml
@@ -38,12 +38,23 @@ git-tree-sha1 = "9c3bd05b68e820fceb43d130ce6b4e86ce788e4e"
     sha256 = "46923ec3e1f9028a11899c47e6b13d675d84daa9db2f37351a19ec9187f87865"
     url = "https://caltech.box.com/shared/static/fuwajscgyblccy8y9aq01d0pgy91gwut.gz"
 
-[earth_orography_30arcseconds]
-git-tree-sha1 = "03dd08fcbf363ed055a176dd7adefb60ff1c3493"
+[landsea_mask_30arcseconds]
+git-tree-sha1 = "517c925535981f9d17ac9e7a65e2c35c3ce9597d"
 
-[earth_orography_60arcseconds]
-git-tree-sha1 = "fe19d8dbe7a18ff39588e1f718014b0479d9c0f7"
+    [[landsea_mask_30arcseconds.download]]
+    sha256 = "11eaf6b7606056d198f3735f7b76ead76269cced186de78075f415101cf39088"
+    url = "https://caltech.box.com/shared/static/z013ay1k6oqofnw69bv5held9x374sux.gz"
 
-    [[earth_orography_60arcseconds.download]]
-    sha256 = "eca66c0701d1c2b9e271742314915ffbf4a0fae92709df611c323f38e019966e"
-    url = "https://caltech.box.com/shared/static/4asrxcgl6xsgenfcug9p0wkkyhtqilgk.gz"
+[landsea_mask_60arcseconds]
+git-tree-sha1 = "10ed7ec61def091c44545825cfb4d9599216c3c8"
+
+    [[landsea_mask_60arcseconds.download]]
+    sha256 = "eb88455a39a00bfadb77effbc31a4df561158c0ca1578476edb683d45e3c49da"
+    url = "https://caltech.box.com/shared/static/vivf36pih7e0ttahqarc2nd5jxb4q8jr.gz"
+
+[landsea_mask_1deg]
+git-tree-sha1 = "cbbc6b3752d9cb9b667ec33cfbeb46819f8db418"
+
+    [[landsea_mask_1deg.download]]
+    sha256 = "3722b553c2fdf28a6574aea2e0b167d16ab050f34e5969ada45625b3a3ecb6da"
+    url = "https://caltech.box.com/shared/static/b3u4dv0dsoswvqgp8y63bzj7awbhwztd.gz"

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -168,8 +168,7 @@ catch error
     )
 end
 co2_data = joinpath(@clima_artifact("co2_dataset", comms_ctx), "co2_mm_mlo.txt")
-land_mask_data =
-    joinpath(@clima_artifact("earth_orography_60arcseconds", comms_ctx), "ETOPO_2022_v1_60s_N90W180_surface.nc")
+land_mask_data = joinpath(@clima_artifact("landsea_mask_60arcseconds", comms_ctx), "landsea_mask.nc")
 
 #=
 ## Component Model Initialization
@@ -214,12 +213,7 @@ Note that land-sea area fraction is different to the land-sea mask, which is a b
 =#
 
 # Preprocess the file to be 1s and 0s before remapping into onto the grid
-land_area_fraction = SpaceVaryingInput(
-    land_mask_data,
-    "z",
-    boundary_space,
-    file_reader_kwargs = (; preprocess_func = (data) -> data >= 0),
-)
+land_area_fraction = SpaceVaryingInput(land_mask_data, "landsea", boundary_space)
 if !mono_surface
     land_area_fraction = Regridder.binary_mask.(land_area_fraction)
 end

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -741,7 +741,7 @@ function solve_coupler!(cs)
     return nothing
 end
 
-## exit if running performance anaysis #hide
+## exit if running performance analysis #hide
 if haskey(ENV, "CI_PERF_SKIP_COUPLED_RUN") #hide
     throw(:exit_profile_init) #hide
 end #hide
@@ -770,7 +770,7 @@ GC.gc()
 
 This is where the full coupling loop, `solve_coupler!` is called for the full timespan of the simulation.
 We use the `ClimaComms.@elapsed` macro to time the simulation on both CPU and GPU, and use this
-value to calculare the simulated years per day (SYPD) of the simulation.
+value to calculate the simulated years per day (SYPD) of the simulation.
 =#
 walltime = ClimaComms.@elapsed comms_ctx.device begin
     s = CA.@timed_str begin

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -155,8 +155,7 @@ dir_paths = Utilities.setup_output_dirs(output_dir = coupler_output_dir, comms_c
 #=
 ## Data File Paths
 =#
-land_mask_data =
-    joinpath(@clima_artifact("earth_orography_60arcseconds", comms_ctx), "ETOPO_2022_v1_60s_N90W180_surface.nc")
+land_mask_data = joinpath(@clima_artifact("landsea_mask_60arcseconds", comms_ctx), "landsea_mask.nc")
 
 #=
 ## Component Model Initialization
@@ -189,14 +188,8 @@ boundary_space = CC.Spaces.horizontal_space(atmos_sim.domain.face_space) # TODO:
 This is a static field that contains the area fraction of land and sea, ranging from 0 to 1. If applicable, sea ice is included in the sea fraction. at this stage.
 Note that land-sea area fraction is different to the land-sea mask, which is a binary field (masks are used internally by the coupler to indicate passive cells that are not populated by a given component model).
 =#
-
-land_area_fraction = SpaceVaryingInput(
-    land_mask_data,
-    "z",
-    boundary_space,
-    file_reader_kwargs = (; preprocess_func = (data) -> data >= 0),
-)
-
+land_mask_data = joinpath(@clima_artifact("landsea_mask_60arcseconds", comms_ctx), "landsea_mask.nc")
+land_area_fraction = SpaceVaryingInput(land_mask_data, "landsea", boundary_space)
 #=
 ### Surface Model: Bucket Land and Slab Ocean
 =#


### PR DESCRIPTION
Switch to using the new land mask computed by filling inland basins instead of looking at elevation on sea level
