### PR TITLE
Tr/isolate run amip postprocessing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,29 @@ pressure levels are being created.
 
 ### Code cleanup
 
+#### Structs representing simulation modes & postprocessing changes - PR [#1120](https://github.com/CliMA/ClimaCoupler.jl/pull/1120)
+
+The available simulation modes are now represented by the following structs:
+
+- `ClimaCoupler.Interfacer.AMIPMode`
+- `ClimaCoupler.Interfacer.SlabplanetMode`
+- `ClimaCoupler.Interfacer.SlabplanetAquaMode`
+- `ClimaCoupler.Interfacer.SlabplanetTerraMode`
+- `ClimaCoupler.Interfacer.SlabplanetEisenmanMode`
+
+All of the above structs are subtypes of the abstract
+`ClimaCoupler.Interfacer.AbstractSlabplanetSimulationMode`, and all of them except
+`ClimaCoupler.Interfacer.AMIPMode` are subtypes of `ClimaCoupler.Interfacer.AbstractSlabplanetSimulationMode`.
+
+These structs are used in `experiments/ClimaEarth/run_amip.jl` instead of representing the
+simulation mode as a string.
+
+The postprocessing in `experiments/ClimaEarth/run_amip.jl` is now moved into functions in
+the new `experiments/ClimaEarth/user_io/postprocessing.jl`. When the simulation is complete,
+`postprocess_sim` is called using the struct representing the simulation mode for dispatch.
+`postprocess_sim` has one method for all slabplanet simulation modes and another for the AMIP
+simulation mode. All postprocessing common to all simulation modes is done in the `common_postprocessing`
+function, which is called by both `postprocess_sim` methods.
 
 #### Output path updates - PRs [#1058][1], [#1106][2], [#1123][3]
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,9 +39,9 @@ pressure levels are being created.
 
 ### Code cleanup
 
-#### Structs representing simulation modes & postprocessing changes - PR [#1120](https://github.com/CliMA/ClimaCoupler.jl/pull/1120)
+#### Abstract types representing simulation modes & postprocessing changes - PR [#1120](https://github.com/CliMA/ClimaCoupler.jl/pull/1120)
 
-The available simulation modes are now represented by the following structs:
+The available simulation modes are now represented by the following abstract types:
 
 - `ClimaCoupler.Interfacer.AMIPMode`
 - `ClimaCoupler.Interfacer.SlabplanetMode`
@@ -49,16 +49,16 @@ The available simulation modes are now represented by the following structs:
 - `ClimaCoupler.Interfacer.SlabplanetTerraMode`
 - `ClimaCoupler.Interfacer.SlabplanetEisenmanMode`
 
-All of the above structs are subtypes of the abstract
+All of the above types are subtypes of the abstract
 `ClimaCoupler.Interfacer.AbstractSlabplanetSimulationMode`, and all of them except
 `ClimaCoupler.Interfacer.AMIPMode` are subtypes of `ClimaCoupler.Interfacer.AbstractSlabplanetSimulationMode`.
 
-These structs are used in `experiments/ClimaEarth/run_amip.jl` instead of representing the
+These types are used in `experiments/ClimaEarth/run_amip.jl` instead of representing the
 simulation mode as a string.
 
 The postprocessing in `experiments/ClimaEarth/run_amip.jl` is now moved into functions in
 the new `experiments/ClimaEarth/user_io/postprocessing.jl`. When the simulation is complete,
-`postprocess_sim` is called using the struct representing the simulation mode for dispatch.
+`postprocess_sim` is called using the type representing the simulation mode for dispatch.
 `postprocess_sim` has one method for all slabplanet simulation modes and another for the AMIP
 simulation mode. All postprocessing common to all simulation modes is done in the `common_postprocessing`
 function, which is called by both `postprocess_sim` methods.

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,11 +39,12 @@ pressure levels are being created.
 
 ### Code cleanup
 
