### PR TITLE
fix atmos standalone output dir

### DIFF
--- a/test/component_model_tests/climaatmos_standalone/atmos_driver.jl
+++ b/test/component_model_tests/climaatmos_standalone/atmos_driver.jl
@@ -40,7 +40,7 @@ else
 end
 
 # Specify atmos output directory to be inside the coupler output directory
-output_dir = joinpath(pkgdir(ClimaCoupler), "experiments", "ClimaEarth", "output", "climaatmos", job_id, "artifacts")
+output_dir = joinpath(pkgdir(ClimaCoupler), "experiments", "ClimaEarth", "output", job_id, "artifacts")
 !isdir(output_dir) && mkpath(output_dir)
 config = merge(config, Dict("output_dir" => output_dir))
 atmos_config = CA.AtmosConfig(config)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The most recent coupler benchmark table generation [failed](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/207#01938dd0-c4c7-4010-98c4-a07d3709ec95) because the output files weren't in the expected place. This is because the atmosphere standalone driver wasn't updated correctly when we recently changed our output paths. This PR fixes it.