### PR TITLE
remove extraneous field exchanges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,13 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
-### Coupler fields surface variable names all use `_sfc` PR[#1195](https://github.com/CliMA/ClimaCoupler.jl/pull/1195)
+#### Remove extra `get_field` functions PR[#1203](https://github.com/CliMA/ClimaCoupler.jl/pull/1203)
+Removes the `get_field` functions for `air_density` for all models, which
+were unused except for the `BucketSimulation` method, which is replaced by a
+function call to `extrapolate_ρ_to_sfc`. Also removes the `get_field` function
+for `ClimaAtmosSimulation` `air_temperature`, which was unused.
+
+#### Coupler fields surface variable names all use `_sfc` PR[#1195](https://github.com/CliMA/ClimaCoupler.jl/pull/1195)
 `T_S`, `z0m_S`, and `z0b_S` are renamed to `T_sfc`, `z0m_sfc`, and `z0b_sfc`.
 This makes them consistent with the other surface fields, e.g. `ρ_sfc` and `q_sfc`.
 

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -73,7 +73,6 @@ for the following properties:
 | Coupler name      | Description | Units |
 |-------------------|-------------|-------|
 | `air_density`       | air density of the atmosphere | kg m^-3 |
-| `air_temperature`   | air temperature at the surface of the atmosphere | K |
 | `energy`            | globally integrated energy | J |
 | `height_int`        | height at the first internal model level | m |
 | `height_sfc`        | height at the surface (only required when using `PartitionedStateFluxes`) | m |
@@ -120,7 +119,6 @@ for the following properties:
 
 | Coupler name      | Description | Units |
 |-------------------|-------------|-------|
-| `air_density`       | surface air density | kg m^-3 |
 | `area_fraction`     | fraction of the simulation grid surface area this model covers | |
 | `beta`              | factor that scales evaporation based on its estimated level of saturation | |
 | `roughness_buoyancy` | aerodynamic roughness length for buoyancy | m |
