### PR TITLE
expose regrid_dir to user

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -200,7 +200,7 @@ steps:
       - label: "MPI AMIP"
         command: "srun julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_mpi.yml --job_id amip_coarse_mpi"
         artifact_paths: "experiments/ClimaEarth/output/amip_coarse_mpi/artifacts/*"
-        timeout_in_minutes: 240
+        timeout_in_minutes: 30
         env:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
@@ -320,6 +320,7 @@ steps:
         agents:
           slurm_ntasks: 1
         soft_fail: true
+        timeout_in_minutes: 40
 
   - group: "Hierarchy tests (1d)"
     steps:


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #1113

Exposes `regrid_dir` option of `setup_output_dirs` to user so it can be changed. Also updates the docstring of that function so it reflects the current behavior.
