### PR TITLE
run MPI AMIP on CPU reservation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -206,8 +206,7 @@ steps:
           CLIMACOMMS_CONTEXT: "MPI"
         agents:
           slurm_ntasks: 4
-          slurm_mem: 48GB
-          slurm_reservation: "false"
+          slurm_mem_per_cpu: 8GB
 
       # short high-res performance test
       - label: "Unthreaded AMIP FINE" # also reported by longruns with a flame graph

--- a/config/ci_configs/amip_coarse_mpi.yml
+++ b/config/ci_configs/amip_coarse_mpi.yml
@@ -1,8 +1,8 @@
 apply_limiter: false
 co2: "maunaloa"
-dt_save_to_sol: "1days"
+dt_save_to_sol: "10days"
 energy_check: false
-h_elem: 6
+h_elem: 4
 mode_name: "amip"
 moist: "equil"
 mono_surface: false


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The MPI AMIP CI run has not been running on our CPU reservation, but this has led to very long buildkite wait times just because of this one job. This PR makes a couple of changes to its config and the memory requested for this job with the goal of making it small enough to reasonably run on the CPU reservation.

This PR makes the following changes to the MPI AMIP config (`amip_coarse_mpi.yml`) with the intention of decreasing its memory footprint:
- increase `dt_save_to_sol` from 1 days to 10 days
- decreate `h_elem` from 6 to 4

Note: before this PR, the MPI AMIP job was using the following amount of resources:
```
[jsloan@login3 ~]$ seff 47086121
Job ID: 47086121
Cluster: central
User/Group: esmbuild/club
State: COMPLETED (exit code 0)
Nodes: 1
Cores per node: 4
CPU Utilized: 00:59:35
CPU Efficiency: 95.38% of 01:02:28 core-walltime
Job Wall-clock time: 00:15:37
Memory Utilized: 36.57 GB (estimated maximum)
Memory Efficiency: 76.18% of 48.00 GB (48.00 GB/node)
```
This PR changes the pipeline to request only 4x8GB for this run, so hopefully 32GB will be enough for it now