### PR TITLE
Split `setup_and_run` in multiple steps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,21 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+### Split `setup_and_run` in multiple functions. PR[#1251](https://github.com/CliMA/ClimaCoupler.jl/pull/1251)
+
+`setup_and_run` was split into three functions:
+- `CoupledSimulation`, which takes a dictionary of a file path and constructs a coupled simulation
+- `run!`, which evolves the model
+- `postprocess`, which makes plots
+
+In addition to this, `step!` was introduced to take a single step forward with
+the coupled simulation.
+
+The function `setup_and_run` is still available.
+
+This change also renames `calendar_dt` to `diagnostics_dt` to make it clearer
+that it refers to diagnostics.
+
 ### Some misc. cleanup PR[#1244](https://github.com/CliMA/ClimaCoupler.jl/pull/1244)
 Changes include
 - Land simulation constructors no longer take in `domain_type`, which was unused.

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -43,4 +43,10 @@ include("setup_run.jl")
 config_file = parse_commandline(argparse_settings())["config_file"]
 
 # Set up and run the coupled simulation
-cs = setup_and_run(config_file)
+cs = CoupledSimulation(config_file)
+run!(cs)
+
+# Postprocessing
+# TODO: Remove this option?
+conservation_softfail = get_coupler_config_dict(config_file)["conservation_softfail"]
+postprocess(cs, conservation_softfail)

--- a/experiments/ClimaEarth/user_io/coupler_diagnostics.jl
+++ b/experiments/ClimaEarth/user_io/coupler_diagnostics.jl
@@ -3,7 +3,7 @@ import ClimaCoupler: Interfacer
 import Dates
 
 """
-    coupler_diagnostics_setup(fields, output_dir, start_date, t_start, calendar_dt)
+    coupler_diagnostics_setup(fields, output_dir, start_date, t_start, diagnostics_dt)
 
 Set up the default diagnostics for an AMIP simulation, using ClimaDiagnostics.
 The diagnostics are saved to NetCDF files. Currently, this just includes a
@@ -11,10 +11,10 @@ diagnostic for turbulent energy fluxes.
 
 Return a DiagnosticsHandler object to coordinate the diagnostics.
 """
-function coupler_diagnostics_setup(fields, output_dir, start_date, t_start, calendar_dt)
+function coupler_diagnostics_setup(fields, output_dir, start_date, t_start, diagnostics_dt, coupled_dt)
     # Create schedules and writer
     schedule_everystep = CD.Schedules.EveryStepSchedule()
-    schedule_calendar_dt = CD.Schedules.EveryCalendarDtSchedule(calendar_dt; start_date)
+    schedule_calendar_dt = CD.Schedules.EveryCalendarDtSchedule(diagnostics_dt; start_date)
     netcdf_writer = CD.Writers.NetCDFWriter(axes(fields.F_turb_energy), output_dir)
 
     # Create the diagnostic for turbulent energy fluxes
@@ -48,6 +48,6 @@ function coupler_diagnostics_setup(fields, output_dir, start_date, t_start, cale
 
     # Create the diagnostics handler containing the scheduled diagnostics
     scheduled_diags = [F_turb_energy_diag_sched]
-    diags_handler = CD.DiagnosticsHandler(scheduled_diags, fields, nothing, t_start)
+    diags_handler = CD.DiagnosticsHandler(scheduled_diags, fields, nothing, t_start, dt = coupled_dt)
     return diags_handler
 end


### PR DESCRIPTION
This commit introduces more structure in ClimaEarth. It splits `setup_and_run` in three functions:
- `setup`, which produces a `CoupledSimulation` (hence, it was renamed to be `CoupledSimulation`, since it is just a constructor)
- `run!`, which runs the simulation. This is supported by the introduction of `step!`, to take one single coupling step. This is particularly useful in debugging
- `postprocess`, to make plots

The advantage of this separation is that one can now construct a simulation without running it, and step a simulation one step at a time. Both of these are particularly useful in interactive work and debugging.

This commit also renames `calendar_dt` to `diag_calendar_dt` to make it clearer that it refers to diagnostics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a modular simulation lifecycle that separates initialization, execution, iterative stepping, and postprocessing.
  - Enhanced simulation output handling now provides clearer performance reporting and robust result validation.

- **Refactor**
  - Streamlined the simulation workflow for improved clarity and consistency in diagnostic scheduling and time management.
  - Maintained legacy functionality while transitioning to a more organized and flexible execution approach.
  - Updated variable naming for better clarity regarding diagnostic periods, including the renaming of `calendar_dt` to `diagnostics_dt`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->