### PR TITLE
distinguish 1D and 2D coupler fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,16 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Identify coupler fields as 1D or 2D at init PR[#1243](https://github.com/CliMA/ClimaCoupler.jl/pull/1243)
+This PR updates the coupler exchange field initialization to specify whether a
+variable is 1D or 2D as it's added to the coupler fields, to avoid allocating
+and performing operations on unneeded fields. The intermediate `coupler_field_names`,
+which component models fill when extending `Interfacer.add_coupler_fields!`,
+is now a `2-Tuple` of `Vector`s rather than a single `Vector`, but `coupler_fields`
+remains a single NamedTuple.
+
 #### Add support for relative parameter filepaths PR[#1228](https://github.com/CliMA/ClimaCoupler.jl/pull/1228)
-Changed TOML parameter file handling to prepend the `pkgdir(ClimaCoupler)` 
+Changed TOML parameter file handling to prepend the `pkgdir(ClimaCoupler)`
 if no file is found at the relative filepath. Before this change, all files
 were assumed to be within the `ClimaCoupler` or `ClimaAtmos` repositories.
 

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -51,12 +51,15 @@ of SciMLBase.jl.
 - `get_model_prog_state(::ComponentModelSimulation)`: A function that
 returns the state vector of the simulation at its current state. This
 is used for checkpointing the simulation.
-- `add_coupler_fields!(coupler_field_names::Set, ::ComponentModelSimulation)`:
+- `add_coupler_fields!(coupler_field_names, ::ComponentModelSimulation)`:
 A function that adds names of quantities the coupler must exchange
 to support this component model. These will be added for each model
-in addition to the existing defaults: `z0m_sfc`, `z0b_sfc`, `beta`,
-`F_turb_energy`, `F_turb_moisture`, `F_turb_ρτxz`, `F_turb_ρτyz`,
-`temp1`, and `temp2`.
+in addition to the existing defaults: `z0m_sfc` (scalar), `z0b_sfc` (scalar),
+`beta` (scalar), `F_turb_energy`, `F_turb_moisture`, `F_turb_ρτxz`, `F_turb_ρτyz`,
+`temp1`, and `temp2`. 1D scalars should be added to the first list in the
+`coupler_field_names` tuple, and 2D fields should be added to the second
+list in `coupler_field_names`. The appropriate space will be allocated based
+on this distinction.
 
 ### ComponentModelSimulation - optional functions
 - `update_sim!(::ComponentModelSimulation, csf, turbulent_fluxes)`: A
@@ -197,9 +200,9 @@ overwritten or used as-is. These currently include the following:
 
 | Coupler name      | Description | Units | Default value |
 |-------------------|-------------|-------|---------------|
-| `beta` | factor that scales evaporation based on its estimated level of saturation | | 1 |
-| `emissivity` | measure of how much energy a surface radiates | | 1 |
-| `height_disp` | displacement height relative to the surface | m | 0 |
+| `beta` | factor that scales evaporation based on its estimated level of saturation (scalar) | | 1 |
+| `emissivity` | measure of how much energy a surface radiates (scalar) | | 1 |
+| `height_disp` | displacement height relative to the surface (scalar) | m | 0 |
 
 - `update_turbulent_fluxes!(::ComponentModelSimulation, fields::NamedTuple)`:
 This function updates the turbulent fluxes of the component model simulation

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -346,6 +346,8 @@ end
 Interfacer.reinit!(sim::ClimaAtmosSimulation) = Interfacer.reinit!(sim.integrator)
 
 """
+    Interfacer.add_coupler_fields!(coupler_field_names, ::ClimaAtmosSimulation)
+
 Extend Interfacer.add_coupler_fields! to add the fields required for ClimaAtmosSimulation.
 
 The fields added are:
@@ -356,8 +358,10 @@ The fields added are:
 - `:q_sfc` (for moisture)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::ClimaAtmosSimulation)
+    # All fields are 2D; update the list of 2D coupler field names
     atmos_coupler_fields = [:surface_direct_albedo, :surface_diffuse_albedo, :ϵ_sfc, :T_sfc, :q_sfc]
-    push!(coupler_field_names, atmos_coupler_fields...)
+    push!(coupler_field_names[2], atmos_coupler_fields...)
+    return nothing
 end
 
 function FieldExchanger.update_sim!(sim::ClimaAtmosSimulation, csf, turbulent_fluxes)

--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -312,6 +312,8 @@ Interfacer.step!(sim::BucketSimulation, t) = Interfacer.step!(sim.integrator, t 
 Interfacer.reinit!(sim::BucketSimulation) = Interfacer.reinit!(sim.integrator)
 
 """
+    Interfacer.add_coupler_fields!(coupler_field_names, ::BucketSimulation)
+
 Extend Interfacer.add_coupler_fields! to add the fields required for BucketSimulation.
 
 The fields added are:
@@ -319,8 +321,10 @@ The fields added are:
 - `:F_radiative` (for radiation input)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::BucketSimulation)
