### PR TITLE
fix coupler field initialization

### DIFF
--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -317,11 +317,9 @@ Extend Interfacer.add_coupler_fields! to add the fields required for BucketSimul
 The fields added are:
 - `:ρ_sfc`
 - `:F_radiative` (for radiation input)
-- `:P_liq` (for precipitation input)
-- `:P_snow` (for precipitation input)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::BucketSimulation)
-    bucket_coupler_fields = [:ρ_sfc, :F_radiative, :P_liq, :P_snow]
+    bucket_coupler_fields = [:ρ_sfc, :F_radiative]
     push!(coupler_field_names, bucket_coupler_fields...)
 end
 

--- a/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudless_aquaplanet.jl
@@ -186,7 +186,7 @@ ocean_sim = SlabOceanSimulation(
 =#
 
 ## coupler exchange fields
-coupler_field_names = (
+coupler_field_names = [
     :T_sfc,
     :z0m_sfc,
     :z0b_sfc,
@@ -206,9 +206,8 @@ coupler_field_names = (
     :P_net,
     :temp1,
     :temp2,
-)
-coupler_fields =
-    NamedTuple{coupler_field_names}(ntuple(i -> CC.Fields.zeros(boundary_space), length(coupler_field_names)))
+]
+coupler_fields = Interfacer.init_coupler_fields(FT, coupler_field_names, boundary_space)
 Utilities.show_memory_usage()
 
 ## model simulations

--- a/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_aquaplanet.jl
@@ -205,7 +205,7 @@ ocean_sim = SlabOceanSimulation(
 =#
 
 ## coupler exchange fields
-coupler_field_names = (
+coupler_field_names = [
     :T_sfc,
     :z0m_sfc,
     :z0b_sfc,
@@ -225,9 +225,8 @@ coupler_field_names = (
     :P_net,
     :temp1,
     :temp2,
-)
-coupler_fields =
-    NamedTuple{coupler_field_names}(ntuple(i -> CC.Fields.zeros(boundary_space), length(coupler_field_names)))
+]
+coupler_fields = Interfacer.init_coupler_fields(FT, coupler_field_names, boundary_space)
 Utilities.show_memory_usage()
 
 ## model simulations

--- a/experiments/ClimaEarth/run_cloudy_slabplanet.jl
+++ b/experiments/ClimaEarth/run_cloudy_slabplanet.jl
@@ -248,7 +248,7 @@ ocean_sim = SlabOceanSimulation(
 =#
 
 ## coupler exchange fields
-coupler_field_names = (
+coupler_field_names = [
     :T_sfc,
     :z0m_sfc,
     :z0b_sfc,
@@ -268,9 +268,8 @@ coupler_field_names = (
     :P_net,
     :temp1,
     :temp2,
-)
-coupler_fields =
-    NamedTuple{coupler_field_names}(ntuple(i -> CC.Fields.zeros(boundary_space), length(coupler_field_names)))
+]
+coupler_fields = Interfacer.init_coupler_fields(FT, coupler_field_names, boundary_space)
 Utilities.show_memory_usage()
 
 ## model simulations

--- a/experiments/ClimaEarth/run_dry_held_suarez.jl
+++ b/experiments/ClimaEarth/run_dry_held_suarez.jl
@@ -156,7 +156,7 @@ end
 =#
 
 ## coupler exchange fields
-coupler_field_names = (
+coupler_field_names = [
     :T_sfc,
     :z0m_sfc,
     :z0b_sfc,
@@ -176,9 +176,8 @@ coupler_field_names = (
     :P_net,
     :temp1,
     :temp2,
-)
-coupler_fields =
-    NamedTuple{coupler_field_names}(ntuple(i -> ClimaCore.Fields.zeros(boundary_space), length(coupler_field_names)))
+]
+coupler_fields = Interfacer.init_coupler_fields(FT, coupler_field_names, boundary_space)
 
 ## model simulations
 model_sims = (atmos_sim = atmos_sim,);

--- a/experiments/ClimaEarth/run_moist_held_suarez.jl
+++ b/experiments/ClimaEarth/run_moist_held_suarez.jl
@@ -192,7 +192,7 @@ ocean_sim = Interfacer.SurfaceStub((;
 =#
 
 ## coupler exchange fields
-coupler_field_names = (
+coupler_field_names = [
     :T_sfc,
     :z0m_sfc,
     :z0b_sfc,
@@ -212,9 +212,8 @@ coupler_field_names = (
     :P_net,
     :temp1,
     :temp2,
-)
-coupler_fields =
-    NamedTuple{coupler_field_names}(ntuple(i -> CC.Fields.zeros(boundary_space), length(coupler_field_names)))
+]
+coupler_fields = Interfacer.init_coupler_fields(FT, coupler_field_names, boundary_space)
 Utilities.show_memory_usage()
 
 ## model simulations

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -102,15 +102,19 @@ float_type(::CoupledSimulation{FT}) where {FT} = FT
 Return a list of default coupler fields needed to run a simulation.
 """
 default_coupler_fields() = [
-    # fields needed for flux calculations and exchange
+    # fields needed for flux calculations
     :z0m_sfc,
     :z0b_sfc,
     :beta,
     :emissivity,
+    # fields used for flux exchange
     :F_turb_energy,
     :F_turb_moisture,
     :F_turb_ρτxz,
     :F_turb_ρτyz,
+    # fields used to track water conservation, and for water fluxes
+    :P_liq,
+    :P_snow,
     # fields used for temporary storage during calculations
     :temp1,
     :temp2,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR does 2 things:
- updates coupler field initialization for the hierarchy drivers to use `init_coupler_fields`, which is preferred to directly constructing a NamedTuple because it first removes duplicate field names
- adds liquid and snow precipitation to the default coupler fields, since I found that they're needed in every case we currently run
  - Generally, precipitation is needed either as a moisture boundary condition input to a surface model, or, if the model doesn't track water, to compute water conservation of the coupled system.