### PR TITLE
allow list of TOML files

### DIFF
--- a/config/amip_configs/amip.yml
+++ b/config/amip_configs/amip.yml
@@ -2,7 +2,7 @@ FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 checkpoint_dt: "720hours"
-coupler_toml_file: "toml/amip.toml"
+coupler_toml: ["toml/amip.toml"]
 dt: "120secs"
 dt_cpl: "120secs"
 dt_save_state_to_disk: "30days"

--- a/config/longrun_configs/amip_target_topo_diagedmf_cpu.yml
+++ b/config/longrun_configs/amip_target_topo_diagedmf_cpu.yml
@@ -3,7 +3,7 @@ aerosol_radiation: true
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml"
 checkpoint_dt: "30days"
-coupler_toml_file: "toml/amip_target_topo_diagedmf.toml"
+coupler_toml: ["toml/amip_target_topo_diagedmf.toml"]
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_cpl: "120secs"

--- a/config/longrun_configs/amip_target_topo_diagedmf_gpu.yml
+++ b/config/longrun_configs/amip_target_topo_diagedmf_gpu.yml
@@ -3,7 +3,7 @@ aerosol_radiation: true
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_diagedmf_0M.yml"
 checkpoint_dt: "300days"
-coupler_toml_file: "toml/amip_target_topo_diagedmf.toml"
+coupler_toml: ["toml/amip_target_topo_diagedmf.toml"]
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_cpl: "120secs"

--- a/config/nightly_configs/amip_coarse.yml
+++ b/config/nightly_configs/amip_coarse.yml
@@ -2,7 +2,7 @@ FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 checkpoint_dt: "720hours"
-coupler_toml_file: "toml/amip.toml"
+coupler_toml: ["toml/amip.toml"]
 dt: "240secs"
 dt_cpl: "240secs"
 dt_save_state_to_disk: "30days"

--- a/config/nightly_configs/amip_coarse_random.yml
+++ b/config/nightly_configs/amip_coarse_random.yml
@@ -2,7 +2,7 @@ FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
 checkpoint_dt: "720hours"
-coupler_toml_file: "toml/amip.toml"
+coupler_toml: ["toml/amip.toml"]
 dt: "240secs"
 dt_cpl: "240secs"
 dt_save_state_to_disk: "30days"

--- a/experiments/ClimaEarth/cli_options.jl
+++ b/experiments/ClimaEarth/cli_options.jl
@@ -20,9 +20,10 @@ function argparse_settings()
         help = "Mode of coupled simulation. [`amip` (default), `slabplanet`, `slabplanet_aqua`, `slabplanet_terra`, `slabplanet_eisenman`]"
         arg_type = String
         default = "amip"
