### PR TITLE
Add optional `toml_files` kwarg to the `BucketSimulation` func

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Add support for parameter files in `BucketSimulation` PR[#1217](https://github.com/CliMA/ClimaCoupler.jl/pull/1217)
+Add a keyword argument `parameter_files` to `BucketSimulation` to enable
+calibration in a coupled simulation, passed via the `"coupler_toml"` argument.
+
 #### Add `ClimaLandSimulation` object PR[#1199](https://github.com/CliMA/ClimaCoupler.jl/pull/1199)
 Add methods to support running `ClimaLand.LandModel` in a coupled simulation.
 Also add tests to verify the constructor setup and taking a step.

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -427,12 +427,9 @@ function get_atmos_config_dict(coupler_dict::Dict, job_id::String, atmos_output_
     atmos_toml = joinpath.(pkgdir(CA), atmos_config["toml"])
     coupler_toml = joinpath.(pkgdir(ClimaCoupler), coupler_dict["coupler_toml"])
     toml = isempty(coupler_toml) ? atmos_toml : coupler_toml
-    if haskey(atmos_config, "calibration_toml")
-        push!(toml, atmos_config["calibration_toml"])
-    end
     if !isempty(toml)
         @info "Overwriting Atmos parameters from input TOML file(s): $toml"
-        atmos_config = merge(atmos_config, Dict("toml" => toml))
+        atmos_config["toml"] = toml
     end
 
     # Specify atmos output directory to be inside the coupler output directory

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -200,6 +200,7 @@ function setup_and_run(config_dict::AbstractDict)
         energy_check,
         conservation_softfail,
         output_dir_root,
+        parameter_files,
     ) = get_coupler_args(config_dict)
 
     #=
@@ -341,6 +342,7 @@ function setup_and_run(config_dict::AbstractDict)
             albedo_type = land_albedo_type,
             land_initial_condition,
             energy_check,
+            parameter_files,
         )
 
         ## sea ice model
@@ -387,6 +389,7 @@ function setup_and_run(config_dict::AbstractDict)
             albedo_type = land_albedo_type,
             land_initial_condition,
             energy_check,
+            parameter_files,
         )
 
         ## ocean model
@@ -435,6 +438,7 @@ function setup_and_run(config_dict::AbstractDict)
             albedo_type = land_albedo_type,
             land_initial_condition,
             energy_check,
+            parameter_files,
         )
 
         ## ocean stub (here set to zero area coverage)

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -58,6 +58,9 @@ function get_coupler_args(config_dict::Dict)
     random_seed = config_dict["unique_seed"] ? time_ns() : 1234
     FT = config_dict["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
 
+    # Vector of TOML files containing model parameters
+    parameter_files = config_dict["coupler_toml"]
+
     # Time information
     t_end = Float64(Utilities.time_to_seconds(config_dict["t_end"]))
     t_start = Float64(Utilities.time_to_seconds(config_dict["t_start"]))
@@ -140,6 +143,7 @@ function get_coupler_args(config_dict::Dict)
         land_initial_condition,
         land_temperature_anomaly,
         use_land_diagnostics,
+        parameter_files,
     )
 end
 
@@ -157,7 +161,6 @@ Extract the necessary arguments from the atmosphere configuration dictionary.
 function get_atmos_args(atmos_config_dict)
     dt_rad = atmos_config_dict["dt_rad"]
     output_default_diagnostics = atmos_config_dict["output_default_diagnostics"]
-
     return (; dt_rad, output_default_diagnostics)
 end
 


### PR DESCRIPTION
This PR adds a `parameter_files` optional keyword argument to `BucketSimulation`. If `toml_files` is not empty, it will be used to construct the `BucketModelParameters`. If it is empty, behavior is unchanged.

`get_coupler_args` now returns `parameter_files` in its tuple, passing it to `BucketSimulation` in `setup_and_run`.

These changes will allow us to pass a calibration parameter file to the `BucketSimulation` in order to calibrate bucket parameters. Closes #1216 