### PR TITLE
use proper constructor naming convention

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,12 @@ callback = Callback(schedule, func)
 maybe_trigger_callback(callback, cs, t)
 ```
 
+#### Constructor renaming PR[#1135](https://github.com/CliMA/ClimaCoupler.jl/pull/1135)
+
+Simulation constructor functions have been renamed to use the simulation name
+itself, following general convention for constructor naming. For example,
+`atmos_init` is now `ClimaAtmosSimulation`, and `bucket_init` is now `BucketSimulation`.
+
 v0.1.2
 -------
 ### ClimaEarth features

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -215,7 +215,6 @@ end
 ## Interfacer Internal Functions and Types
 
 ```@docs
-    ClimaCoupler.Interfacer.stub_init
     ClimaCoupler.Interfacer.AbstractSimulation
     ClimaCoupler.Interfacer.AbstractSimulationMode
 ```

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -32,7 +32,7 @@ function hasmoisture(integrator)
     return !(integrator.p.atmos.moisture_model isa CA.DryModel)
 end
 
-function atmos_init(atmos_config)
+function ClimaAtmosSimulation(atmos_config)
     # By passing `parsed_args` to `AtmosConfig`, `parsed_args` overwrites the default atmos config
     FT = atmos_config.parsed_args["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
     simulation = CA.get_simulation(atmos_config)

--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -48,7 +48,7 @@ end
 
 Initializes the bucket model variables.
 """
-function bucket_init(
+function BucketSimulation(
     ::Type{FT},
     tspan::Tuple{Float64, Float64},
     config::String,

--- a/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
@@ -45,11 +45,11 @@ Base.@kwdef struct EisenmanOceanParameters{FT <: AbstractFloat}
 end
 
 """
-    eisenman_seaice_init(::Type{FT}, tspan; space = nothing, area_fraction = nothing, thermo_params = nothing, stepper = CTS.RK4(), dt = 0.02, saveat = 1.0e10)
+    EisenmanIceSimulation(::Type{FT}, tspan; space = nothing, area_fraction = nothing, thermo_params = nothing, stepper = CTS.RK4(), dt = 0.02, saveat = 1.0e10)
 
 Initialize the Eisenman-Zhang sea ice model and simulation.
 """
-function eisenman_seaice_init(
+function EisenmanIceSimulation(
     ::Type{FT},
     tspan;
     space = nothing,

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -54,11 +54,20 @@ function slab_ice_space_init(::Type{FT}, space, p) where {FT}
 end
 
 """
-    ice_init(::Type{FT}; tspan, dt, saveat, space, ice_fraction, stepper = CTS.RK4()) where {FT}
+    PrescribedIceSimulation(::Type{FT}; tspan, dt, saveat, space, ice_fraction, stepper = CTS.RK4()) where {FT}
 
 Initializes the `DiffEq` problem, and creates a Simulation-type object containing the necessary information for `Interfacer.step!` in the coupling loop.
 """
-function ice_init(::Type{FT}; tspan, saveat, dt, space, area_fraction, thermo_params, stepper = CTS.RK4()) where {FT}
+function PrescribedIceSimulation(
+    ::Type{FT};
+    tspan,
+    saveat,
+    dt,
+    space,
+    area_fraction,
+    thermo_params,
+    stepper = CTS.RK4(),
+) where {FT}
 
     params = IceSlabParameters{FT}()
 

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -55,11 +55,11 @@ function slab_ocean_space_init(space, params)
 end
 
 """
-    ocean_init(::Type{FT}; tspan, dt, saveat, space, area_fraction, stepper = CTS.RK4()) where {FT}
+    SlabOceanSimulation(::Type{FT}; tspan, dt, saveat, space, area_fraction, stepper = CTS.RK4()) where {FT}
 
 Initializes the `DiffEq` problem, and creates a Simulation-type object containing the necessary information for `step!` in the coupling loop.
 """
-function ocean_init(
+function SlabOceanSimulation(
     ::Type{FT};
     tspan,
     dt,

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -740,11 +740,6 @@ function solve_coupler!(cs)
     return nothing
 end
 
-## exit if running performance analysis #hide
-if haskey(ENV, "CI_PERF_SKIP_COUPLED_RUN") #hide
-    throw(:exit_profile_init) #hide
-end #hide
-
 #=
 ## Precompilation of Coupling Loop
 

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -199,7 +199,7 @@ This uses the `ClimaAtmos.jl` model, with parameterization options specified in 
 Utilities.show_memory_usage()
 
 ## init atmos model component
-atmos_sim = atmos_init(CA.AtmosConfig(atmos_config_dict));
+atmos_sim = ClimaAtmosSimulation(CA.AtmosConfig(atmos_config_dict));
 # Get surface elevation from `atmos` coordinate field
 surface_elevation = CC.Fields.level(CC.Fields.coordinate_field(atmos_sim.integrator.u.f).z, CC.Utilities.half)
 Utilities.show_memory_usage()
@@ -256,7 +256,7 @@ if sim_mode <: AMIPMode
     @info("AMIP boundary conditions - do not expect energy conservation")
 
     ## land model
-    land_sim = bucket_init(
+    land_sim = BucketSimulation(
         FT,
         tspan,
         land_domain_type,
@@ -315,7 +315,7 @@ if sim_mode <: AMIPMode
     evaluate!(SIC_init, SIC_timevaryinginput, t_start)
 
     ice_fraction = get_ice_fraction.(SIC_init, mono_surface)
-    ice_sim = ice_init(
+    ice_sim = PrescribedIceSimulation(
         FT;
         tspan = tspan,
         dt = component_dt_dict["dt_seaice"],
@@ -355,7 +355,7 @@ elseif (sim_mode <: AbstractSlabplanetSimulationMode) && !(sim_mode <: Slabplane
     land_area_fraction = sim_mode <: SlabplanetTerraMode ? land_area_fraction .* 0 .+ 1 : land_area_fraction
 
     ## land model
-    land_sim = bucket_init(
+    land_sim = BucketSimulation(
         FT,
         tspan,
         land_domain_type,
@@ -375,7 +375,7 @@ elseif (sim_mode <: AbstractSlabplanetSimulationMode) && !(sim_mode <: Slabplane
     )
 
     ## ocean model
-    ocean_sim = ocean_init(
+    ocean_sim = SlabOceanSimulation(
         FT;
         tspan = tspan,
         dt = component_dt_dict["dt_ocean"],
@@ -406,7 +406,7 @@ elseif (sim_mode <: AbstractSlabplanetSimulationMode) && !(sim_mode <: Slabplane
 elseif sim_mode <: SlabplanetEisenmanMode
 
     ## land model
-    land_sim = bucket_init(
+    land_sim = BucketSimulation(
         FT,
         tspan,
         land_domain_type,
@@ -426,7 +426,7 @@ elseif sim_mode <: SlabplanetEisenmanMode
     )
 
     ## ocean stub (here set to zero area coverage)
-    ocean_sim = ocean_init(
+    ocean_sim = SlabOceanSimulation(
         FT;
         tspan = tspan,
         dt = component_dt_dict["dt_ocean"],
@@ -437,7 +437,7 @@ elseif sim_mode <: SlabplanetEisenmanMode
     )
 
     ## sea ice + ocean model
-    ice_sim = eisenman_seaice_init(
+    ice_sim = EisenmanIceSimulation(
         FT,
         tspan,
         space = boundary_space,

--- a/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
@@ -139,7 +139,7 @@ This uses the `ClimaAtmos.jl` model, with parameterization options specified in 
 =#
 
 ## init atmos model component
-atmos_sim = atmos_init(atmos_config_object);
+atmos_sim = ClimaAtmosSimulation(atmos_config_object);
 thermo_params = get_thermo_params(atmos_sim)
 
 #=
@@ -153,7 +153,7 @@ boundary_space = CC.Spaces.horizontal_space(atmos_sim.domain.face_space) # TODO:
 ### Surface Model: Slab Ocean
 =#
 
-ocean_sim = ocean_init(
+ocean_sim = SlabOceanSimulation(
     FT;
     tspan = tspan,
     dt = Δt_cpl,

--- a/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
@@ -164,7 +164,7 @@ This uses the `ClimaAtmos.jl` model, with parameterization options specified in 
 =#
 
 ## init atmos model component
-atmos_sim = atmos_init(atmos_config_object);
+atmos_sim = ClimaAtmosSimulation(atmos_config_object);
 thermo_params = get_thermo_params(atmos_sim)
 
 #=
@@ -177,7 +177,7 @@ boundary_space = CC.Spaces.horizontal_space(atmos_sim.domain.face_space) # TODO:
 #=
 ### Surface Model: Slab Ocean
 =#
-ocean_sim = ocean_init(
+ocean_sim = SlabOceanSimulation(
     FT;
     tspan = tspan,
     dt = Δt_cpl,

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -174,7 +174,7 @@ This uses the `ClimaAtmos.jl` model, with parameterization options specified in 
 =#
 
 ## init atmos model component
-atmos_sim = atmos_init(atmos_config_object);
+atmos_sim = ClimaAtmosSimulation(atmos_config_object);
 surface_elevation = CC.Fields.level(CC.Fields.coordinate_field(atmos_sim.integrator.u.f).z, CC.Utilities.half)
 thermo_params = get_thermo_params(atmos_sim)
 
@@ -203,7 +203,7 @@ land_area_fraction = SpaceVaryingInput(land_mask_data, "landsea", boundary_space
 saveat = Float64(Utilities.time_to_seconds(config_dict["dt_save_to_sol"]))
 
 ## land model
-land_sim = bucket_init(
+land_sim = BucketSimulation(
     FT,
     tspan,
     "sphere",
@@ -222,7 +222,7 @@ land_sim = bucket_init(
     use_land_diagnostics = true,
 )
 
-ocean_sim = ocean_init(
+ocean_sim = SlabOceanSimulation(
     FT;
     tspan = tspan,
     dt = Δt_cpl,

--- a/experiments/ClimaEarth/run_dry_held_suarez.jl
+++ b/experiments/ClimaEarth/run_dry_held_suarez.jl
@@ -126,7 +126,7 @@ comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
 =#
 
 ## init atmos model component
-atmos_sim = atmos_init(atmos_config_object);
+atmos_sim = ClimaAtmosSimulation(atmos_config_object);
 thermo_params = get_thermo_params(atmos_sim)
 
 #=

--- a/experiments/ClimaEarth/run_moist_held_suarez.jl
+++ b/experiments/ClimaEarth/run_moist_held_suarez.jl
@@ -140,7 +140,7 @@ This uses the `ClimaAtmos.jl` model, with parameterization options specified in 
 =#
 
 ## init atmos model component
-atmos_sim = atmos_init(atmos_config_object);
+atmos_sim = ClimaAtmosSimulation(atmos_config_object);
 thermo_params = get_thermo_params(atmos_sim)
 
 #=

--- a/src/surface_stub.jl
+++ b/src/surface_stub.jl
@@ -7,13 +7,6 @@ struct SurfaceStub{I} <: SurfaceModelSimulation
     cache::I
 end
 
-"""
-    stub_init(cache)
-
-Initialization function for SurfaceStub simulation type.
-"""
-stub_init(cache) = SurfaceStub(cache)
-
 ## Extensions of Interfacer.jl functions
 
 """

--- a/test/component_model_tests/eisenman_seaice_tests.jl
+++ b/test/component_model_tests/eisenman_seaice_tests.jl
@@ -302,7 +302,7 @@ for FT in (Float32, Float64)
     @testset "step! update + total energy calculation for FT=$FT" begin
         Δt = Float64(1000)
 
-        sim = eisenman_seaice_init(
+        sim = EisenmanIceSimulation(
             FT,
             (0, 2e6),
             space = boundary_space,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Our constructors have been using names like `<sim>_init`. This PR renames them to use e.g. `SimName` instead, following constructor naming convention.

closes #1126
