### PR TITLE
Print more information on failed restore

### DIFF
--- a/experiments/ClimaEarth/components/shared/restore.jl
+++ b/experiments/ClimaEarth/components/shared/restore.jl
@@ -75,7 +75,7 @@ function restore!(
     T1 <: Union{StaticArrays.StaticArray, Number, UnitRange, Symbol},
     T2 <: Union{StaticArrays.StaticArray, Number, UnitRange, Symbol},
 }
-    v1 == v2 || error("$name is a immutable but it inconsistent")
+    v1 == v2 || error("$name is a immutable but it inconsistent ($(v1) != $(v2))")
     return nothing
 end
 


### PR DESCRIPTION
This commit prints some additional information when one is restarting a simulation and `v1 != v2`, helping with debugging.
