### PR TITLE
use `sim_mode` only in init

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,14 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Postprocessing no longer uses `sim_mode` PR[#1153](https://github.com/CliMA/ClimaCoupler.jl/pull/1153)
+Postprocessing now consists of a single function that's used for all simulation
+modes. Note that now all available diagnostics will be plotted at the end of
+the simulation, where before we specified a subset to plot based on the
+simulation type.
+This PR also removes the `plot_diagnostics` config option. `use_coupler_diagnostics`
+should be used instead.
+
 #### PrescribedOceanSimulation added, includes SST update PR[#1144](https://github.com/CliMA/ClimaCoupler.jl/pull/1144)
 This PR is similar to #1141 below, but applies to SST rather than SIC.
 SST is now updated within `PrescribedOceanSimulation` methods, rather

--- a/config/ci_configs/slabplanet_atmos_diags.yml
+++ b/config/ci_configs/slabplanet_atmos_diags.yml
@@ -1,5 +1,4 @@
 apply_limiter: false
-plot_diagnostics: true
 dt: "200secs"
 dt_cpl: "200secs"
 dt_save_to_sol: "9days"

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -39,7 +39,7 @@ Once we have created a `ScheduledDiagnostic` for each variable we're interested 
 we collect them in a vector and pass this to our `DiagnosticsHandler` object.
 
 An example of this process for the variable `F_turb_energy` can be found in
-`experiments/ClimaEarth/user_io/amip_diagnostics.jl`.
+`experiments/ClimaEarth/user_io/coupler_diagnostics.jl`.
 
 For more information about this process, please see the
 ClimaDiagnostics.jl [documentation](https://clima.github.io/ClimaDiagnostics.jl/dev/).

--- a/experiments/ClimaEarth/cli_options.jl
+++ b/experiments/ClimaEarth/cli_options.jl
@@ -119,10 +119,6 @@ function argparse_settings()
         help = "Directory to save output files. Note that TempestRemap fails if interactive and paths are too long. [\"experiments/ClimaEarth/output\" (default)]"
         arg_type = String
         default = "experiments/ClimaEarth/output"
-        "--plot_diagnostics"
-        help = "Boolean flag indicating whether to make plot diagnostics [`false` (default), `true`]"
-        arg_type = Bool
-        default = false
         # ClimaAtmos specific
         "--surface_setup"
         help = "Triggers ClimaAtmos into the coupled mode [`PrescribedSurface` (default), `DefaultMoninObukhov`]" # retained here for standalone Atmos benchmarks

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -280,7 +280,6 @@ if sim_mode <: AMIPMode
     ocean_fraction = FT(1) .- ice_fraction .- land_fraction
     ocean_sim = PrescribedOceanSimulation(FT, boundary_space, date0, t_start, ocean_fraction, thermo_params, comms_ctx)
 
-    mode_specifics = (; type = sim_mode)
     Utilities.show_memory_usage()
 
 elseif (sim_mode <: AbstractSlabplanetSimulationMode) && !(sim_mode <: SlabplanetEisenmanMode)
@@ -335,7 +334,6 @@ elseif (sim_mode <: AbstractSlabplanetSimulationMode) && !(sim_mode <: Slabplane
         thermo_params = thermo_params,
     ))
 
-    mode_specifics = (; type = sim_mode)
     Utilities.show_memory_usage()
 
 elseif sim_mode <: SlabplanetEisenmanMode
@@ -382,7 +380,6 @@ elseif sim_mode <: SlabplanetEisenmanMode
         thermo_params = thermo_params,
     )
 
-    mode_specifics = (; type = sim_mode)
     Utilities.show_memory_usage()
 end
 
@@ -487,14 +484,14 @@ end
 #= Set up default AMIP diagnostics
 Use ClimaDiagnostics for default AMIP diagnostics, which currently include turbulent energy fluxes.
 =#
-if sim_mode <: AMIPMode && use_coupler_diagnostics
+if use_coupler_diagnostics
+    @info "Using default coupler diagnostics"
     include("user_io/amip_diagnostics.jl")
     coupler_diags_path = joinpath(dir_paths.output, "coupler")
     isdir(coupler_diags_path) || mkpath(coupler_diags_path)
