### PR TITLE
Fix modification of parameter filepaths

### DIFF
--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -44,6 +44,13 @@ This function may modify the input dictionary to remove unnecessary keys.
 - All arguments needed for the coupled simulation
 """
 function get_coupler_args(config_dict::Dict)
+    # Vector of TOML files containing model parameters
+    # We need to modify this Dict entry to be consistent with ClimaAtmos TOML files
+    config_dict["coupler_toml"] = map(config_dict["coupler_toml"]) do file
+        isfile(file) ? file : joinpath(pkgdir(ClimaCoupler), file)
+    end
+    parameter_files = config_dict["coupler_toml"]
+
     # Make a copy so that we don't modify the original input
     config_dict = copy(config_dict)
 
@@ -57,11 +64,6 @@ function get_coupler_args(config_dict::Dict)
     # Computational simulation setup information
     random_seed = config_dict["unique_seed"] ? time_ns() : 1234
     FT = config_dict["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
-
-    # Vector of TOML files containing model parameters
-    parameter_files = map(config_dict["coupler_toml"]) do file
-        isfile(file) ? file : joinpath(pkgdir(ClimaCoupler), file)
-    end
 
     # Time information
     t_end = Float64(Utilities.time_to_seconds(config_dict["t_end"]))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
The previous PR #1228 did not modify `config_dict["coupler_toml"]`, passing the incorrect filepath(s) to ClimaAtmos. This PR updates `coupler_toml` and returns `parameter_files`, ensuring that atmos and land get the same filepaths.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
