### PR TITLE
Allow dt_rad not in hours

### DIFF
--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -523,7 +523,9 @@ update_firstdayofmonth!_cb = TimeManager.MonthlyCallback(
     ref_date = [dates.date1[1]],
     active = true,
 )
-dt_water_albedo = parse(FT, filter(x -> !occursin(x, "hours"), dt_rad))
+# if no units specified, assume hours. Otherwise parse and read to seconds, and convert to hours
+dt_water_albedo =
+    isnothing(tryparse(FT, dt_rad)) ? FT(Utilities.time_to_seconds(dt_rad) / (60 * 60)) : parse(FT, dt_rad)
 albedo_cb = TimeManager.HourlyCallback(
     dt = dt_water_albedo,
     func = FluxCalculator.water_albedo_from_atmosphere!,

--- a/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
@@ -214,7 +214,9 @@ update_firstdayofmonth!_cb = TimeManager.MonthlyCallback(
     ref_date = [dates.date1[1]],
     active = true,
 )
-dt_water_albedo = parse(FT, filter(x -> !occursin(x, "hours"), dt_rad))
+# if no units specified, assume hours. Otherwise parse and read to seconds, and convert to hours
+dt_water_albedo =
+    isnothing(tryparse(FT, dt_rad)) ? FT(Utilities.time_to_seconds(dt_rad) / (60 * 60)) : parse(FT, dt_rad)
 albedo_cb = TimeManager.HourlyCallback(
     dt = dt_water_albedo,
     func = FluxCalculator.water_albedo_from_atmosphere!,

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -277,7 +277,9 @@ update_firstdayofmonth!_cb = TimeManager.MonthlyCallback(
     ref_date = [dates.date1[1]],
     active = true,
 )
-dt_water_albedo = parse(FT, filter(x -> !occursin(x, "hours"), dt_rad))
+# if no units specified, assume hours. Otherwise parse and read to seconds, and convert to hours
+dt_water_albedo =
+    isnothing(tryparse(FT, dt_rad)) ? FT(Utilities.time_to_seconds(dt_rad) / (60 * 60)) : parse(FT, dt_rad)
 albedo_cb = TimeManager.HourlyCallback(
     dt = dt_water_albedo,
     func = FluxCalculator.water_albedo_from_atmosphere!,


### PR DESCRIPTION
If dt_rad contains no units, this change assumes it is in hours (same as before change). Otherwise, it calls `ClimaCoupler.Utilities.time_to_seconds`, and converts the output to hours. The previous method of parsing recognized inputs such as "hr", "hour", and "hrs", but `ClimaCoupler.Utilities.time_to_seconds` does not. It can be changed easily to recognize more forms of the time units if support them is desired. 

Closes #1046 
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