-    amip_diags_handler =
-        amip_diagnostics_setup(coupler_fields, coupler_diags_path, dates.date0[1], tspan[1], calendar_dt)
+    diags_handler = amip_diagnostics_setup(coupler_fields, coupler_diags_path, dates.date0[1], tspan[1], calendar_dt)
 else
-    amip_diags_handler = nothing
+    diags_handler = nothing
 end
 
 #=
@@ -515,12 +512,11 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     Δt_cpl,
     model_sims,
-    mode_specifics,
     callbacks,
     dir_paths,
     turbulent_fluxes,
     thermo_params,
-    amip_diags_handler,
+    diags_handler,
 );
 Utilities.show_memory_usage()
 
@@ -659,8 +655,7 @@ function solve_coupler!(cs)
         ## compute/output AMIP diagnostics if scheduled for this timestep
         ## wrap the current CoupledSimulation fields and time in a NamedTuple to match the ClimaDiagnostics interface
         cs_nt = (; u = cs.fields, p = nothing, t = t, step = round(t / Δt_cpl))
-        (cs.mode.type <: AMIPMode && !isnothing(cs.amip_diags_handler)) &&
-            CD.orchestrate_diagnostics(cs_nt, cs.amip_diags_handler)
+        !isnothing(cs.diags_handler) && CD.orchestrate_diagnostics(cs_nt, cs.diags_handler)
     end
     return nothing
 end
@@ -737,13 +732,7 @@ The postprocessing includes:
 =#
 
 if ClimaComms.iamroot(comms_ctx)
-    postprocessing_vars = (;
-        plot_diagnostics,
-        use_coupler_diagnostics,
-        output_default_diagnostics,
-        t_end,
-        conservation_softfail,
-        atmos_output_dir,
-    )
-    postprocess_sim(cs.mode.type, cs, postprocessing_vars)
+    postprocessing_vars =
+        (; plot_diagnostics, use_coupler_diagnostics, output_default_diagnostics, t_end, conservation_softfail)
+    postprocess_sim(cs, postprocessing_vars)
 end

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -131,7 +131,6 @@ add_extra_diagnostics!(config_dict)
     energy_check,
     conservation_softfail,
     output_dir_root,
-    plot_diagnostics,
 ) = get_coupler_args(config_dict)
 
 #=
@@ -486,10 +485,10 @@ Use ClimaDiagnostics for default AMIP diagnostics, which currently include turbu
 =#
 if use_coupler_diagnostics
     @info "Using default coupler diagnostics"
-    include("user_io/amip_diagnostics.jl")
+    include("user_io/coupler_diagnostics.jl")
     coupler_diags_path = joinpath(dir_paths.output, "coupler")
     isdir(coupler_diags_path) || mkpath(coupler_diags_path)
-    diags_handler = amip_diagnostics_setup(coupler_fields, coupler_diags_path, dates.date0[1], tspan[1], calendar_dt)
+    diags_handler = coupler_diagnostics_setup(coupler_fields, coupler_diags_path, dates.date0[1], tspan[1], calendar_dt)
 else
     diags_handler = nothing
 end
@@ -732,7 +731,6 @@ The postprocessing includes:
 =#
 
 if ClimaComms.iamroot(comms_ctx)
-    postprocessing_vars =
-        (; plot_diagnostics, use_coupler_diagnostics, output_default_diagnostics, t_end, conservation_softfail)
+    postprocessing_vars = (; use_coupler_diagnostics, output_default_diagnostics, t_end, conservation_softfail)
     postprocess_sim(cs, postprocessing_vars)
 end

--- a/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
@@ -241,12 +241,11 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     Δt_cpl,
     model_sims,
-    (;), # mode_specifics
     callbacks,
     dir_paths,
     turbulent_fluxes,
     thermo_params,
-    nothing, # amip_diags_handler
+    nothing, # diags_handler
 );
 
 #=