-#### Output path updates - PRs [#1058](https://github.com/CliMA/ClimaCoupler.jl/pull/1058),
-    [#1106](https://github.com/CliMA/ClimaCoupler.jl/pull/1106),
-    [#1123](https://github.com/CliMA/ClimaCoupler.jl/pull/1123)
 
+#### Output path updates - PRs [#1058][1], [#1106][2], [#1123][3]
 
+[1]: https://github.com/CliMA/ClimaCoupler.jl/pull/1058
+[2]: https://github.com/CliMA/ClimaCoupler.jl/pull/1106
+[3]: https://github.com/CliMA/ClimaCoupler.jl/pull/1123
 Previously, ClimaEarth simulation outputs were saved in a path
 `experiments/ClimaEarth/output/$mode_name/$job_id/artifacts/`. Now, `ClimaEarth`
 creates output folders with an increment (increasing the counter every time the
@@ -69,7 +70,7 @@ coupler_output_dir_amip/
 ├── output_0002/
 │   └── ... component model outputs in their folders ...
 └── output_active -> output_0002/
-``
+```
 Note that any external scripts that assume an output path will need to be updated.
 
 #### Remove ClimaCoupler.Diagnostics module - PR [#953](https://github.com/CliMA/ClimaCoupler.jl/pull/953)

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -217,5 +217,5 @@ end
 ```@docs
     ClimaCoupler.Interfacer.stub_init
     ClimaCoupler.Interfacer.AbstractSimulation
-    ClimaCoupler.Interfacer.AbstractSlabplanetSimulationMode
+    ClimaCoupler.Interfacer.AbstractSimulationMode
 ```

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -199,11 +199,23 @@ end
     ClimaCoupler.Interfacer.AtmosModelSimulation
     ClimaCoupler.Interfacer.SurfaceModelSimulation
     ClimaCoupler.Interfacer.ComponentModelSimulation
-    ClimaCoupler.Interfacer.AbstractSimulation
     ClimaCoupler.Interfacer.SurfaceStub
-    ClimaCoupler.Interfacer.stub_init
     ClimaCoupler.Interfacer.float_type
     ClimaCoupler.Interfacer.name
     ClimaCoupler.Interfacer.get_field
     ClimaCoupler.Interfacer.update_field!
+    ClimaCoupler.Interfacer.AbstractSlabplanetSimulationMode
+    ClimaCoupler.Interfacer.AMIPMode
+    ClimaCoupler.Interfacer.SlabplanetMode
+    ClimaCoupler.Interfacer.SlabplanetAquaMode
+    ClimaCoupler.Interfacer.SlabplanetTerraMode
+    ClimaCoupler.Interfacer.SlabplanetEisenmanMode
+```
+
+## Interfacer Internal Functions and Types
+
+```@docs
+    ClimaCoupler.Interfacer.stub_init
+    ClimaCoupler.Interfacer.AbstractSimulation
+    ClimaCoupler.Interfacer.AbstractSlabplanetSimulationMode
 ```

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -1,19 +1,11 @@
 import YAML
 
-abstract type AbstractModeType end
-abstract type AbstractSlabPlanetModeType <: AbstractModeType end
-abstract type AbstractSlabPlanetModeSubType1 <: AbstractSlabPlanetModeType end
-struct AMIP_mode <: AbstractModeType end
-struct slabplanet_mode <: AbstractSlabPlanetModeSubType1 end
-struct slabplanet_aqua_mode <: AbstractSlabPlanetModeSubType1 end
-struct slabplanet_terra_mode <: AbstractSlabPlanetModeSubType1 end
-struct slabplanet_eisenman_mode <: AbstractSlabPlanetModeType end
 mode_name_dict = Dict(
-    "amip" => AMIP_mode,
-    "slabplanet" => slabplanet_mode,
-    "slabplanet_aqua" => slabplanet_aqua_mode,
-    "slabplanet_terra" => slabplanet_terra_mode,
-    "slabplanet_eisenman" => slabplanet_eisenman_mode,
+    "amip" => AMIPMode,
+    "slabplanet" => SlabplanetMode,
+    "slabplanet_aqua" => SlabplanetAquaMode,
+    "slabplanet_terra" => SlabplanetTerraMode,
+    "slabplanet_eisenman" => SlabplanetEisenmanMode,
 )
 
 """
@@ -58,7 +50,7 @@ function get_coupler_args(config_dict::Dict)
     config_dict["print_config_dict"] && @info(config_dict)
     job_id = config_dict["job_id"]
     mode_name = config_dict["mode_name"]
-    mode_type = mode_name_dict[mode_name]()
+    sim_mode = mode_name_dict[mode_name]()
 
     # Computational simulation setup information
     random_seed = config_dict["unique_seed"] ? time_ns() : 1234
@@ -108,7 +100,7 @@ function get_coupler_args(config_dict::Dict)
 
     return (;
         job_id,
-        mode_type,
+        sim_mode,
         random_seed,
         FT,
         comms_ctx,

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -1,5 +1,21 @@
 import YAML
 
+abstract type AbstractModeType end
+abstract type AbstractSlabPlanetModeType <: AbstractModeType end
+abstract type AbstractSlabPlanetModeSubType1 <: AbstractSlabPlanetModeType end
+struct AMIP_mode <: AbstractModeType end
+struct slabplanet_mode <: AbstractSlabPlanetModeSubType1 end
+struct slabplanet_aqua_mode <: AbstractSlabPlanetModeSubType1 end
+struct slabplanet_terra_mode <: AbstractSlabPlanetModeSubType1 end
+struct slabplanet_eisenman_mode <: AbstractSlabPlanetModeType end
+mode_name_dict = Dict(
+    "amip" => AMIP_mode,
+    "slabplanet" => slabplanet_mode,
+    "slabplanet_aqua" => slabplanet_aqua_mode,
+    "slabplanet_terra" => slabplanet_terra_mode,
+    "slabplanet_eisenman" => slabplanet_eisenman_mode,
+)
+
 """
     get_coupler_config()
 
@@ -42,6 +58,7 @@ function get_coupler_args(config_dict::Dict)
     config_dict["print_config_dict"] && @info(config_dict)
     job_id = config_dict["job_id"]
     mode_name = config_dict["mode_name"]
+    mode_type = mode_name_dict[mode_name]()
 
     # Computational simulation setup information
     random_seed = config_dict["unique_seed"] ? time_ns() : 1234
@@ -91,7 +108,7 @@ function get_coupler_args(config_dict::Dict)
 
     return (;
         job_id,
-        mode_name,
+        mode_type,
         random_seed,
         FT,
         comms_ctx,

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -50,7 +50,7 @@ function get_coupler_args(config_dict::Dict)
     config_dict["print_config_dict"] && @info(config_dict)
     job_id = config_dict["job_id"]
     mode_name = config_dict["mode_name"]
-    sim_mode = mode_name_dict[mode_name]()
+    sim_mode = mode_name_dict[mode_name]
 
     # Computational simulation setup information
     random_seed = config_dict["unique_seed"] ? time_ns() : 1234

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -5,8 +5,8 @@ include("diagnostics_plots.jl")
 """
     postprocess_sim(sim_mode::AbstractSlabplanetSimulationMode, cs, postprocessing_vars)
 
-If they exist, perform conservation checks, for any slabplanet simulation, and then call
-`common_postprocessing` to perform common postprocessing tasks that are common to all simulation types.
+Call `common_postprocessing` to perform common postprocessing tasks that are common to all simulation types.
+Then, if conservation checks exist, perform them.
 """
 function postprocess_sim(sim_mode::AbstractSlabplanetSimulationMode, cs, postprocessing_vars)
     (; conservation_softfail,) = postprocessing_vars
@@ -35,8 +35,8 @@ end
 """
     postprocess_sim(sim_mode::AMIPMode, cs, postprocessing_vars)
 
-Conditionally plot AMIP diagnostics and call `common_postprocessing` to perform
-postprocessing tasks that are common to all simulation types.
+Call `common_postprocessing` to perform postprocessing tasks that are common to all simulation
+types, and then conditionally plot AMIP diagnostics
 """
 function postprocess_sim(sim_mode::AMIPMode, cs, postprocessing_vars)
     (; use_coupler_diagnostics, output_default_diagnostics, t_end) = postprocessing_vars
@@ -78,6 +78,7 @@ function postprocess_sim(sim_mode::AMIPMode, cs, postprocessing_vars)
         compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir)
     end
 
+    # close all AMIP diagnostics file writers
     !isnothing(cs.amip_diags_handler) &&
         map(diag -> close(diag.output_writer), cs.amip_diags_handler.scheduled_diagnostics)
 end

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -1,0 +1,100 @@
+## helpers for user-specified IO
+include("debug_plots.jl")
+include("diagnostics_plots.jl")
+
+"""
+    postprocess_sim(sim_mode::AbstractSlabplanetSimulationMode, cs, postprocessing_vars)
+
+If they exist, perform conservation checks, for any slabplanet simulation, and then call
+`common_postprocessing` to perform common postprocessing tasks that are common to all simulation types.
+"""
+function postprocess_sim(sim_mode::AbstractSlabplanetSimulationMode, cs, postprocessing_vars)
+    (; conservation_softfail,) = postprocessing_vars
+
+    common_postprocessing(cs, postprocessing_vars)
+
+    if !isnothing(cs.conservation_checks)
+        @info "Conservation Check Plots"
+        plot_global_conservation(
+            cs.conservation_checks.energy,
+            cs,
+            conservation_softfail,
+            figname1 = joinpath(cs.dirs.artifacts, "total_energy_bucket.png"),
+            figname2 = joinpath(cs.dirs.artifacts, "total_energy_log_bucket.png"),
+        )
+        plot_global_conservation(
+            cs.conservation_checks.water,
+            cs,
+            conservation_softfail,
+            figname1 = joinpath(cs.dirs.artifacts, "total_water_bucket.png"),
+            figname2 = joinpath(cs.dirs.artifacts, "total_water_log_bucket.png"),
+        )
+    end
+end
+
+"""
+    postprocess_sim(sim_mode::AMIPMode, cs, postprocessing_vars)
+
+Conditionally plot AMIP diagnostics and call `common_postprocessing` to perform
+postprocessing tasks that are common to all simulation types.
+"""
+function postprocess_sim(sim_mode::AMIPMode, cs, postprocessing_vars)
+    (; use_coupler_diagnostics, output_default_diagnostics, t_end) = postprocessing_vars
+
+    common_postprocessing(cs, postprocessing_vars)
+
+    if use_coupler_diagnostics
+        ## plot data that correspond to the model's last save_hdf5 call (i.e., last month)
+        @info "AMIP plots"
+
+        ## ClimaESM
+        include("user_io/diagnostics_plots.jl")
+
+        # define variable names and output directories for each diagnostic
+        amip_short_names_atmos = ["ta", "ua", "hus", "clw", "pr", "ts", "toa_fluxes_net"]
+        amip_short_names_coupler = ["F_turb_energy"]
+        output_dir_coupler = cs.dirs.output
+
+        # Check if all output variables are available in the specified directories
+        make_diagnostics_plots(
+            atmos_output_dir,
+            cs.dirs.artifacts,
+            short_names = amip_short_names_atmos,
+            output_prefix = "atmos_",
+        )
+        make_diagnostics_plots(
+            output_dir_coupler,
+            cs.dirs.artifacts,
+            short_names = amip_short_names_coupler,
+            output_prefix = "coupler_",
+        )
+    end
+
+    # Check this because we only want monthly data for making plots
+    if t_end > 84600 * 31 * 3 && output_default_diagnostics
+        include("leaderboard/leaderboard.jl")
+        leaderboard_base_path = cs.dirs.artifacts
+        compute_leaderboard(leaderboard_base_path, atmos_output_dir)
+        compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir)
+    end
+
+    !isnothing(cs.amip_diags_handler) &&
+        map(diag -> close(diag.output_writer), cs.amip_diags_handler.scheduled_diagnostics)
+end
+
+"""
+    common_postprocessing(cs, postprocessing_vars)
+
+Perform postprocessing common to all simulation types.
+"""
+function common_postprocessing(cs, postprocessing_vars)
+    (; plot_diagnostics, atmos_output_dir) = postprocessing_vars
+    if plot_diagnostics
+        @info "Plotting diagnostics"
+        include("user_io/diagnostics_plots.jl")
+        make_diagnostics_plots(atmos_output_dir, cs.dirs.artifacts)
+    end
+
+    # plot all model states and coupler fields (useful for debugging)
+    !CA.is_distributed(cs.comms_ctx) && debug(cs, cs.dirs.artifacts)
+end

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -3,12 +3,12 @@ include("debug_plots.jl")
 include("diagnostics_plots.jl")
 
 """
-    postprocess_sim(sim_mode::AbstractSlabplanetSimulationMode, cs, postprocessing_vars)
+    postprocess_sim(::Type{AbstractSlabplanetSimulationMode}, cs, postprocessing_vars)
 
 Call `common_postprocessing` to perform common postprocessing tasks that are common to all simulation types.
 Then, if conservation checks exist, perform them.
 """
-function postprocess_sim(sim_mode::AbstractSlabplanetSimulationMode, cs, postprocessing_vars)
+function postprocess_sim(::Type{<:AbstractSlabplanetSimulationMode}, cs, postprocessing_vars)
     (; conservation_softfail,) = postprocessing_vars
 
     common_postprocessing(cs, postprocessing_vars)
@@ -33,12 +33,12 @@ function postprocess_sim(sim_mode::AbstractSlabplanetSimulationMode, cs, postpro
 end
 
 """
-    postprocess_sim(sim_mode::AMIPMode, cs, postprocessing_vars)
+    postprocess_sim(::Type{AMIPMode}, cs, postprocessing_vars)
 
 Call `common_postprocessing` to perform postprocessing tasks that are common to all simulation
 types, and then conditionally plot AMIP diagnostics
 """
-function postprocess_sim(sim_mode::AMIPMode, cs, postprocessing_vars)
+function postprocess_sim(::Type{AMIPMode}, cs, postprocessing_vars)
     (; use_coupler_diagnostics, output_default_diagnostics, t_end) = postprocessing_vars
 
     common_postprocessing(cs, postprocessing_vars)

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -278,7 +278,7 @@ abstract type AMIPMode <: AbstractSimulationMode end
 
 An abstract type represeting the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
 a ClimaLand.jl bucket land model, a thermal slab ocean model, and no sea ice model. Instead
-of using a sea ice model, the ocean evaluated in areas that would be covered in ice.
+of using a sea ice model, the ocean is evaluated in areas that would be covered in ice.
 """
 abstract type SlabplanetMode <: AbstractSlabplanetSimulationMode end
 

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -249,7 +249,7 @@ reinit!(sim::ComponentModelSimulation) = error("undefined reinit! for " * name(s
 include("surface_stub.jl")
 
 """
-    AbstractModeType
+    AbstractSimulationMode
 
 An abstract type representing a simulation mode.
 """
@@ -258,14 +258,55 @@ abstract type AbstractSimulationMode end
 """
     AbstractSlabplanetSimulationMode
 
-An abstract type representing a simulation mode for slabplanet models.
+An abstract type representing a simulation mode for slabplanet models. Slabplanet simulations
+are more idealized than the AMIP configuration, but provide valuable insight about
+conservation and individual model behavior.
 """
 abstract type AbstractSlabplanetSimulationMode <: AbstractSimulationMode end
 
+"""
+    AMIPMode
+
+A struct representing the AMIP simulation mode. AMIP is currently the most complex
+configuration of the ClimaEarth model. It runs a ClimaAtmos.jl atmosphere model,
+ClimaLand.jl bucket land model, a prescribed ocean model, and a simple thermal sea ice model.
+"""
 struct AMIPMode <: AbstractSimulationMode end
+
+"""
+    SlabplanetMode
+
+A struct represeting the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
+a ClimaLand.jl bucket land model, a thermal slab ocean model, and no sea ice model. Instead
+of using a sea ice model, the ocean evaluated in areas that would be covered in ice.
+"""
 struct SlabplanetMode <: AbstractSlabplanetSimulationMode end
+
+"""
+    SlabplanetAquaMode
+
+A struct representing the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
+and only once surface model, a thermal slab ocean model, which is evaluated over the entire
+surface. There are no land or sea ice models.
+"""
 struct SlabplanetAquaMode <: AbstractSlabplanetSimulationMode end
+
+"""
+    SlabplanetTerraMode
+
+A struct representing the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
+and only once surface model, a ClimaLand.jl bucket land model, which is evaluated over the
+entire surface. There are no ocean or sea ice models.
+"""
 struct SlabplanetTerraMode <: AbstractSlabplanetSimulationMode end
+
+"""
+    SlabplanetEisenmanMode
+
+A struct representing the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
+a ClimaLand.jl bucket land model, and Eisenman sea ice model. The ocean model
+is included in the Eisenman sea ice model.
+"""
 struct SlabplanetEisenmanMode <: AbstractSlabplanetSimulationMode end
 
 end # module

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -267,46 +267,46 @@ abstract type AbstractSlabplanetSimulationMode <: AbstractSimulationMode end
 """
     AMIPMode
 
-A struct representing the AMIP simulation mode. AMIP is currently the most complex
+An abstract type representing the AMIP simulation mode. AMIP is currently the most complex
 configuration of the ClimaEarth model. It runs a ClimaAtmos.jl atmosphere model,
 ClimaLand.jl bucket land model, a prescribed ocean model, and a simple thermal sea ice model.
 """
-struct AMIPMode <: AbstractSimulationMode end
+abstract type AMIPMode <: AbstractSimulationMode end
 
 """
     SlabplanetMode
 
-A struct represeting the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
+An abstract type represeting the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
 a ClimaLand.jl bucket land model, a thermal slab ocean model, and no sea ice model. Instead
 of using a sea ice model, the ocean evaluated in areas that would be covered in ice.
 """
-struct SlabplanetMode <: AbstractSlabplanetSimulationMode end
+abstract type SlabplanetMode <: AbstractSlabplanetSimulationMode end
 
 """
     SlabplanetAquaMode
 
-A struct representing the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
+An abstract type representing the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
 and only once surface model, a thermal slab ocean model, which is evaluated over the entire
 surface. There are no land or sea ice models.
 """
-struct SlabplanetAquaMode <: AbstractSlabplanetSimulationMode end
+abstract type SlabplanetAquaMode <: AbstractSlabplanetSimulationMode end
 
 """
     SlabplanetTerraMode
 
-A struct representing the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
+An abstract type representing the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
 and only once surface model, a ClimaLand.jl bucket land model, which is evaluated over the
 entire surface. There are no ocean or sea ice models.
 """
-struct SlabplanetTerraMode <: AbstractSlabplanetSimulationMode end
+abstract type SlabplanetTerraMode <: AbstractSlabplanetSimulationMode end
 
 """
     SlabplanetEisenmanMode
 
-A struct representing the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
+An abstract type representing the slabplanet simulation mode with a ClimaAtmos.jl atmosphere model,
 a ClimaLand.jl bucket land model, and Eisenman sea ice model. The ocean model
 is included in the Eisenman sea ice model.
 """
-struct SlabplanetEisenmanMode <: AbstractSlabplanetSimulationMode end
+abstract type SlabplanetEisenmanMode <: AbstractSlabplanetSimulationMode end
 
 end # module

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -23,7 +23,13 @@ export CoupledSimulation,
     update_field!,
     SurfaceStub,
     step!,
-    reinit!
+    reinit!,
+    AbstractSlabplanetSimulationMode,
+    AMIPMode,
+    SlabplanetMode,
+    SlabplanetAquaMode,
+    SlabplanetTerraMode,
+    SlabplanetEisenmanMode
 
 
 """
@@ -241,5 +247,25 @@ reinit!(sim::ComponentModelSimulation) = error("undefined reinit! for " * name(s
 
 # Include file containing the surface stub simulation type.
 include("surface_stub.jl")
+
+"""
+    AbstractModeType
+
+An abstract type representing a simulation mode.
+"""
+abstract type AbstractSimulationMode end
+
+"""
+    AbstractSlabplanetSimulationMode
+
+An abstract type representing a simulation mode for slabplanet models.
+"""
+abstract type AbstractSlabplanetSimulationMode <: AbstractSimulationMode end
+
+struct AMIPMode <: AbstractSimulationMode end
+struct SlabplanetMode <: AbstractSlabplanetSimulationMode end
+struct SlabplanetAquaMode <: AbstractSlabplanetSimulationMode end
+struct SlabplanetTerraMode <: AbstractSlabplanetSimulationMode end
+struct SlabplanetEisenmanMode <: AbstractSlabplanetSimulationMode end
 
 end # module


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
closes #1119 


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
This PR adds a struct for each different mode_name.
A struct is returned by get_cupler_args as mode_type (suggest a better name for the var).
This is used everywhere mode_name was. The structs do have hierarchy,
but the Abstract types should be given better names.

It also adds a new file,
experiments/ClimaEarth/user_io/postprocessing.jl, which contains
the `postprocess_sim` function. This function copies the if statements
previously at the end of run_amip.jl, but it uses dispatch for the simulation
mode. The postprocessing if statements are now moved into the functions. 
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
