### PR TITLE
Add ITime

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,8 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
 ClimaComms = "0.6.2"
-ClimaCore = "0.14.17"
-ClimaUtilities = "0.1.9"
+ClimaCore = "0.14.23"
+ClimaUtilities = "0.1.22"
 Dates = "1"
 Logging = "1"
 SciMLBase = "2.11"

--- a/config/ci_configs/amip_component_dts.yml
+++ b/config/ci_configs/amip_component_dts.yml
@@ -6,7 +6,7 @@ dt_land: "50secs"
 dt_ocean: "30secs"
 dt_rad: "1hours"
 dt_save_to_sol: "1days"
-dt_seaice: "75secs"
+dt_seaice: "37.5secs"
 dz_bottom: 30
 dz_top: 3000
 energy_check: false

--- a/config/ci_configs/amip_default.yml
+++ b/config/ci_configs/amip_default.yml
@@ -16,3 +16,4 @@ t_end: "300secs"
 vert_diff: "true"
 z_elem: 50
 z_stretch: false
+use_itime: true

--- a/docs/src/timemanager.md
+++ b/docs/src/timemanager.md
@@ -12,3 +12,17 @@ ClimaCoupler.TimeManager.strdate_to_datetime
 ClimaCoupler.TimeManager.datetime_to_strdate
 ClimaCoupler.TimeManager.maybe_trigger_callback
 ```
+
+## ITime
+
+`ITime`, or _integer time_, is a time type used by CliMA simulations to keep
+track of simulation time. For more information, refer to the
+[TimeManager section](https://clima.github.io/ClimaUtilities.jl/dev/timemanager/)
+in ClimaUtilities and the [ITime section](https://clima.github.io/ClimaAtmos.jl/dev/itime/)
+in ClimaAtmos.
+
+### How do I use ITime?
+
+If you are running a simulation from a YAML file, you can simply set `use_itime`
+to true to enable `ITime`. If you do not want to use `ITime` and want to use
+floating point numbers, then set `use_itime` to false to not use `ITime`.

--- a/experiments/ClimaCore/sea_breeze/run.jl
+++ b/experiments/ClimaCore/sea_breeze/run.jl
@@ -117,7 +117,7 @@ system before executing the simulation.
 
 t_start, t_end = (0.0, 1e4)
 Δt_coupled = 0.1
-saveat = t_start:10.0:t_end
+saveat = collect(t_start:10.0:t_end)
 atm_nsteps, ocn_nsteps, lnd_nsteps = (5, 1, 1)
 
 ## Initialize Models

--- a/experiments/ClimaEarth/cli_options.jl
+++ b/experiments/ClimaEarth/cli_options.jl
@@ -159,6 +159,10 @@ function argparse_settings()
         help = "Boolean flag indicating whether to compute and output land model diagnostics [`true` (default), `false`]"
         arg_type = Bool
         default = true
+        "--use_itime"
+        help = "Boolean flag indicating whether to use ITime (integer time) or not (will use Float64) [`true` (default), `false`]"
+        arg_type = Bool
+        default = true
     end
     return s
 end

--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -49,23 +49,23 @@ Initializes the bucket model variables.
 """
 function BucketSimulation(
     ::Type{FT},
-    tspan::Tuple{Float64, Float64},
+    tspan::Tuple{TT, TT},
     config::String,
     albedo_type::String,
     land_initial_condition::String,
     land_temperature_anomaly::String,
     output_dir::String;
     space,
-    dt::Float64,
-    saveat::Vector{Float64},
+    dt::TT,
+    saveat::Vector{TT},
     area_fraction,
     stepper = CTS.RK4(),
     date_ref::Dates.DateTime,
-    t_start::Float64,
+    t_start::TT,
     energy_check::Bool,
     surface_elevation,
     use_land_diagnostics::Bool,
-) where {FT}
+) where {FT, TT <: Union{Float64, ITime}}
     if config != "sphere"
         println(
             "Currently only spherical shell domains are supported; single column set-up will be addressed in future PR.",
@@ -102,7 +102,7 @@ function BucketSimulation(
     d_soil = FT(3.5) # soil depth
     z_0m = FT(1e-3) # roughness length for momentum over smooth bare soil
     z_0b = FT(1e-3) # roughness length for tracers over smooth bare soil
-    τc = FT(dt) # This is the timescale on which snow exponentially damps to zero, in the case where all
+    τc = FT(float(dt)) # This is the timescale on which snow exponentially damps to zero, in the case where all
     # the snow would melt in time `τc`. It prevents us from having to specially time step in cases where
     # all the snow melts in a single timestep.
     σS_c = FT(0.2) # critical snow water equivalent

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -91,9 +91,13 @@ function SlabOceanSimulation(
     ode_algo = CTS.ExplicitAlgorithm(stepper)
     ode_function =
         CTS.ClimaODEFunction(; T_exp! = slab_ocean_rhs!, dss! = (Y, p, t) -> CC.Spaces.weighted_dss!(Y, p.dss_buffer))
-
-    problem = SciMLBase.ODEProblem(ode_function, Y, Float64.(tspan), cache)
-    integrator = SciMLBase.init(problem, ode_algo, dt = Float64(dt), saveat = Float64.(saveat), adaptive = false)
+    if typeof(dt) isa Number
+        dt = Float64(dt)
+        tspan = Float64.(tspan)
+        saveat = Float64.(saveat)
+    end
+    problem = SciMLBase.ODEProblem(ode_function, Y, tspan, cache)
+    integrator = SciMLBase.init(problem, ode_algo, dt = dt, saveat = saveat, adaptive = false)
 
     sim = SlabOceanSimulation(params, space, integrator)
 

--- a/experiments/ClimaEarth/run_moist_held_suarez.jl
+++ b/experiments/ClimaEarth/run_moist_held_suarez.jl
@@ -31,6 +31,7 @@ import ClimaCoupler:
 
 # TODO: Move to ClimaUtilities once we move the Schedules to ClimaUtilities
 import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule
+import ClimaUtilities.TimeManager: ITime
 
 pkg_dir = pkgdir(ClimaCoupler)
 
@@ -64,6 +65,13 @@ restart_t = Int(0)
 t_end = "1000days"
 tspan = (Float64(0.0), Float64(Utilities.time_to_seconds(t_end)))
 start_date = "19790301"
+use_itime = true
+if use_itime
+    tspan = (
+        ITime(0.0, epoch = Dates.DateTime(1979, 3, 1)),
+        ITime(Utilities.time_to_seconds(t_end), epoch = Dates.DateTime(1979, 3, 1)),
+    )
+end
 checkpoint_dt = "480hours"
 
 #=
@@ -122,8 +130,15 @@ config_dict = Dict(
     "moist" => "equil",
     "prognostic_surface" => "PrescribedSurfaceTemperature",
     "turb_flux_partition" => "CombinedStateFluxesMOST",
+    "use_itime" => use_itime,
 )
 # TODO: may need to switch to Bulk fluxes
+
+## Convert Δt_cpl and tspan to ITime
+if use_itime
+    Δt_cpl, t0, tf = promote(ITime(Δt_cpl), tspan[1], tspan[2])
+    tspan = (t0, tf)
+end
 
 ## merge dictionaries of command line arguments, coupler dictionary and component model dictionaries
 atmos_output_dir = joinpath(dir_paths.output, "clima_atmos")

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -44,6 +44,7 @@ import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput, evaluate!
 import ClimaUtilities.Utils: period_to_seconds_float
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
+import ClimaUtilities.TimeManager: ITime
 import Interpolations # triggers InterpolationsExt in ClimaUtilities
 # Random is used by RRMTGP for some cloud properties
 import Random

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -49,6 +49,7 @@ function get_coupler_args(config_dict::Dict)
     job_id = config_dict["job_id"]
     mode_name = config_dict["mode_name"]
     sim_mode = mode_name_dict[mode_name]
+    use_itime = config_dict["use_itime"]
 
     # Computational simulation setup information
     random_seed = config_dict["unique_seed"] ? time_ns() : 1234
@@ -60,9 +61,20 @@ function get_coupler_args(config_dict::Dict)
     date0 = date = Dates.DateTime(config_dict["start_date"], Dates.dateformat"yyyymmdd")
     Δt_cpl = Float64(Utilities.time_to_seconds(config_dict["dt_cpl"]))
     saveat = Float64(Utilities.time_to_seconds(config_dict["dt_save_to_sol"]))
-    saveat = [t_start:saveat:t_end..., t_end]
-    component_dt_dict = config_dict["component_dt_dict"]
-
+    saveat = promote(t_start:saveat:t_end..., t_end)
+    if use_itime
+        t_end = ITime(t_end, epoch = date0)
+        t_start = ITime(t_start, epoch = date0)
+        Δt_cpl = ITime(Δt_cpl, epoch = date0)
+        times = promote(t_end, t_start, Δt_cpl, ITime.(values(config_dict["component_dt_dict"]))...)
+        t_end, t_start, Δt_cpl = (times[1], times[2], times[3])
+        saveat = ITime(Float64(Utilities.time_to_seconds(config_dict["dt_save_to_sol"])))
+        saveat = [promote([t_start:saveat:t_end..., t_end]...)...]
+        component_dt_dict =
+            Dict(component => first(promote(ITime(dt), t_end)) for (component, dt) in config_dict["component_dt_dict"])
+    else
+        component_dt_dict = config_dict["component_dt_dict"]
+    end
     # Checkpointing information
     checkpoint_dt = config_dict["checkpoint_dt"]
 
@@ -167,7 +179,7 @@ The default periods are:
 - `calendar_dt`: A DateTime interval representing the period
 """
 function get_diag_period(t_start, t_end)
-    sim_duration = t_end - t_start
+    sim_duration = float(t_end - t_start)
     secs_per_day = 86400
     if sim_duration >= 90 * secs_per_day
         # if duration >= 90 days, take monthly means
@@ -211,7 +223,7 @@ function parse_component_dts!(config_dict)
 
     # Specify component model names
     component_dt_names = ["dt_atmos", "dt_land", "dt_ocean", "dt_seaice"]
-    component_dt_dict = Dict{String, Float64}()
+    component_dt_dict = Dict{String, typeof(Δt_cpl)}()
     # check if all component dt's are specified
     if all(key -> !isnothing(config_dict[key]), component_dt_names)
         # when all component dt's are specified, ignore the dt field

--- a/experiments/ClimaEarth/user_io/debug_plots.jl
+++ b/experiments/ClimaEarth/user_io/debug_plots.jl
@@ -32,7 +32,7 @@ function plot_global_conservation(
     model_sims = coupler_sim.model_sims
     ccs = cc.sums
 
-    days = collect(1:length(ccs[1])) * coupler_sim.Δt_cpl / 86400
+    days = collect(1:length(ccs[1])) * float(coupler_sim.Δt_cpl) / 86400
 
     # evolution of energy of each component relative to initial value
     total = ccs.total  # total

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -13,6 +13,7 @@ conservation checks if enabled, and closing all diagnostics file writers.
 """
 function postprocess_sim(cs, postprocessing_vars)
     (; output_default_diagnostics, t_end, conservation_softfail) = postprocessing_vars
+    t_end = float(t_end)
     output_dir = cs.dirs.output
     artifact_dir = cs.dirs.artifacts
     coupler_output_dir = joinpath(output_dir, "coupler")

--- a/src/ConservationChecker.jl
+++ b/src/ConservationChecker.jl
@@ -90,10 +90,10 @@ function check_conservation!(
             parent(radiative_energy_flux_toa) .= parent(Interfacer.get_field(sim, Val(:radiative_energy_flux_toa)))
 
             if isempty(ccs.toa_net_source)
-                radiation_sources_accum = sum(radiative_energy_flux_toa .* FT(coupler_sim.Δt_cpl)) # ∫ J / m^2 dA
+                radiation_sources_accum = sum(radiative_energy_flux_toa .* FT(float(coupler_sim.Δt_cpl))) # ∫ J / m^2 dA
             else
                 radiation_sources_accum =
-                    sum(radiative_energy_flux_toa .* FT(coupler_sim.Δt_cpl)) .+ ccs.toa_net_source[end] # ∫ J / m^2 dA
+                    sum(radiative_energy_flux_toa .* FT(float(coupler_sim.Δt_cpl))) .+ ccs.toa_net_source[end] # ∫ J / m^2 dA
             end
             push!(ccs.toa_net_source, radiation_sources_accum)
 
@@ -203,7 +203,7 @@ function surface_water_gain_from_rates(cs::Interfacer.CoupledSimulation)
     precipitation_l = cs.fields.P_liq
     precipitation_s = cs.fields.P_snow
     FT = eltype(evaporation)
-    @. -(evaporation + precipitation_l + precipitation_s) * FT(cs.Δt_cpl) # kg / m^2 / layer depth
+    @. -(evaporation + precipitation_l + precipitation_s) * FT(float(cs.Δt_cpl)) # kg / m^2 / layer depth
 end
 
 end # module

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -52,7 +52,7 @@ struct CoupledSimulation{
     FV,
     E,
     TS,
-    DTI <: Real,
+    DTI,
     NTMS <: NamedTuple,
     NTC <: NamedTuple,
     NTP <: NamedTuple,

--- a/src/TimeManager.jl
+++ b/src/TimeManager.jl
@@ -12,6 +12,7 @@ import ..Utilities: time_to_seconds
 
 export current_date, strdate_to_datetime, datetime_to_strdate
 
+import ClimaUtilities.TimeManager: ITime, date
 
 """
     current_date(cs::Interfacer.CoupledSimulation, t::Int)
@@ -23,6 +24,17 @@ Return the model date at the current timestep.
 - `t`: [Real] number of seconds since simulation began
 """
 current_date(cs::Interfacer.CoupledSimulation, t::Real) = cs.dates.date0[1] + Dates.Second(t)
+
+"""
+    current_date(cs::Interfacer.CoupledSimulation, t::ITime)
+
+Return the model date at the current timestep.
+
+# Arguments
+- `cs`: [CoupledSimulation] containing info about the simulation
+- `t`: [ITime] containing all the information needed to produce a date
+"""
+current_date(cs::Interfacer.CoupledSimulation, t::ITime) = date(t)
 
 """
     strdate_to_datetime(strdate::String)

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -100,7 +100,7 @@ for FT in (Float32, Float64)
         # set non-zero radiation and precipitation
         F_r = cf.radiative_energy_flux_toa
         P = cf.P_liq
-        Δt = cs.Δt_cpl
+        Δt = float(cs.Δt_cpl)
 
         # analytical solution
         tot_energy_an = sum(FT.(F_r .* 3Δt .+ 1e6 .* 1.25))


### PR DESCRIPTION
## Purpose 
This PR adds `ITime` which is needed to do long run without floating point errors in time.

## To-do
- [x] Verify that the first few steps of a long run does not fail (see this [buildkite](https://buildkite.com/clima/climacoupler-longruns/builds/835#_))

One thing to note is that depending on the `dt` passed, it automatically defaults to the reasonable value for the period. This means that if `dt` is 120 seconds (as seen [here](https://buildkite.com/clima/climacoupler-longruns/builds/835#0195011d-c12a-4fdf-9518-e44f82e1334a)), then the period defaults to one minute which may or may not be desirable. This is not specific to ClimaCoupler, but also affects ClimaAtmos as well.