### PR TITLE
Fix CTS version in calibration environment

### DIFF
--- a/experiments/calibration/Project.toml
+++ b/experiments/calibration/Project.toml
@@ -31,4 +31,4 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 ClimaCalibrate = "0.0.10"
-ClimaTimeSteppers = "=0.8.1"
+ClimaTimeSteppers = "0.8.2"


### PR DESCRIPTION
This small PR should fix the broken calibration test in the [longrun pipeline ](https://buildkite.com/clima/climacoupler-longruns/builds/839#019531d3-1c09-4b31-adf6-963c0bd5044e).