+    # All fields are 2D; update the list of 2D coupler field names
     bucket_coupler_fields = [:ρ_sfc, :F_radiative]
-    push!(coupler_field_names, bucket_coupler_fields...)
+    push!(coupler_field_names[2], bucket_coupler_fields...)
+    return nothing
 end
 
 # extensions required by FluxCalculator (partitioned fluxes)

--- a/experiments/ClimaEarth/components/land/climaland_integrated.jl
+++ b/experiments/ClimaEarth/components/land/climaland_integrated.jl
@@ -416,8 +416,8 @@ end
 function Interfacer.update_field!(::ClimaLandSimulation, ::Val{:air_humidity}, field)
     parent(sim.integrator.p.drivers.q) .= parent(field)
 end
-function Interfacer.update_field!(sim::ClimaLandSimulation, ::Val{:c_co2}, field)
-    sim.integrator.p.drivers.c_co2 .= field
+function Interfacer.update_field!(sim::ClimaLandSimulation, ::Val{:c_co2}, scalar)
+    sim.integrator.p.drivers.c_co2 = scalar
 end
 function Interfacer.update_field!(sim::ClimaLandSimulation, ::Val{:liquid_precipitation}, field)
     ρ_liq = (LP.ρ_cloud_liq(sim.model.soil.parameters.earth_param_set))
@@ -441,21 +441,27 @@ Interfacer.step!(sim::ClimaLandSimulation, t) = Interfacer.step!(sim.integrator,
 Interfacer.reinit!(sim::ClimaLandSimulation, t) = Interfacer.reinit!(sim.integrator, t)
 
 """
+    Interfacer.add_coupler_fields!(coupler_field_names, ::ClimaLandSimulation)
+
 Extend Interfacer.add_coupler_fields! to add the fields required for ClimaLandSimulation.
 
 The fields added are:
+- `:c_co2` (for photosynthesis, biogeochemistry) - scalar
 - `:SW_d` (for radiative transfer)
 - `:LW_d` (for radiative transfer)
 - `:cos_zenith_angle` (for radiative transfer)
 - `:diffuse_fraction` (for radiative transfer)
-- `:c_co2` (for photosynthesis, biogeochemistry)
 - `:P_air` (for canopy conductance)
 - `:T_air` (for canopy conductance)
 - `:q_air` (for canopy conductance)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::ClimaLandSimulation)
-    land_coupler_fields = [:SW_d, :LW_d, :cos_zenith_angle, :diffuse_fraction, :c_co2, :P_air, :T_air, :q_air]
-    push!(coupler_field_names, land_coupler_fields...)
+    land_coupler_fields_1d = [:c_co2]
+    land_coupler_fields_2d =
+        [:SW_d, :LW_d, :cos_zenith_angle, :diffuse_fraction, :P_air, :T_air, :q_air, :P_liq, :P_snow]
+    push!(coupler_field_names[1], land_coupler_fields_1d...)
+    push!(coupler_field_names[2], land_coupler_fields_2d...)
+    return nothing
 end
 
 function Checkpointer.get_model_prog_state(sim::ClimaLandSimulation)

--- a/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
@@ -158,6 +158,8 @@ Interfacer.step!(sim::EisenmanIceSimulation, t) = Interfacer.step!(sim.integrato
 Interfacer.reinit!(sim::EisenmanIceSimulation) = Interfacer.reinit!(sim.integrator)
 
 """
+    Interfacer.add_coupler_fields!(coupler_field_names, ::EisenmanIceSimulation)
+
 Extend Interfacer.add_coupler_fields! to add the fields required for EisenmanIceSimulation.
 
 The fields added are:
@@ -165,8 +167,10 @@ The fields added are:
 - `:F_radiative` (for radiation input)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::EisenmanIceSimulation)
+    # All fields are 2D; update the list of 2D coupler field names
     eisenman_coupler_fields = [:ρ_sfc, :F_radiative]
