### PR TITLE
Interpret config file/args as relative to pkg_dir

### DIFF
--- a/experiments/ClimaEarth/cli_options.jl
+++ b/experiments/ClimaEarth/cli_options.jl
@@ -5,7 +5,8 @@ function argparse_settings()
         ### ClimaCoupler flags
         # Simulation-identifying information
         "--config_file"
-        help = "A yaml file used to set the configuration of the coupled model [\"config/ci_configs/amip_default.yml\" (default)]"
+        help = "A yaml file, relative to ClimaCoupler.jl, used to set the configuration of the\
+        coupled model [\"config/ci_configs/amip_default.yml\" (default)]"
         arg_type = String
         default = "config/ci_configs/amip_default.yml"
         "--job_id"
@@ -84,7 +85,7 @@ function argparse_settings()
         default = 480
         # Restart information
         "--restart_dir"
-        help = "Directory containing restart files"
+        help = "Directory containing restart files, relative to ClimaCoupler.jl [nothing (default)]"
         arg_type = String
         default = nothing
         "--restart_t"
@@ -120,7 +121,8 @@ function argparse_settings()
         default = false
         # Output information
         "--coupler_output_dir"
-        help = "Directory to save output files. Note that TempestRemap fails if interactive and paths are too long. [\"experiments/ClimaEarth/output\" (default)]"
+        help = "Directory to save output files, relative to ClimaCoupler.jl. Note that TempestRemap\
+        fails if interactive and paths are too long. [\"experiments/ClimaEarth/output\" (default)]"
         arg_type = String
         default = "experiments/ClimaEarth/output"
         "--plot_diagnostics"

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -139,7 +139,7 @@ postprocessing and the conservation checks) of the simulation will be saved,
 #and `dir_paths.checkpoints`, where restart files are saved.
 =#
 
-COUPLER_OUTPUT_DIR = joinpath(output_dir_root, job_id)
+COUPLER_OUTPUT_DIR = joinpath(pkg_dir, output_dir_root, job_id)
 dir_paths = Utilities.setup_output_dirs(output_dir = COUPLER_OUTPUT_DIR, comms_ctx = comms_ctx)
 @info "Coupler output directory $(dir_paths.output)"
 @info "Coupler artifacts directory $(dir_paths.artifacts)"

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -22,13 +22,13 @@ function get_coupler_config()
     parsed_args = parse_commandline(argparse_settings())
 
     # Extract the configuration file and job ID
-    config_file = parsed_args["config_file"]
+    config_file = joinpath(pkg_dir, parsed_args["config_file"])
     job_id = parsed_args["job_id"]
     # Get the job ID from the config file string if not provided
     job_id = isnothing(job_id) ? string(split(split(config_file, '/')[end], '.')[1]) : job_id
 
     # Read in config dictionary from file, overriding the defaults in `parsed_args`
-    config_dict = merge(parsed_args, YAML.load_file(parsed_args["config_file"]))
+    config_dict = merge(parsed_args, YAML.load_file(config_file))
     config_dict["job_id"] = job_id
     return config_dict
 end
@@ -70,7 +70,7 @@ function get_coupler_args(config_dict::Dict)
     hourly_checkpoint_dt = config_dict["hourly_checkpoint_dt"]
 
     # Restart information
-    restart_dir = config_dict["restart_dir"]
+    restart_dir = isnothing(config_dict["restart_dir"]) ? nothing : joinpath(pkg_dir, config_dict["restart_dir"])
     restart_t = Int(config_dict["restart_t"])
 
     # Diagnostics information
@@ -88,7 +88,7 @@ function get_coupler_args(config_dict::Dict)
     conservation_softfail = config_dict["conservation_softfail"]
 
     # Output information
-    output_dir_root = config_dict["coupler_output_dir"]
+    output_dir_root = joinpath(pkg_dir, config_dict["coupler_output_dir"])
     plot_diagnostics = config_dict["plot_diagnostics"]
 
     # ClimaLand-specific information


### PR DESCRIPTION


<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This addressed the "make sure output dir doesn't end up being experiments/ClimaEarth/experiments/ClimaEarth/... when run from exp/ClimaEarth/ directory" point from issue #1122 


## To-do
- improve the cli help strings to make it clear the way paths are interpreted


## Content
Interpret the config file path as relative to the
ClimaCoupler.jl package. Do the same for the restart_dir and coupler_output_dir in the config.

This enables `run_amip` to also be run from
`experiments/ClimaEarth` with the default config path and without modifying the usual output path.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
