### PR TITLE
unify output dirs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,8 +29,10 @@ pressure levels are being created.
 
 ### Code cleanup
 
-#### Output path updates - PRs [#1106](https://github.com/CliMA/ClimaCoupler.jl/pull/1058),
-    [#1106](https://github.com/CliMA/ClimaCoupler.jl/pull/1106)
+#### Output path updates - PRs [#1058](https://github.com/CliMA/ClimaCoupler.jl/pull/1058),
+    [#1106](https://github.com/CliMA/ClimaCoupler.jl/pull/1106),
+    [#1123](https://github.com/CliMA/ClimaCoupler.jl/pull/1123)
+
 
 Previously, ClimaEarth simulation outputs were saved in a path
 `experiments/ClimaEarth/output/$mode_name/$job_id/artifacts/`. Now, `ClimaEarth`
@@ -42,10 +44,14 @@ coupler_output_dir_amip/
 ├── checkpoints
 │       └── checkpoints for the various models
 ├── artifacts
-│       └── plots produced by the postporcessing step
+│       └── plots produced by the postprocessing step
 ├── output_0000/
-│   ├── atmos/
+│   ├── clima_atmos/
 │   │   └── output of the atmos model
+│   └── clima_land/
+│   │   └── output of the land model
+│   └── coupler/
+│   │   └── output of coupler quantities
 │   └── ocean/
 │       └── output of the ocean model
 ├── output_0001/

--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -53,7 +53,7 @@ function bucket_init(
     config::String,
     albedo_type::String,
     land_temperature_anomaly::String,
-    dir_paths::NamedTuple;
+    output_dir::String;
     space,
     dt::Float64,
     saveat::Float64,
@@ -71,9 +71,6 @@ function bucket_init(
         )
         @assert config == "sphere"
     end
-
-    regrid_dirpath = dir_paths.regrid
-    artifacts_dir = dir_paths.artifacts
 
     α_snow = FT(0.8) # snow albedo
     if albedo_type == "map_static" # Read in albedo from static data file (default type)
@@ -152,7 +149,7 @@ function bucket_init(
 
     # Add diagnostics
     if use_land_diagnostics
-        netcdf_writer = CD.Writers.NetCDFWriter(domain.space.subsurface, artifacts_dir)
+        netcdf_writer = CD.Writers.NetCDFWriter(domain.space.subsurface, output_dir)
         scheduled_diagnostics =
             CL.default_diagnostics(model, date_ref, output_writer = netcdf_writer, average_period = :monthly)
 

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -139,10 +139,15 @@ dir_paths = Utilities.setup_output_dirs(output_dir = COUPLER_OUTPUT_DIR, comms_c
 @info "Coupler artifacts directory $(dir_paths.artifacts)"
 @info "Coupler checkpoint directory $(dir_paths.checkpoints)"
 
+atmos_output_dir = joinpath(dir_paths.output, "clima_atmos")
+isdir(atmos_output_dir) || mkpath(atmos_output_dir)
+land_output_dir = joinpath(dir_paths.output, "clima_land")
+isdir(land_output_dir) || mkpath(land_output_dir)
+
+
 ## get component model dictionaries (if applicable)
 ## Note this step must come after parsing the coupler config dictionary, since
 ##  some parameters are passed from the coupler config to the component model configs
-atmos_output_dir = joinpath(dir_paths.output, "clima_atmos")
 atmos_config_dict = get_atmos_config_dict(config_dict, job_id, atmos_output_dir)
 (; dt_rad, output_default_diagnostics) = get_atmos_args(atmos_config_dict)
 
@@ -249,7 +254,7 @@ if mode_name == "amip"
         land_domain_type,
         land_albedo_type,
         land_temperature_anomaly,
-        dir_paths;
+        land_output_dir;
         dt = component_dt_dict["dt_land"],
         space = boundary_space,
         saveat = saveat,
@@ -347,7 +352,7 @@ elseif mode_name in ("slabplanet", "slabplanet_aqua", "slabplanet_terra")
         land_domain_type,
         land_albedo_type,
         land_temperature_anomaly,
-        dir_paths;
+        land_output_dir;
         dt = component_dt_dict["dt_land"],
         space = boundary_space,
         saveat = saveat,
@@ -397,7 +402,7 @@ elseif mode_name == "slabplanet_eisenman"
         land_domain_type,
         land_albedo_type,
         land_temperature_anomaly,
-        dir_paths;
+        land_output_dir;
         dt = component_dt_dict["dt_land"],
         space = boundary_space,
         saveat = saveat,
@@ -552,7 +557,10 @@ Use ClimaDiagnostics for default AMIP diagnostics, which currently include turbu
 =#
 if mode_name == "amip" && use_coupler_diagnostics
     include("user_io/amip_diagnostics.jl")
-    amip_diags_handler = amip_diagnostics_setup(coupler_fields, dir_paths.output, dates.date0[1], tspan[1], calendar_dt)
+    coupler_diags_path = joinpath(dir_paths.output, "coupler")
+    isdir(coupler_diags_path) || mkpath(coupler_diags_path)
+    amip_diags_handler =
+        amip_diagnostics_setup(coupler_fields, coupler_diags_path, dates.date0[1], tspan[1], calendar_dt)
 else
     amip_diags_handler = nothing
 end

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -133,8 +133,10 @@ config_dict = Dict(
     "override_precip_timescale" => false,
 )
 
-## merge dictionaries of command line arguments, coupler dictionary and component model dictionaries
 atmos_output_dir = joinpath(dir_paths.output, "clima_atmos")
+land_output_dir = joinpath(dir_paths.output, "clima_land")
+
+## merge dictionaries of command line arguments, coupler dictionary and component model dictionaries
 atmos_config_dict = get_atmos_config_dict(config_dict, job_id, atmos_output_dir)
 atmos_config_object = CA.AtmosConfig(atmos_config_dict)
 
@@ -205,7 +207,7 @@ land_sim = bucket_init(
     "sphere",
     "map_static",
     "aquaplanet",
-    dir_paths;
+    land_output_dir;
     dt = Δt_cpl,
     space = boundary_space,
     saveat = saveat,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Update the land and coupler-computed diagnostics to be saved in folders adjacent to those from atmos.

The resulting structure is now:
- coupler diagnostics saved in `output/~run_name~/output_active/coupler/`
- atmos diagnostics saved in `output/~run_name~/output_active/clima_atmos/`
- land diagnostics saved in `output/~run_name~/output_active/clima_land/`

Where we previously had:
- coupler diagnostics (`F_turb_energy`) saved in `output/~run_name~/output_active/`
- atmos diagnostics saved in  `output/~run_name~/output_active/clima_atmos/`
- land diagnostics saved in  `output/~run_name~/artifacts/`

closes #1030

### To do
- [x] update path passed to `amip_diagnostics_setup`
- [x] update path passed to `bucket_init`