--- a/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
@@ -265,12 +265,11 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     Δt_cpl,
     model_sims,
-    (;), # mode_specifics
     callbacks,
     dir_paths,
     turbulent_fluxes,
     thermo_params,
-    nothing, # amip_diags_handler
+    nothing, # diags_handler
 );
 
 #=

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -301,12 +301,11 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     Δt_cpl,
     model_sims,
-    (;), # mode_specifics
     callbacks,
     dir_paths,
     turbulent_fluxes,
     thermo_params,
-    nothing, # amip_diags_handler
+    nothing, # diags_handler
 );
 
 #=

--- a/experiments/ClimaEarth/run_dry_held_suarez.jl
+++ b/experiments/ClimaEarth/run_dry_held_suarez.jl
@@ -189,12 +189,11 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     Δt_cpl,
     model_sims,
-    (;), # mode_specifics
     callbacks,
     dir_paths,
     nothing, # turbulent_fluxes
     thermo_params,
-    nothing, # amip_diags_handler
+    nothing, # diags_handler
 );
 
 #=

--- a/experiments/ClimaEarth/run_moist_held_suarez.jl
+++ b/experiments/ClimaEarth/run_moist_held_suarez.jl
@@ -239,12 +239,11 @@ cs = Interfacer.CoupledSimulation{FT}(
     [tspan[1], tspan[2]],
     Δt_cpl,
     model_sims,
-    (;), # mode_specifics
     callbacks,
     dir_paths,
     turbulent_fluxes,
     thermo_params,
-    nothing, # amip_diags_handler
+    nothing, # diags_handler
 );
 
 #=