@@ -170,7 +168,6 @@ which is extended by `SurfaceStub`
 in the `surface_stub.jl` file, with
 the cache variables specified as:
 ```
-get_field(sim::AbstractSurfaceStub, ::Val{:air_density}) = sim.cache.ρ_sfc
 get_field(sim::AbstractSurfaceStub, ::Val{:area_fraction}) = sim.cache.area_fraction
 get_field(sim::AbstractSurfaceStub, ::Val{:beta}) = sim.cache.beta
 get_field(sim::AbstractSurfaceStub, ::Val{:energy}) = nothing

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -170,10 +170,6 @@ moisture_flux(::Union{CA.EquilMoistModel, CA.NonEquilMoistModel}, integrator) =
 ρq_tot(::Union{CA.EquilMoistModel, CA.NonEquilMoistModel}, integrator) = integrator.u.c.ρq_tot
 
 # extensions required by the Interfacer
-Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:air_density}) =
-    TD.air_density.(thermo_params, sim.integrator.p.precomputed.ᶜts)
-Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:air_temperature}) =
-    TD.air_temperature.(thermo_params, sim.integrator.p.precomputed.ᶜts)
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:liquid_precipitation}) =
     surface_rain_flux(sim.integrator.p.atmos.moisture_model, sim.integrator)
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:radiative_energy_flux_sfc}) =

--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -229,7 +229,6 @@ function BucketSimulation(
 end
 
 # extensions required by Interfacer
-Interfacer.get_field(sim::BucketSimulation, ::Val{:air_density}) = sim.integrator.p.bucket.ρ_sfc
 Interfacer.get_field(sim::BucketSimulation, ::Val{:area_fraction}) = sim.area_fraction
 Interfacer.get_field(sim::BucketSimulation, ::Val{:beta}) =
     CL.surface_evaporative_scaling(sim.model, sim.integrator.u, sim.integrator.p)
@@ -323,7 +322,7 @@ function FluxCalculator.surface_thermo_state(
     # Note that the surface air density, ρ_sfc, is computed using the atmospheric state at the first level and making ideal gas
     # and hydrostatic balance assumptions. The land model does not compute the surface air density so this is
     # a reasonable stand-in.
-    ρ_sfc = Interfacer.get_field(sim, Val(:air_density))
+    ρ_sfc = FluxCalculator.extrapolate_ρ_to_sfc.(thermo_params, thermo_state_int, T_sfc) # ideally the # calculate elsewhere, here just getter...
     q_sfc = Interfacer.get_field(sim, Val(:surface_humidity)) # already calculated in rhs! (cache)
     @. TD.PhaseEquil_ρTq.(thermo_params, ρ_sfc, T_sfc, q_sfc)
 end

--- a/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
@@ -92,7 +92,6 @@ function EisenmanIceSimulation(
 end
 
 # extensions required by Interfacer
-Interfacer.get_field(sim::EisenmanIceSimulation, ::Val{:air_density}) = sim.integrator.p.Ya.ρ_sfc
 Interfacer.get_field(sim::EisenmanIceSimulation, ::Val{:area_fraction}) = sim.integrator.p.area_fraction
 Interfacer.get_field(sim::EisenmanIceSimulation, ::Val{:beta}) = convert(eltype(sim.integrator.u), 1.0)
 Interfacer.get_field(sim::EisenmanIceSimulation, ::Val{:roughness_buoyancy}) =

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -154,7 +154,6 @@ function PrescribedIceSimulation(
 end
 
 # extensions required by Interfacer
-Interfacer.get_field(sim::PrescribedIceSimulation, ::Val{:air_density}) = sim.integrator.p.ρ_sfc
 Interfacer.get_field(sim::PrescribedIceSimulation, ::Val{:area_fraction}) = sim.integrator.p.area_fraction
 Interfacer.get_field(sim::PrescribedIceSimulation, ::Val{:beta}) = convert(eltype(sim.integrator.u), 1.0)
 Interfacer.get_field(sim::PrescribedIceSimulation, ::Val{:roughness_buoyancy}) = sim.integrator.p.params.z0b

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -107,7 +107,6 @@ function SlabOceanSimulation(
 end
 
 # extensions required by Interfacer
-Interfacer.get_field(sim::SlabOceanSimulation, ::Val{:air_density}) = sim.integrator.p.ρ_sfc
 Interfacer.get_field(sim::SlabOceanSimulation, ::Val{:area_fraction}) = sim.integrator.p.area_fraction
 Interfacer.get_field(sim::SlabOceanSimulation, ::Val{:beta}) = convert(eltype(sim.integrator.u), 1.0)
 Interfacer.get_field(sim::SlabOceanSimulation, ::Val{:roughness_buoyancy}) = sim.integrator.p.params.z0b

--- a/experiments/ClimaEarth/test/component_model_tests/prescr_ocean_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/prescr_ocean_tests.jl
@@ -63,7 +63,6 @@ end
     @test !isnothing(sim.cache.SST_timevaryinginput)
 
     # Test `Interfacer.get_field` function
-    @test Interfacer.get_field(sim, Val(:air_density)) == sim.cache.ρ_sfc
     @test Interfacer.get_field(sim, Val(:area_fraction)) == sim.cache.area_fraction
     @test Interfacer.get_field(sim, Val(:beta)) == sim.cache.beta
     @test Interfacer.get_field(sim, Val(:roughness_buoyancy)) == sim.cache.z0b

--- a/experiments/ClimaEarth/user_io/debug_plots.jl
+++ b/experiments/ClimaEarth/user_io/debug_plots.jl
@@ -230,8 +230,7 @@ Interfacer.get_field(sim::BucketSimulation, ::Val{:W}) = sim.integrator.u.bucket
 
 # currently selected plot fields
 plot_field_names(sim::Interfacer.SurfaceModelSimulation) = (:area_fraction, :surface_temperature, :surface_humidity)
-plot_field_names(sim::BucketSimulation) =
-    (:area_fraction, :surface_temperature, :surface_humidity, :air_density, :σS, :Ws, :W)
+plot_field_names(sim::BucketSimulation) = (:area_fraction, :surface_temperature, :surface_humidity, :σS, :Ws, :W)
 plot_field_names(sim::ClimaAtmosSimulation) = (:w, :ρq_tot, :ρe_tot, :liquid_precipitation, :snow_precipitation)
 
 

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -119,8 +119,6 @@ an atmosphere component model.
 get_field(
     sim::AtmosModelSimulation,
     val::Union{
-        Val{:air_density},
-        Val{:air_temperature},
         Val{:energy},
         Val{:height_int},
         Val{:height_sfc},
@@ -146,7 +144,6 @@ a surface component model.
 get_field(
     sim::SurfaceModelSimulation,
     val::Union{
-        Val{:air_density},
         Val{:area_fraction},
         Val{:beta},
         Val{:roughness_buoyancy},

--- a/src/surface_stub.jl
+++ b/src/surface_stub.jl
@@ -33,7 +33,6 @@ end
 
 A getter function, that should not allocate. If undefined, it returns a descriptive error.
 """
-get_field(sim::AbstractSurfaceStub, ::Val{:air_density}) = sim.cache.ρ_sfc
 get_field(sim::AbstractSurfaceStub, ::Val{:area_fraction}) = sim.cache.area_fraction
 get_field(sim::AbstractSurfaceStub, ::Val{:beta}) = sim.cache.beta
 get_field(sim::AbstractSurfaceStub, ::Val{:energy}) = nothing

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -40,8 +40,6 @@ Interfacer.get_field(sim::TestAtmos, ::Val{:height_sfc}) = sim.integrator.p.z_sf
 Interfacer.get_field(sim::TestAtmos, ::Val{:uv_int}) = @. StaticArrays.SVector(sim.integrator.p.u, sim.integrator.p.v)
 Interfacer.get_field(sim::TestAtmos, ::Val{:thermo_state_int}) =
     TD.PhaseEquil_ρTq.(get_thermo_params(sim), sim.integrator.ρ, sim.integrator.T, sim.integrator.q)
-Interfacer.get_field(sim::TestAtmos, ::Val{:air_density}) = sim.integrator.ρ
-Interfacer.get_field(sim::TestAtmos, ::Val{:air_temperature}) = sim.integrator.T
 
 function FieldExchanger.update_sim!(sim::TestAtmos, fields, _)
     (; F_turb_ρτxz, F_turb_energy, F_turb_moisture) = fields
@@ -237,7 +235,7 @@ for FT in (Float32, Float64)
 
             # analytical solution is possible for the BulkScheme() case
             if scheme isa FluxCalculator.BulkScheme
-                ρ_sfc = Interfacer.get_field(atmos_sim, Val(:air_density))
+                ρ_sfc = TD.air_density.(thermo_params, thermo_state_int)
                 cpm = TD.cv_m.(thermo_params, thermo_state_int) .+ TD.gas_constant_air.(thermo_params, thermo_state_int) # cp = R + cv
                 gz =
                     (

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -84,7 +84,6 @@ for FT in (Float32, Float64)
         @test Interfacer.get_field(stub, Val(:roughness_momentum)) == 4
         @test Interfacer.get_field(stub, Val(:roughness_buoyancy)) == 5
         @test Interfacer.get_field(stub, Val(:beta)) == 6
-        @test Interfacer.get_field(stub, Val(:air_density)) == FT(1)
         @test ≈(Interfacer.get_field(stub, Val(:surface_humidity))[1], FT(0.0076), atol = FT(1e-4))
     end
 
@@ -133,7 +132,6 @@ end
 
     # Test that get_field gives correct warnings for unextended fields
     for value in (
-        :air_density,
         :area_fraction,
         :beta,
         :roughness_buoyancy,
@@ -158,8 +156,6 @@ end
 
     # Test that get_field gives correct warnings for unextended fields
     for value in (
-        :air_density,
-        :air_temperature,
         :energy,
         :height_int,
         :height_sfc,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We've had some functions defined to exchange air density between components, presumably for turbulent flux calculations. Going through the code, I realized that the only surface model we retrieved air density from was the bucket surface models. This value is set via a call to `extrapolate_\rho_to_sfc`, so I just called that function directly and removed the bucket `get_field(bucket_sim, :air_density)` function.

We also had a function `get_field(atmos_sim, :air_density)`, but never used this either. Instead we use the function `calculate_surface_air_density` to compute the air density given the surface temperature, and use this to update coupler fields and surface models.

We keep the functions `update_field!(sim, :air_density, field)` for surface models since some (but not all) of them need this for RHS calculations.

Buildkite outputs visually look the same between this PR and main.

## Content
- remove surface models `get_field(sim, :air_density)` function
  - only the BucketModel function was used
  - compute it as needed using `FluxCalculator.extrapolate_ρ_to_sfc` instead
- remove atmosphere `get_field(sim, :air_density)` function
  - this was unused
  - `FluxCalculator.calculate_surface_air_density` extended for ClimaAtmos is used instead
- remove atmosphere `get_field(sim, :air_temperature)` function
  - this was unused