### PR TITLE
Update climacommon to 2025_03_18

### DIFF
--- a/.buildkite/amip/pipeline.yml
+++ b/.buildkite/amip/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 96:00:00
-  modules: climacommon/2025_01_27
+  modules: climacommon/2025_03_18
 
 env:
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100

--- a/.buildkite/benchmarks/pipeline.yml
+++ b/.buildkite/benchmarks/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 24:00:00
-  modules: climacommon/2025_01_27
+  modules: climacommon/2025_03_18
 
 env:
   JULIA_NVTX_CALLBACKS: gc

--- a/.buildkite/hierarchies/pipeline.yml
+++ b/.buildkite/hierarchies/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_time: 24:00:00
-  modules: climacommon/2025_01_27
+  modules: climacommon/2025_03_18
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
@@ -30,7 +30,7 @@ steps:
 
     agents:
       queue: clima
-      modules: climacommon/2025_01_27
+      modules: climacommon/2025_03_18
     env:
       JULIA_NUM_PRECOMPILE_TASKS: 8
       JULIA_MAX_NUM_PRECOMPILE_FILES: 50
@@ -52,7 +52,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2025_01_27
+          modules: climacommon/2025_03_18
 
       - label: "Clima: GPU ClimaCoupler moist HS"
         command:
@@ -64,7 +64,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2025_01_27
+          modules: climacommon/2025_03_18
 
       - label: "Clima: GPU ClimaCoupler Cloudless Aquaplanet"
         command:
@@ -76,7 +76,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2025_01_27
+          modules: climacommon/2025_03_18
 
       - label: "Clima: GPU ClimaCoupler Cloudy Aquaplanet"
         command:
@@ -88,7 +88,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2025_01_27
+          modules: climacommon/2025_03_18
 
       - label: "Clima: GPU ClimaCoupler Cloudy Slabplanet"
         command:
@@ -100,4 +100,4 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2025_01_27
+          modules: climacommon/2025_03_18

--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_time: 24:00:00
-  modules: climacommon/2025_01_27
+  modules: climacommon/2025_03_18
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
@@ -48,7 +48,7 @@ steps:
       - "julia --project=experiments/calibration/ -e 'using Pkg; Pkg.instantiate(;verbose=true); Pkg.develop(;path=\".\")'"
     agents:
       queue: clima
-      modules: climacommon/2025_01_27
+      modules: climacommon/2025_03_18
     env:
       JULIA_NUM_PRECOMPILE_TASKS: 8
       JULIA_MAX_NUM_PRECOMPILE_FILES: 50
@@ -298,7 +298,7 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 30GB
-          modules: climacommon/2025_01_27
+          modules: climacommon/2025_03_18
         soft_fail: true
 
   # DYAMOND AMIP: 1 day (convection resolving)
@@ -314,7 +314,7 @@ steps:
       queue: clima
       slurm_mem: 20GB
       slurm_gpus: 1
-      modules: climacommon/2025_01_27
+      modules: climacommon/2025_03_18
     soft_fail: true
 
   - label: "Perfect model calibration test"
@@ -332,7 +332,7 @@ steps:
       slurm_gpus_per_task: 1
       slurm_cpus_per_task: 4
       slurm_time: 05:00:00
-      modules: climacommon/2025_01_27
+      modules: climacommon/2025_03_18
 
   - wait
 

--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 14:00:00
-  modules: climacommon/2025_01_27
+  modules: climacommon/2025_03_18
 
 env:
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_time: 4:00:00
-  modules: climacommon/2025_01_27
+  modules: climacommon/2025_03_18
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖

I received an update so that I can inform you directly of the changes (but feel free to check the [release notes](https://github.com/CliMA/ClimaModules/blob/main/NEWS.md)).

The most recent version of climacommon uses the newly released Julia 1.11.4.

This version is needed to use CUDA 5.7, so I would recommend updating.