-    push!(coupler_field_names, eisenman_coupler_fields...)
+    push!(coupler_field_names[2], eisenman_coupler_fields...)
+    return nothing
 end
 
 # extensions required by FluxCalculator (partitioned fluxes)

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -190,6 +190,8 @@ Interfacer.step!(sim::PrescribedIceSimulation, t) = Interfacer.step!(sim.integra
 Interfacer.reinit!(sim::PrescribedIceSimulation) = Interfacer.reinit!(sim.integrator)
 
 """
+    Interfacer.add_coupler_fields!(coupler_field_names, ::PrescribedIceSimulation)
+
 Extend Interfacer.add_coupler_fields! to add the fields required for PrescribedIceSimulation.
 
 The fields added are:
@@ -197,8 +199,10 @@ The fields added are:
 - `:F_radiative` (for radiation input)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::PrescribedIceSimulation)
+    # All fields are 2D; update the list of 2D coupler field names
     ice_coupler_fields = [:ρ_sfc, :F_radiative]
-    push!(coupler_field_names, ice_coupler_fields...)
+    push!(coupler_field_names[2], ice_coupler_fields...)
+    return nothing
 end
 
 # extensions required by FluxCalculator (partitioned fluxes)

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -148,6 +148,8 @@ Interfacer.step!(sim::SlabOceanSimulation, t) = Interfacer.step!(sim.integrator,
 Interfacer.reinit!(sim::SlabOceanSimulation) = Interfacer.reinit!(sim.integrator)
 
 """
+    Interfacer.add_coupler_fields!(coupler_field_names, ::SlabOceanSimulation)
+
 Extend Interfacer.add_coupler_fields! to add the fields required for SlabOceanSimulation.
 
 The fields added are:
@@ -155,8 +157,10 @@ The fields added are:
 - `:F_radiative` (for radiation input)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::SlabOceanSimulation)
+    # All fields are 2D; update the list of 2D coupler field names
     ocean_coupler_fields = [:ρ_sfc, :F_radiative]
-    push!(coupler_field_names, ocean_coupler_fields...)
+    push!(coupler_field_names[2], ocean_coupler_fields...)
+    return nothing
 end
 
 # extensions required by FluxCalculator (partitioned fluxes)

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -490,8 +490,8 @@ function setup_and_run(config_dict::AbstractDict)
     for sim in model_sims
         Interfacer.add_coupler_fields!(coupler_field_names, sim)
     end
-    # add coupler fields required to track conservation, if specified
-    energy_check && push!(coupler_field_names, :radiative_energy_flux_toa, :P_net)
+    # add 2D coupler fields required to track conservation, if specified
+    energy_check && push!(coupler_field_names[2], :radiative_energy_flux_toa, :P_net)
 
     # allocate space for the coupler fields
     coupler_fields = Interfacer.init_coupler_fields(FT, coupler_field_names, boundary_space)

--- a/experiments/ClimaEarth/test/debug_plots_tests.jl
+++ b/experiments/ClimaEarth/test/debug_plots_tests.jl
@@ -35,24 +35,27 @@ plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
 @testset "import_atmos_fields!" begin
 
     boundary_space = TestHelper.create_space(FT)
-    coupler_names = [
-        :surface_direct_albedo,
-        :surface_diffuse_albedo,
-        :F_radiative,
-        :F_turb_energy,
-        :F_turb_moisture,
-        :F_turb_ρτxz,
-        :F_turb_ρτyz,
-        :P_liq,
-        :P_snow,
-        :T_sfc,
-        :ρ_sfc,
-        :q_sfc,
-        :beta,
-        :z0b_sfc,
-        :z0m_sfc,
-        :radiative_energy_flux_toa,
-    ]
+    coupler_names = (
+        [],
+        [
+            :surface_direct_albedo,
+            :surface_diffuse_albedo,
+            :F_radiative,
+            :F_turb_energy,
+            :F_turb_moisture,
+            :F_turb_ρτxz,
+            :F_turb_ρτyz,
+            :P_liq,
+            :P_snow,
+            :T_sfc,
+            :ρ_sfc,
+            :q_sfc,
+            :beta,
+            :z0b_sfc,
+            :z0m_sfc,
+            :radiative_energy_flux_toa,
+        ],
+    )
     atmos_names = (:atmos_field,)
     surface_names = (:surface_field,)
     stub_names = (:stub_field,)

