### PR TITLE
Fix restart CI job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -312,14 +312,14 @@ steps:
           slurm_mem: 20GB
           slurm_gpus: 1
 
-  # - group: "Bash scripts"
-  #   steps:
-  #     - label: "Submit and Monitor sbatch Job on Caltech HPC"
-  #       # check that (1) the script can be succesfully submitted, (2) it runs successfully
-  #       command: "test/mpi_tests/test_sbatch_script.sh"
-  #       agents:
-  #         slurm_ntasks: 1
-  #       soft_fail: true
+  - group: "Test restart run and bash script"
+    steps:
+      - label: "Submit and Monitor sbatch Job on Caltech HPC"
+        # check that (1) the script can be succesfully submitted, (2) it runs successfully
+        command: "test/mpi_tests/test_sbatch_script.sh"
+        agents:
+          slurm_ntasks: 1
+        soft_fail: true
 
   - group: "Hierarchy tests (1d)"
     steps:

--- a/config/ci_configs/amip_coarse_ft64_hourly_checkpoints_restart.yml
+++ b/config/ci_configs/amip_coarse_ft64_hourly_checkpoints_restart.yml
@@ -1,7 +1,6 @@
 apply_limiter: false
 co2: "maunaloa"
-checkpoint_dt: "1hours"
-dt_save_restart: "10days"
+checkpoint_dt: "400secs"
 dt_save_to_sol: "1days"
 energy_check: false
 h_elem: 6

--- a/src/Checkpointer.jl
+++ b/src/Checkpointer.jl
@@ -82,7 +82,12 @@ function checkpoint_sims(cs::Interfacer.CoupledSimulation)
         if Checkpointer.get_model_prog_state(sim) !== nothing
             t = Dates.datetime2epochms(cs.dates.date[1])
             t0 = Dates.datetime2epochms(cs.dates.date0[1])
-            Checkpointer.checkpoint_model_state(sim, cs.comms_ctx, Int((t - t0) / 1e3), output_dir = cs.dirs.artifacts)
+            Checkpointer.checkpoint_model_state(
+                sim,
+                cs.comms_ctx,
+                Int((t - t0) / 1e3),
+                output_dir = cs.dirs.checkpoints,
+            )
         end
     end
 end

--- a/test/mpi_tests/local_checks.sh
+++ b/test/mpi_tests/local_checks.sh
@@ -12,11 +12,9 @@ module load climacommon/2024_10_09
 export CC_PATH=$(pwd)/ # adjust this to the path of your ClimaCoupler.jl directory
 export JOB_ID=amip_coarse_ft64_hourly_checkpoints_restart
 export CONFIG_FILE=${CC_PATH}config/ci_configs/${JOB_ID}.yml
-export RESTART_DIR=experiments/ClimaEarth/output/${JOB_ID}/artifacts/
+export RESTART_DIR=experiments/ClimaEarth/output/${JOB_ID}/checkpoints/
 
 export OPENBLAS_NUM_THREADS=1
-export JULIA_NVTX_CALLBACKS=gc
-export OMPI_MCA_opal_warn_on_missing_libcuda=0
 export JULIA_MAX_NUM_PRECOMPILE_FILES=100
 export SLURM_KILL_BAD_EXIT=1
 


### PR DESCRIPTION
The checkpoint frequency was larger than the total simulation time, so no
checkpoint was being produced. Moreover, the folder where to look for the checkpoints was no longer accurate

Closes #1159 