### PR TITLE
update test compat

### DIFF
--- a/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
@@ -57,7 +57,7 @@ function EisenmanIceSimulation(
     thermo_params = nothing,
     stepper = CTS.RK4(),
     dt = 0.02,
-    saveat = 1.0e10,
+    saveat = [1.0e10],
 ) where {FT}
 
     params_ice = EisenmanIceParameters{FT}()

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -31,9 +31,10 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
 Aqua = "0.8"
-ClimaAtmos = "0.27"
+ClimaAtmos = "0.27, 0.28"
 ClimaParams = "0.10"
 ClimaTimeSteppers = "0.7, 0.8"
+ClimaUtilities = "0.1"
 Dates = "1"
 Pkg = "1"
 PrettyTables = "2"

--- a/test/component_model_tests/eisenman_seaice_tests.jl
+++ b/test/component_model_tests/eisenman_seaice_tests.jl
@@ -308,9 +308,7 @@ for FT in (Float32, Float64)
             space = boundary_space,
             area_fraction = ones(boundary_space),
             thermo_params = thermo_params,
-            stepper = CTS.RK4(),
             dt = Δt,
-            saveat = 1.0e10,
         )
         sim.integrator.p.Ya.F_turb .= 0
         sim.integrator.p.Ya.F_rad .= 300


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The ClimaAtmos-only benchmark runs have been [failing](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/220#_) because the test environment compat wasn't updated correctly when we updated to ClimaTimeSteppers v0.8. This PR fixes the test compat so the test environment can use the latest Atmos and CTS versions