--- a/experiments/ClimaEarth/user_io/debug_plots.jl
+++ b/experiments/ClimaEarth/user_io/debug_plots.jl
@@ -95,14 +95,14 @@ function debug(cs::Interfacer.CoupledSimulation, dir = "debug", cs_fields_ref = 
 end
 
 """
-    debug(cs_fields::CC.Fields.Field, dir, cs_fields_ref = nothing)
+    debug(cs_fields, dir, cs_fields_ref = nothing)
 
 Plot useful coupler fields (in `field_names`) and save plots to a directory.
 
 If `cs_fields_ref` is provided (e.g., using a copy of cs.fields from the initialization),
 plot the anomalies of the fields with respect to `cs_fields_ref`.
 """
-function debug(cs_fields::CC.Fields.Field, dir, cs_fields_ref = nothing)
+function debug(cs_fields, dir, cs_fields_ref = nothing)
     field_names = propertynames(cs_fields)
     fig = Makie.Figure(size = (1500, 800))
     min_square_len = ceil(Int, sqrt(length(field_names)))

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -104,7 +104,7 @@ function calculate_surface_air_density(atmos_sim::Interfacer.AtmosModelSimulatio
 end
 
 """
-    partitioned_turbulent_fluxes!(model_sims::NamedTuple, fields::CC.Fields.Field, boundary_space::CC.Spaces.AbstractSpace, surface_scheme, thermo_params::TD.Parameters.ThermodynamicsParameters)
+    partitioned_turbulent_fluxes!(model_sims::NamedTuple, fields::NamedTuple, boundary_space::CC.Spaces.AbstractSpace, surface_scheme, thermo_params::TD.Parameters.ThermodynamicsParameters)
 
 The current setup calculates the aerodynamic fluxes in the coupler (assuming no regridding is needed)
 using adapter function `get_surface_fluxes!`, which calls `SurfaceFluxes.jl`. The coupler saves
@@ -127,14 +127,13 @@ TODO:
 """
 function partitioned_turbulent_fluxes!(
     model_sims::NamedTuple,
-    fields::CC.Fields.Field,
+    csf::NamedTuple,
     boundary_space::CC.Spaces.AbstractSpace,
     surface_scheme,
     thermo_params::TD.Parameters.ThermodynamicsParameters,
 )
 
     atmos_sim = model_sims.atmos_sim
-    csf = fields
     FT = CC.Spaces.undertype(boundary_space)
 
     # reset coupler fields

--- a/src/surface_stub.jl
+++ b/src/surface_stub.jl
@@ -97,14 +97,17 @@ The stub surface simulation is not updated by this function. Extends `SciMLBase.
 reinit!(::AbstractSurfaceStub) = nothing
 
 """
+    Interfacer.add_coupler_fields!(coupler_field_names, ::AbstractSurfaceStub)
+
 Extend Interfacer.add_coupler_fields! to add the fields required for AbstractSurfaceStub.
 
 The fields added are:
 - `:ρ_sfc` (for humidity calculation)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::AbstractSurfaceStub)
+    # Add to the 2D coupler fields
     surface_coupler_fields = [:ρ_sfc]
-    push!(coupler_field_names, surface_coupler_fields...)
+    push!(coupler_field_names[2], surface_coupler_fields...)
 end
 
 """

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -199,20 +199,23 @@ for FT in (Float32, Float64)
 
             model_sims = (; atmos_sim, ocean_sim, ocean_sim2)
 
-            coupler_cache_names = [
-                :T_sfc,
-                :surface_direct_albedo,
-                :surface_diffuse_albedo,
-                :F_R_sfc,
-                :F_R_toa,
-                :P_liq,
-                :P_snow,
-                :P_net,
-                :F_turb_energy,
-                :F_turb_ρτxz,
-                :F_turb_ρτyz,
-                :F_turb_moisture,
-            ]
+            coupler_cache_names = (
+                [],
+                [
+                    :T_sfc,
+                    :surface_direct_albedo,
+                    :surface_diffuse_albedo,
+                    :F_R_sfc,
+                    :F_R_toa,
+                    :P_liq,
+                    :P_snow,
+                    :P_net,
+                    :F_turb_energy,
+                    :F_turb_ρτxz,
+                    :F_turb_ρτyz,
+                    :F_turb_moisture,
+                ],
+            )
             fields = Interfacer.init_coupler_fields(FT, coupler_cache_names, boundary_space)
 
             # calculate turbulent fluxes


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Many coupler exchange fields are 2D fields at the surface, but some are 1D scalars (CO2 concentration, beta, roughness lengths, etc) - at least for now. This PR updates the coupler exchange field initialization to specify whether a variable is 1D or 2D as it's added to the coupler fields, to avoid allocating and performing operations on unneeded fields. The intermediate `coupler_field_names` is now a 2-Tuple of Vectors rather than a single Vector, but `coupler_fields` remains a single NamedTuple

Edit: I just realized that even if we have a 1D field for one surface component model, it can (will) vary between surfaces. So for these we probably still want to have a 2D coupler field for exchange with the atmosphere. This really only leaves CO2 as a 1D field we'll exchange, so I'm not sure this PR is worth it.