--- a/experiments/ClimaEarth/user_io/amip_diagnostics.jl
+++ b/experiments/ClimaEarth/user_io/amip_diagnostics.jl
@@ -48,6 +48,6 @@ function amip_diagnostics_setup(fields, output_dir, start_date, t_start, calenda
 
     # Create the diagnostics handler containing the scheduled diagnostics
     scheduled_diags = [F_turb_energy_diag_sched]
-    amip_diags_handler = CD.DiagnosticsHandler(scheduled_diags, fields, nothing, t_start)
-    return amip_diags_handler
+    diags_handler = CD.DiagnosticsHandler(scheduled_diags, fields, nothing, t_start)
+    return diags_handler
 end

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -28,7 +28,7 @@ function get_coupler_config()
     job_id = isnothing(job_id) ? string(split(split(config_file, '/')[end], '.')[1]) : job_id
 
     # Read in config dictionary from file, overriding the defaults in `parsed_args`
-    config_dict = merge(parsed_args, YAML.load_file(parsed_args["config_file"]))
+    config_dict = merge(parsed_args, YAML.load_file(config_file))
     config_dict["job_id"] = job_id
     return config_dict
 end

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -76,7 +76,7 @@ function get_coupler_args(config_dict::Dict)
     # Diagnostics information
     use_coupler_diagnostics = config_dict["use_coupler_diagnostics"]
     use_land_diagnostics = config_dict["use_land_diagnostics"]
-    calendar_dt = config_dict["calendar_dt"]
+    (_, calendar_dt) = get_diag_period(t_start, t_end)
 
     # Physical simulation information
     evolving_ocean = config_dict["evolving_ocean"]
@@ -89,7 +89,6 @@ function get_coupler_args(config_dict::Dict)
 
     # Output information
     output_dir_root = config_dict["coupler_output_dir"]
-    plot_diagnostics = config_dict["plot_diagnostics"]
 
     # ClimaLand-specific information
     land_domain_type = config_dict["land_domain_type"]
@@ -122,7 +121,6 @@ function get_coupler_args(config_dict::Dict)
         energy_check,
         conservation_softfail,
         output_dir_root,
-        plot_diagnostics,
         land_domain_type,
         land_albedo_type,
         land_initial_condition,

--- a/experiments/ClimaEarth/user_io/coupler_diagnostics.jl
+++ b/experiments/ClimaEarth/user_io/coupler_diagnostics.jl
@@ -3,7 +3,7 @@ import ClimaCoupler: Interfacer
 import Dates
 
 """
-    amip_diagnostics_setup(fields, output_dir, start_date, t_start, calendar_dt)
+    coupler_diagnostics_setup(fields, output_dir, start_date, t_start, calendar_dt)
 
 Set up the default diagnostics for an AMIP simulation, using ClimaDiagnostics.
 The diagnostics are saved to NetCDF files. Currently, this just includes a
@@ -11,7 +11,7 @@ diagnostic for turbulent energy fluxes.
 
 Return a DiagnosticsHandler object to coordinate the diagnostics.
 """
-function amip_diagnostics_setup(fields, output_dir, start_date, t_start, calendar_dt)
+function coupler_diagnostics_setup(fields, output_dir, start_date, t_start, calendar_dt)
     # Create schedules and writer
     schedule_everystep = CD.Schedules.EveryStepSchedule()
     schedule_calendar_dt = CD.Schedules.EveryCalendarDtSchedule(calendar_dt, start_date = start_date)

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -4,16 +4,40 @@ include("diagnostics_plots.jl")
 include("../leaderboard/leaderboard.jl")
 
 """
-    postprocess_sim(::Type{AbstractSlabplanetSimulationMode}, cs, postprocessing_vars)
+    postprocess_sim(cs, postprocessing_vars)
 
-Call `common_postprocessing` to perform common postprocessing tasks that are common to all simulation types.
-Then, if conservation checks exist, perform them.
+Perform all postprocessing operations. This includes plotting all available
+diagnostics, plotting all model states and coupler fields for debugging,
+producing the leaderboard if monthly data is available, performing
+conservation checks if enabled, and closing all diagnostics file writers.
 """
-function postprocess_sim(::Type{<:AbstractSlabplanetSimulationMode}, cs, postprocessing_vars)
-    (; conservation_softfail,) = postprocessing_vars
+function postprocess_sim(cs, postprocessing_vars)
+    (; use_coupler_diagnostics, output_default_diagnostics, t_end, conservation_softfail) = postprocessing_vars
+    output_dir = cs.dirs.output
+    artifact_dir = cs.dirs.artifacts
+    coupler_output_dir = joinpath(output_dir, "coupler")
+    atmos_output_dir = joinpath(output_dir, "clima_atmos")
+    land_output_dir = joinpath(output_dir, "clima_land")
 
-    common_postprocessing(cs, postprocessing_vars)
+    # Plot generic diagnostics if requested
+    if use_coupler_diagnostics && plot_diagnostics
+        @info "Plotting diagnostics for coupler, atmos, and land"
+        make_diagnostics_plots(coupler_output_dir, artifact_dir, output_prefix = "coupler_")
+        make_diagnostics_plots(atmos_output_dir, artifact_dir, output_prefix = "atmos_")
+        make_diagnostics_plots(land_output_dir, artifact_dir, output_prefix = "land_")
+    end
 
+    # Plot all model states and coupler fields (useful for debugging)
+    !CA.is_distributed(cs.comms_ctx) && debug(cs, artifact_dir)
+
+    # If we have monthly data, plot the leaderboard
+    if t_end > 84600 * 31 * 3 && output_default_diagnostics
+        leaderboard_base_path = artifact_dir
+        compute_leaderboard(leaderboard_base_path, atmos_output_dir)
+        compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir)
+    end
+
+    # Perform conservation checks if they exist
     if !isnothing(cs.conservation_checks)
         @info "Conservation Check Plots"
         plot_global_conservation(
@@ -31,66 +55,7 @@ function postprocess_sim(::Type{<:AbstractSlabplanetSimulationMode}, cs, postpro
             figname2 = joinpath(cs.dirs.artifacts, "total_water_log_bucket.png"),
         )
     end
-end
 
-"""
-    postprocess_sim(::Type{AMIPMode}, cs, postprocessing_vars)
-
-Call `common_postprocessing` to perform postprocessing tasks that are common to all simulation
-types, and then conditionally plot AMIP diagnostics
-"""
-function postprocess_sim(::Type{AMIPMode}, cs, postprocessing_vars)
-    (; use_coupler_diagnostics, output_default_diagnostics, t_end) = postprocessing_vars
-
-    common_postprocessing(cs, postprocessing_vars)
-
-    if use_coupler_diagnostics
-        ## plot data that correspond to the model's last save_hdf5 call (i.e., last month)
-        @info "AMIP plots"
-        # define variable names and output directories for each diagnostic
-        amip_short_names_atmos = ["ta", "ua", "hus", "clw", "pr", "ts", "toa_fluxes_net"]
-        amip_short_names_coupler = ["F_turb_energy"]
-        output_dir_coupler = cs.dirs.output
-
-        # Check if all output variables are available in the specified directories
-        make_diagnostics_plots(
-            atmos_output_dir,
-            cs.dirs.artifacts,
-            short_names = amip_short_names_atmos,
-            output_prefix = "atmos_",
-        )
-        make_diagnostics_plots(
-            output_dir_coupler,
-            cs.dirs.artifacts,
-            short_names = amip_short_names_coupler,
-            output_prefix = "coupler_",
-        )
-    end
-
-    # Check this because we only want monthly data for making plots
-    if t_end > 84600 * 31 * 3 && output_default_diagnostics
-        leaderboard_base_path = cs.dirs.artifacts
-        compute_leaderboard(leaderboard_base_path, atmos_output_dir)
-        compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir)
-    end
-
-    # close all AMIP diagnostics file writers
-    !isnothing(cs.amip_diags_handler) &&
-        map(diag -> close(diag.output_writer), cs.amip_diags_handler.scheduled_diagnostics)
-end
-
-"""
-    common_postprocessing(cs, postprocessing_vars)
-
-Perform postprocessing common to all simulation types.
-"""
-function common_postprocessing(cs, postprocessing_vars)
-    (; plot_diagnostics, atmos_output_dir) = postprocessing_vars
-    if plot_diagnostics
-        @info "Plotting diagnostics"
-        make_diagnostics_plots(atmos_output_dir, cs.dirs.artifacts)
-    end
-
-    # plot all model states and coupler fields (useful for debugging)
-    !CA.is_distributed(cs.comms_ctx) && debug(cs, cs.dirs.artifacts)
+    # Close all diagnostics file writers
+    !isnothing(cs.diags_handler) && map(diag -> close(diag.output_writer), cs.diags_handler.scheduled_diagnostics)
 end

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -20,7 +20,7 @@ function postprocess_sim(cs, postprocessing_vars)
     land_output_dir = joinpath(output_dir, "clima_land")
 
     # Plot generic diagnostics if requested
