### PR TITLE
fig config diagnostic merging; print only on root

### DIFF
--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -356,8 +356,12 @@ function get_atmos_config_dict(coupler_dict::Dict, job_id::String, atmos_output_
     atmos_config["output_dir_style"] = "RemovePreexisting"
     atmos_config["output_dir"] = atmos_output_dir
 
-    # Access extra atmosphere diagnostics from coupler so we can rename for atmos code
-    atmos_config["diagnostics"] = coupler_dict["extra_atmos_diagnostics"]
+    # Add all extra atmos diagnostic entries into the vector of atmos diagnostics
+    # If atmos doesn't have any diagnostics, use the extra_atmos_diagnostics from the coupler
+    atmos_config["diagnostics"] =
+        haskey(atmos_config, "diagnostics") ?
+        collect([atmos_config["diagnostics"]; coupler_dict["extra_atmos_diagnostics"]]) :
+        coupler_dict["extra_atmos_diagnostics"]
 
     # The Atmos `get_simulation` function expects the atmos config to contains its timestep size
     # in the `dt` field. If there is a `dt_atmos` field in coupler_dict, we add it to the atmos config as `dt`

--- a/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
@@ -32,6 +32,12 @@ import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule
 pkg_dir = pkgdir(ClimaCoupler)
 
 #=
+## Setup Communication Context
+=#
+
+comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
+
+#=
 ### Helper Functions
 =#
 
@@ -122,12 +128,6 @@ config_dict = Dict(
 atmos_output_dir = joinpath(dir_paths.output, "clima_atmos")
 atmos_config_dict = get_atmos_config_dict(config_dict, job_id, atmos_output_dir)
 atmos_config_object = CA.AtmosConfig(atmos_config_dict)
-
-#=
-## Setup Communication Context
-=#
-
-comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
 
 #=
 ## Component Model Initialization

--- a/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
@@ -32,6 +32,12 @@ import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule
 pkg_dir = pkgdir(ClimaCoupler)
 
 #=
+## Setup Communication Context
+=#
+
+comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
+
+#=
 ### Helper Functions
 =#
 
@@ -145,14 +151,6 @@ atmos_config_object.toml_dict["detr_vertdiv_coeff"]["value"] = 0.6
 atmos_config_object.toml_dict["detr_buoy_coeff"]["value"] = 0.12
 atmos_config_object.toml_dict["min_area_limiter_scale"]["value"] = 0
 atmos_config_object.toml_dict["max_area_limiter_scale"]["value"] = 0
-
-#=
-## Setup Communication Context
-=#
-
-comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
-ClimaComms.init(comms_ctx)
-
 
 #=
 ## Component Model Initialization

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -36,6 +36,12 @@ import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule
 pkg_dir = pkgdir(ClimaCoupler)
 
 #=
+## Setup Communication Context
+=#
+
+comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
+
+#=
 ### Helper Functions
 =#
 
@@ -152,12 +158,6 @@ atmos_config_object.toml_dict["detr_vertdiv_coeff"]["value"] = 0.6
 atmos_config_object.toml_dict["detr_buoy_coeff"]["value"] = 0.12
 atmos_config_object.toml_dict["min_area_limiter_scale"]["value"] = 0
 atmos_config_object.toml_dict["max_area_limiter_scale"]["value"] = 0
-
-#=
-## Setup Communication Context
-=#
-
-comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
 
 #=
 ## Component Model Initialization

--- a/experiments/ClimaEarth/run_dry_held_suarez.jl
+++ b/experiments/ClimaEarth/run_dry_held_suarez.jl
@@ -33,6 +33,12 @@ import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule
 pkg_dir = pkgdir(ClimaCoupler)
 
 #=
+## Setup Communication Context
+=#
+
+comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
+
+#=
 ### Helper Functions
 =#
 
@@ -114,12 +120,6 @@ config_dict = Dict(
 atmos_output_dir = joinpath(dir_paths.output, "clima_atmos")
 atmos_config_dict = get_atmos_config_dict(config_dict, job_id, atmos_output_dir)
 atmos_config_object = CA.AtmosConfig(atmos_config_dict)
-
-#=
-## Setup Communication Context
-=#
-
-comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
 
 #=
 ## Component Model Initialization

--- a/experiments/ClimaEarth/run_moist_held_suarez.jl
+++ b/experiments/ClimaEarth/run_moist_held_suarez.jl
@@ -35,6 +35,12 @@ import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule
 pkg_dir = pkgdir(ClimaCoupler)
 
 #=
+## Setup Communication Context
+=#
+
+comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
+
+#=
 ### Helper Functions
 =#
 
@@ -123,12 +129,6 @@ config_dict = Dict(
 atmos_output_dir = joinpath(dir_paths.output, "clima_atmos")
 atmos_config_dict = get_atmos_config_dict(config_dict, job_id, atmos_output_dir)
 atmos_config_object = CA.AtmosConfig(atmos_config_dict)
-
-#=
-## Setup Communication Context
-=#
-
-comms_ctx = Utilities.get_comms_context(Dict("device" => "auto"))
 
 #=
 ## Component Model Initialization

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -160,6 +160,8 @@ diagnostics, and conservation checks, and then runs the simulation.
 function setup_and_run(config_file = joinpath(pkgdir(ClimaCoupler), "config/ci_configs/amip_default.yml"))
     # Parse the configuration file
     config_dict = get_coupler_config_dict(config_file)
+    # Initialize communication context (do this first so all printing is only on root)
+    comms_ctx = Utilities.get_comms_context(config_dict)
     # Select the correct timestep for each component model based on which are available
     parse_component_dts!(config_dict)
     # Add extra diagnostics if specified
@@ -170,7 +172,6 @@ function setup_and_run(config_file = joinpath(pkgdir(ClimaCoupler), "config/ci_c
         sim_mode,
         random_seed,
         FT,
-        comms_ctx,
         t_end,
         t_start,
         date0,

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -53,7 +53,6 @@ function get_coupler_args(config_dict::Dict)
     # Computational simulation setup information
     random_seed = config_dict["unique_seed"] ? time_ns() : 1234
     FT = config_dict["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
-    comms_ctx = Utilities.get_comms_context(config_dict)
 
     # Time information
     t_end = Float64(Utilities.time_to_seconds(config_dict["t_end"]))
@@ -100,7 +99,6 @@ function get_coupler_args(config_dict::Dict)
         sim_mode,
         random_seed,
         FT,
-        comms_ctx,
         t_end,
         t_start,
         date0,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR does 2 distinct things:
1. Fix merging of diagnostics specified in the coupler and atmosphere. Previously, `atmos_config_dict["diagnostics"]` was overwritten by the coupler `config_dict["extra_atmos_diags"]`. Now these additional diagnostics are appended, so we output all diagnostics.
2. Initialize the ClimaComms communication context immediately after creating the `config_dict`, so all printing happens on root in the MPI case