-        "--coupler_toml_file"
-        help = "An optional toml file used to overwrite the default model parameters."
-        default = nothing
+        "--coupler_toml"
+        help = "An optional list of paths to toml files used to overwrite the default model parameters."
+        arg_type = Vector{String}
+        default = []
         # Computational simulation setup information
         "--unique_seed"
         help = "Boolean flag indicating whether to set the random number seed to a unique value [`false` (default), `true`]"

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -342,16 +342,14 @@ function get_atmos_config_dict(coupler_dict::Dict, job_id::String, atmos_output_
         error("Invalid `atmos_config_repo`; please use \"ClimaCoupler\" or \"ClimaAtmos\"")
     end
 
-    # use coupler toml if atmos is not defined
-    atmos_toml_file = atmos_config["toml"]
-    coupler_toml_file = coupler_dict["coupler_toml_file"]
+    # use atmos toml if coupler toml is not defined
+    atmos_toml = joinpath.(pkgdir(CA), atmos_config["toml"])
+    coupler_toml = joinpath.(pkgdir(ClimaCoupler), coupler_dict["coupler_toml"])
+    toml = isempty(coupler_toml) ? atmos_toml : coupler_toml
 
-    toml_file = !isempty(atmos_toml_file) ? joinpath(pkgdir(CA), atmos_toml_file[1]) : nothing
-    toml_file = !isnothing(coupler_toml_file) ? joinpath(pkgdir(ClimaCoupler), coupler_toml_file) : toml_file
-
-    if !isnothing(toml_file)
-        @info "Overwriting Atmos parameters from $toml_file"
-        atmos_config = merge(atmos_config, Dict("toml" => [toml_file]))
+    if !isempty(toml)
+        @info "Overwriting Atmos parameters from input TOML file(s)"
+        atmos_config = merge(atmos_config, Dict("toml" => toml))
     end
 
     # Specify atmos output directory to be inside the coupler output directory

--- a/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
@@ -71,7 +71,7 @@ config_dict = Dict(
     "FLOAT_TYPE" => string(FT),
     # file paths
     "atmos_config_file" => nothing,
-    "coupler_toml_file" => nothing,
+    "coupler_toml" => [],
     "coupler_output_dir" => coupler_output_dir,
     "mode_name" => "",
     "job_id" => job_id,

--- a/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
@@ -71,7 +71,7 @@ config_dict = Dict(
     "FLOAT_TYPE" => string(FT),
     # file paths
     "atmos_config_file" => nothing,
-    "coupler_toml_file" => nothing,
+    "coupler_toml" => [],
     "coupler_output_dir" => coupler_output_dir,
     "mode_name" => "",
     "job_id" => job_id,

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -77,7 +77,7 @@ config_dict = Dict(
     "FLOAT_TYPE" => string(FT),
     # file paths
     "atmos_config_file" => nothing,
-    "coupler_toml_file" => nothing,
+    "coupler_toml" => [],
     "coupler_output_dir" => coupler_output_dir,
     "mode_name" => "",
     "job_id" => job_id,

--- a/experiments/ClimaEarth/run_dry_held_suarez.jl
+++ b/experiments/ClimaEarth/run_dry_held_suarez.jl
@@ -71,7 +71,7 @@ config_dict = Dict(
     "FLOAT_TYPE" => string(FT),
     # file paths
     "atmos_config_file" => nothing,
-    "coupler_toml_file" => nothing,
+    "coupler_toml" => [],
     "coupler_output_dir" => coupler_output_dir,
     "mode_name" => "",
     "atmos_config_repo" => "ClimaAtmos",

--- a/experiments/ClimaEarth/run_moist_held_suarez.jl
+++ b/experiments/ClimaEarth/run_moist_held_suarez.jl
@@ -74,7 +74,7 @@ config_dict = Dict(
     "FLOAT_TYPE" => string(FT),
     # file paths
     "atmos_config_file" => nothing,
-    "coupler_toml_file" => nothing,
+    "coupler_toml" => [],
     "coupler_output_dir" => coupler_output_dir,
     "mode_name" => "",
     "job_id" => job_id,

--- a/experiments/ClimaEarth/test/amip_test.yml
+++ b/experiments/ClimaEarth/test/amip_test.yml
@@ -1,7 +1,7 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
-coupler_toml_file: "toml/amip.toml"
+coupler_toml: ["toml/amip.toml"]
 dt: "180secs"
 dt_cpl: "180secs"
 dt_save_state_to_disk: "30days"

--- a/test/component_model_tests/climaatmos_standalone/longrun_aquaplanet_allsky_tvinsol_0M_slabocean.yml
+++ b/test/component_model_tests/climaatmos_standalone/longrun_aquaplanet_allsky_tvinsol_0M_slabocean.yml
@@ -17,7 +17,7 @@ rad: "allsky"
 rayleigh_sponge: true
 surface_setup: "DefaultMoninObukhov"
 t_end: "120days"
-coupler_toml_file: "test/component_model_tests/climaatmos_standalone/longrun_aquaplanet.toml"
+coupler_toml: ["test/component_model_tests/climaatmos_standalone/longrun_aquaplanet.toml"]
 vert_diff: "FriersonDiffusion"
 z_elem: 63
 z_max: 55000.0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
For calibration purposes, we want to be able to take in multiple TOML files. This PR updates ClimaCoupler to use a more similar structure to ClimaAtmos in allowing multiple TOMLs. Also renames "coupler_toml_file" to "coupler_toml" for brevity.

closes #1149