-    if use_coupler_diagnostics && plot_diagnostics
+    if use_coupler_diagnostics
         @info "Plotting diagnostics for coupler, atmos, and land"
         make_diagnostics_plots(coupler_output_dir, artifact_dir, output_prefix = "coupler_")
         make_diagnostics_plots(atmos_output_dir, artifact_dir, output_prefix = "atmos_")

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -54,7 +54,6 @@ struct CoupledSimulation{
     TS,
     DTI <: Real,
     NTMS <: NamedTuple,
-    NTM <: NamedTuple,
     NTC <: NamedTuple,
     NTP <: NamedTuple,
     TF,
@@ -69,12 +68,11 @@ struct CoupledSimulation{
     tspan::TS
     Δt_cpl::DTI
     model_sims::NTMS
-    mode::NTM
     callbacks::NTC
     dirs::NTP
     turbulent_fluxes::TF
     thermo_params::TP
-    amip_diags_handler::DH
+    diags_handler::DH
 end
 
 CoupledSimulation{FT}(args...) where {FT} = CoupledSimulation{FT, typeof.(args[1:end])...}(args...)

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -90,12 +90,11 @@ for FT in (Float32, Float64)
             (Int(0), Int(1000)), # tspan
             Int(200), # Δt_cpl
             model_sims, # model_sims
-            (;), # mode
             (;), # callbacks
             (;), # dirs
             nothing, # turbulent_fluxes
             nothing, # thermo_params
-            nothing, # amip_diags_handler
+            nothing, # diags_handler
         )
 
         # set non-zero radiation and precipitation
@@ -170,12 +169,11 @@ for FT in (Float32, Float64)
             (Int(0), Int(1000)), # tspan
             Int(200), # Δt_cpl
             model_sims, # model_sims
-            (;), # mode
             (;), # callbacks
             (;), # dirs
             nothing, # turbulent_fluxes
             nothing, # thermo_params
-            nothing, # amip_diags_handler
+            nothing, # diags_handler
         )
 
         tot_energy, tot_water = ConservationChecker.check_conservation!(cs)

