### PR TITLE
move hierarchy experiments before wait

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -362,15 +362,6 @@ steps:
           slurm_ntasks: 1
         soft_fail: true
 
-  - wait
-
-  # plot job performance history
-  - label: ":chart_with_downwards_trend: build history"
-    command:
-      - build_history staging # name of branch to plot
-    artifact_paths:
-      - "build_history.html"
-
   - group: "Hierarchy tests (1d)"
     steps:
       - label: ":construction: Dry Held Suarez"
@@ -418,11 +409,19 @@ steps:
         agents:
           slurm_mem: 20GB
 
-      - wait
-      - label: ":construction: Hierarchy plots"
-        key: "hierarchy_plots"
-        command:
-          - "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/hierarchy/climate_plots.jl"
-        artifact_paths:  "paper_figs/*"
-        agents:
-          slurm_mem: 20GB
+  - wait
+
+  # plot job performance history
+  - label: ":chart_with_downwards_trend: build history"
+    command:
+      - build_history staging # name of branch to plot
+    artifact_paths:
+      - "build_history.html"
+
+  - label: ":construction: Hierarchy plots"
+    key: "hierarchy_plots"
+    command:
+      - "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/hierarchy/climate_plots.jl"
+    artifact_paths:  "paper_figs/*"
+    agents:
+      slurm_mem: 20GB


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The hierarchy experiments have been after the main experiments and their postprocessing in the buildkite pipeline, including a wait between these two sections. This means the hierarchy experiments have been waiting to run until after all of the other experiments are done. It will be faster to run them in parallel with the other experiments.

This PR moves all plotting steps to the end of the pipeline, after a single `wait`