### PR TITLE
Pass in arrays for saveat.

### DIFF
--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -58,7 +58,7 @@ function BucketSimulation(
     output_dir::String;
     space,
     dt::Float64,
-    saveat::Float64,
+    saveat::Vector{Float64},
     area_fraction,
     stepper = CTS.RK4(),
     date_ref::Dates.DateTime,

--- a/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
@@ -81,7 +81,7 @@ function EisenmanIceSimulation(
         dss_buffer = CC.Spaces.create_dss_buffer(Y),
     )
     problem = SciMLBase.ODEProblem(ode_function, Y, Float64.(tspan), cache)
-    integrator = SciMLBase.init(problem, ode_algo, dt = Float64(dt), saveat = Float64(saveat), adaptive = false)
+    integrator = SciMLBase.init(problem, ode_algo, dt = Float64(dt), saveat = Float64.(saveat), adaptive = false)
 
     sim = EisenmanIceSimulation(params, Y, space, integrator)
     return sim

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -141,7 +141,7 @@ function PrescribedIceSimulation(
     ode_function = CTS.ClimaODEFunction(T_exp! = ice_rhs!, dss! = (Y, p, t) -> CC.Spaces.weighted_dss!(Y, p.dss_buffer))
 
     problem = SciMLBase.ODEProblem(ode_function, Y, Float64.(tspan), (; cache..., params = params))
-    integrator = SciMLBase.init(problem, ode_algo, dt = Float64(dt), saveat = Float64(saveat), adaptive = false)
+    integrator = SciMLBase.init(problem, ode_algo, dt = Float64(dt), saveat = Float64.(saveat), adaptive = false)
 
     sim = PrescribedIceSimulation(params, Y, space, integrator)
 

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -94,7 +94,7 @@ function SlabOceanSimulation(
         CTS.ClimaODEFunction(; T_exp! = slab_ocean_rhs!, dss! = (Y, p, t) -> CC.Spaces.weighted_dss!(Y, p.dss_buffer))
 
     problem = SciMLBase.ODEProblem(ode_function, Y, Float64.(tspan), cache)
-    integrator = SciMLBase.init(problem, ode_algo, dt = Float64(dt), saveat = Float64(saveat), adaptive = false)
+    integrator = SciMLBase.init(problem, ode_algo, dt = Float64(dt), saveat = Float64.(saveat), adaptive = false)
 
     sim = SlabOceanSimulation(params, Y, space, integrator)
 

--- a/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
@@ -153,12 +153,15 @@ boundary_space = CC.Spaces.horizontal_space(atmos_sim.domain.face_space) # TODO:
 ### Surface Model: Slab Ocean
 =#
 
+saveat = Float64(Utilities.time_to_seconds(config_dict["dt_save_to_sol"]))
+saveat = [tspan[1]:saveat:tspan[1]..., tspan[2]]
+
 ocean_sim = SlabOceanSimulation(
     FT;
     tspan = tspan,
     dt = Δt_cpl,
     space = boundary_space,
-    saveat = Float64(Utilities.time_to_seconds(config_dict["dt_save_to_sol"])),
+    saveat = saveat,
     area_fraction = ones(boundary_space),
     thermo_params = thermo_params,
     evolving = true,

--- a/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
@@ -177,12 +177,16 @@ boundary_space = CC.Spaces.horizontal_space(atmos_sim.domain.face_space) # TODO:
 #=
 ### Surface Model: Slab Ocean
 =#
+
+saveat = Float64(Utilities.time_to_seconds(config_dict["dt_save_to_sol"]))
+saveat = [tspan[1]:saveat:tspan[1]..., tspan[2]]
+
 ocean_sim = SlabOceanSimulation(
     FT;
     tspan = tspan,
     dt = Δt_cpl,
     space = boundary_space,
-    saveat = Float64(Utilities.time_to_seconds(config_dict["dt_save_to_sol"])),
+    saveat = saveat,
     area_fraction = ones(boundary_space),
     thermo_params = thermo_params,
     evolving = true,

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -201,6 +201,7 @@ land_area_fraction = SpaceVaryingInput(land_mask_data, "landsea", boundary_space
 =#
 
 saveat = Float64(Utilities.time_to_seconds(config_dict["dt_save_to_sol"]))
+saveat = [tspan[1]:saveat:tspan[1]..., tspan[2]]
 
 ## land model
 land_sim = BucketSimulation(

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -63,6 +63,7 @@ function get_coupler_args(config_dict::Dict)
     date0 = date = Dates.DateTime(config_dict["start_date"], Dates.dateformat"yyyymmdd")
     Δt_cpl = Float64(Utilities.time_to_seconds(config_dict["dt_cpl"]))
     saveat = Float64(Utilities.time_to_seconds(config_dict["dt_save_to_sol"]))
+    saveat = [t_start:saveat:t_end..., t_end]
     component_dt_dict = config_dict["component_dt_dict"]
 
     # Checkpointing information


### PR DESCRIPTION
With the release of v0.8.2 for ClimaTimeSteppers, you cannot use a number for `saveat`.

- [X] Verify nightly coarse AMIP can enter the time stepping loop (see this [buildkite](https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/246#_))