--- a/test/debug/debug_amip_plots.jl
+++ b/test/debug/debug_amip_plots.jl
@@ -74,12 +74,11 @@ plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
         (Int(0), Int(1)), # tspan
         Int(200), # Δt_cpl
         model_sims, # model_sims
-        (;), # mode
         (;), # callbacks
         (;), # dirs
         nothing, # turbulent_fluxes
         nothing, # thermo_params
-        nothing, # amip_diags_handler
+        nothing, # diags_handler
     )
 
     output_plots = "test_debug"

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -161,12 +161,11 @@ for FT in (Float32, Float64)
                 ocean_sim = Interfacer.SurfaceStub((; area_fraction = ocean_d)),
                 land_sim = DummyStub((; area_fraction = land_fraction)),
             ), # model_sims
-            (;), # mode
             (;), # callbacks
             (;), # dirs
             nothing, # turbulent_fluxes
             nothing, # thermo_params
-            nothing, # amip_diags_handler
+            nothing, # diags_handler
         )
 
         FieldExchanger.update_surface_fractions!(cs)

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -317,12 +317,11 @@ for FT in (Float32, Float64)
             (Int(0), Int(1)), # tspan
             0, # Δt_cpl
             model_sims, # model_sims
-            (;), # mode
             (;), # callbacks
             (;), # dirs
             nothing, # turbulent_fluxes
             nothing, # thermo_params
-            nothing, # amip_diags_handler
+            nothing, # diags_handler
         )
         FluxCalculator.water_albedo_from_atmosphere!(cs)
         @test sum(parent(cs.model_sims.ocean_sim.cache.α_direct) .- parent(ones(boundary_space)) .* 2) == 0

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -41,12 +41,11 @@ for FT in (Float32, Float64)
             (Int(0), Int(1000)), # tspan
             Int(200), # Δt_cpl
             (;), # model_sims
-            (;), # mode
             (;), # callbacks
             (;), # dirs
             nothing, # turbulent_fluxes
             nothing, # thermo_params
-            nothing, # amip_diags_handler
+            nothing, # diags_handler
         )
 
         @test Interfacer.float_type(cs) == FT

--- a/test/time_manager_tests.jl
+++ b/test/time_manager_tests.jl
@@ -24,12 +24,11 @@ for FT in (Float32, Float64)
             tspan, # tspan
             Int(Δt_cpl), # Δt_cpl
             (;), # model_sims
-            (;), # mode
             (;), # callbacks
             (;), # dirs
             nothing, # turbulent_fluxes
             nothing, # thermo_params
-            nothing, # amip_diags_handler
+            nothing, # diags_handler
         )
 
         for t in ((tspan[1] + Δt_cpl):Δt_cpl:tspan[end])


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Remove all uses of `sim_mode` after initialization, which was mostly in postprocessing/diagnostics. Note that now _all_ available diagnostics will be plotted at the end of the simulation, where before we specified a subset to plot based on the simulation type.

closes #1138

## To-do
- [x] check CI output diagnostics


## Content
- [x] shared postprocessing for slabplanet and AMIP simulation types
- [x] rename `amip_diags_handler` -> `diags_handler`
- [x] delete `plot_diagnostics` config option (redundant with `use_coupler_diagnostics`)
- [x] remove `mode_specifics` from `CoupledSimulation` altogether
- [x] rename `amip_diagnostics_setup` to `coupler_diagnostics_setup`


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
