### PR TITLE
Fix: Close file after restoring model cache

### DIFF
--- a/src/Checkpointer.jl
+++ b/src/Checkpointer.jl
@@ -160,7 +160,9 @@ the component models that have a cache.
 function restart_model_cache!(sim, input_file)
     ispath(input_file) || error("File $(input_file) not found")
     # Component models are responsible for defining a method for this
-    restore_cache!(sim, JLD2.jldopen(input_file)["cache"])
+    JLD2.jldopen(input_file) do file
+        restore_cache!(sim, file["cache"])
+    end
 end
 
 """


### PR DESCRIPTION
## Purpose 

Closes #1236


## Content

Explicitly calls `close(file)` after the model cache is restored to avoid IOErrors.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
