### PR TITLE
run AMIP with the integrated land model

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -176,6 +176,20 @@ steps:
         agents:
           slurm_mem: 20GB
 
+      - label: "AMIP: DecayWithHeight + integrated land"
+        key: "amip_integrated_land"
+        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_decay_with_height_integrated_land.yml --job_id amip_integrated_land"
+        artifact_paths: "experiments/ClimaEarth/output/amip_integrated_land/artifacts/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: "AMIP: DecayWithHeight + bucket"
+        key: "amip_decay_with_height_bucket"
+        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_decay_with_height_bucket.yml --job_id amip_decay_with_height_bucket"
+        artifact_paths: "experiments/ClimaEarth/output/amip_decay_with_height_bucket/artifacts/*"
+        agents:
+          slurm_mem: 20GB
+
       - label: "AMIP: bucket initial condition test"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_bucket_ic.yml --job_id amip_bucket_ic"
         artifact_paths: "experiments/ClimaEarth/output/amip_bucket_ic/artifacts/*"
@@ -277,6 +291,26 @@ steps:
         key: "gpu_amip_default"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_default.yml --job_id gpu_amip_default"
         artifact_paths: "experiments/ClimaEarth/output/gpu_amip_default/artifacts/*"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_mem: 20GB
+          slurm_gpus: 1
+
+      - label: "GPU AMIP: DecayWithHeight + integrated land"
+        key: "gpu_amip_integrated_land"
+        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_decay_with_height_integrated_land.yml --job_id gpu_amip_integrated_land"
+        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_integrated_land/artifacts/*"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_mem: 20GB
+          slurm_gpus: 1
+
+      - label: "GPU AMIP: DecayWithHeight + bucket"
+        key: "gpu_amip_decay_with_height_bucket"
+        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_decay_with_height_bucket.yml --job_id gpu_amip_decay_with_height_bucket"
+        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_decay_with_height_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,18 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Test AMIP with integrated land model. PR[#1254](https://github.com/CliMA/ClimaCoupler.jl/pull/1254)
+
+The integrated ClimaLand model can now be used in coupled simulations.
+A short run of AMIP using the full land model is now tested in our regular
+Buildkite pipeline, and the restarts test uses the full land model
+rather than the bucket.
+
+This PR adds the config option `land_model`, which can be set to either
+`bucket` or `integrated` to choose which land model to run with.
+
 #### Remove `nans_to_zero`. PR[#1278](https://github.com/CliMA/ClimaCoupler.jl/pull/1278)
+
 Instead of zeroing out all NaNs in a surface field, we zero out all values
 where the area fraction is 0, which is logically what we want to do.
 

--- a/config/ci_configs/amip_decay_with_height_bucket.yml
+++ b/config/ci_configs/amip_decay_with_height_bucket.yml
@@ -1,29 +1,36 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/longrun_configs/amip_target_edonly.yml"
+checkpoint_dt: "720hours"
 coupler_toml: ["toml/amip.toml"]
-dt: "180secs"
-dt_cpl: "180secs"
-dt_save_state_to_disk: "30days"
-dt_save_to_sol: "30days"
+dt: "240secs"
+dt_cpl: "240secs"
+dt_save_state_to_disk: "12hours"
+dt_save_to_sol: "12hours"
 dz_bottom: 100.0
 energy_check: false
 h_elem: 8
-checkpoint_dt: "720hours"
 land_albedo_type: "map_temporal"
-land_model: "integrated"
+land_model: "bucket"
 mode_name: "amip"
+moist: equil
 netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: true
+rad: allskywithclear
+radiation_reset_rng_seed: true
 rayleigh_sponge: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "540secs"
-topo_smoothing: true
+t_end: "480secs"
 topography: "Earth"
+topo_smoothing: true
 turbconv: ~
 vert_diff: "DecayWithHeightDiffusion"
-viscous_sponge: false
-z_elem: 31
-z_max: 50000.0
+viscous_sponge: true
+z_elem: 39
+z_max: 60000.0
+extra_atmos_diagnostics:
+  - short_name: [pr, rhoa, uas, vas, thetaa, hussfc, ts]
+    reduction_time: average
+    period: 1days

--- a/config/ci_configs/amip_decay_with_height_integrated_land.yml
+++ b/config/ci_configs/amip_decay_with_height_integrated_land.yml
@@ -1,29 +1,36 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/longrun_configs/amip_target_edonly.yml"
+checkpoint_dt: "720hours"
 coupler_toml: ["toml/amip.toml"]
-dt: "180secs"
-dt_cpl: "180secs"
-dt_save_state_to_disk: "30days"
-dt_save_to_sol: "30days"
+dt: "240secs"
+dt_cpl: "240secs"
+dt_save_state_to_disk: "12hours"
+dt_save_to_sol: "12hours"
 dz_bottom: 100.0
 energy_check: false
 h_elem: 8
-checkpoint_dt: "720hours"
 land_albedo_type: "map_temporal"
 land_model: "integrated"
 mode_name: "amip"
+moist: equil
 netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: true
+rad: allskywithclear
+radiation_reset_rng_seed: true
 rayleigh_sponge: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "540secs"
-topo_smoothing: true
+t_end: "480secs"
 topography: "Earth"
+topo_smoothing: true
 turbconv: ~
 vert_diff: "DecayWithHeightDiffusion"
-viscous_sponge: false
-z_elem: 31
-z_max: 50000.0
+viscous_sponge: true
+z_elem: 39
+z_max: 60000.0
+extra_atmos_diagnostics:
+  - short_name: [pr, rhoa, uas, vas, thetaa, hussfc, ts]
+    reduction_time: average
+    period: 1days

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -53,9 +53,17 @@ after solving of the simulation has been paused or interrupted. Like
 of SciMLBase.jl.
 
 ### ComponentModelSimulation - optional functions
-- `get_model_prog_state(::ComponentModelSimulation)`: A function that
-returns the state vector of the simulation at its current state. This
-is used for checkpointing the simulation.
+- `Checkpointer.get_model_prog_state(::ComponentModelSimulation)`:
+A function that returns the state vector of the simulation at its current
+state. This is used for checkpointing the simulation.
+
+- `Checkpointer.get_model_cache(::ComponentModelSimulation)`:
+A function that returns the cache of the simulation at its current state.
+This is used for checkpointing the simulation.
+
+- `Checkpointer.restore_cache(::ComponentModelSimulation, new_cache)`:
+A function that updates the cache of the simulation with the provided
+`new_cache`. This is used for restarting the simulation.
 
 - `get_field(::ComponentModelSimulation, ::Val{property})`:
 Default `get_field` functions are provided for `energy` and `water` fields,

--- a/experiments/ClimaEarth/Manifest-v1.11.toml
+++ b/experiments/ClimaEarth/Manifest-v1.11.toml
@@ -344,9 +344,9 @@ version = "0.2.12"
 
 [[deps.ClimaLand]]
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
-git-tree-sha1 = "309507cd078678f291e1b8698b64b8200a78ab52"
+git-tree-sha1 = "08d08423e0a955180d3eea39c340b81603a00585"
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "0.15.13"
+version = "0.15.14"
 
     [deps.ClimaLand.extensions]
     CreateParametersExt = "ClimaParams"

--- a/experiments/ClimaEarth/Manifest.toml
+++ b/experiments/ClimaEarth/Manifest.toml
@@ -341,9 +341,9 @@ version = "0.2.12"
 
 [[deps.ClimaLand]]
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
-git-tree-sha1 = "309507cd078678f291e1b8698b64b8200a78ab52"
+git-tree-sha1 = "08d08423e0a955180d3eea39c340b81603a00585"
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "0.15.13"
+version = "0.15.14"
 
     [deps.ClimaLand.extensions]
     CreateParametersExt = "ClimaParams"

--- a/experiments/ClimaEarth/cli_options.jl
+++ b/experiments/ClimaEarth/cli_options.jl
@@ -131,6 +131,10 @@ function argparse_settings()
         arg_type = Vector{Dict{Any, Any}}
         default = []
         ### ClimaLand specific
+        "--land_model"
+        help = "Land model to use. [`bucket` (default), `integrated`]"
+        arg_type = String
+        default = "bucket"
         "--land_albedo_type"
         help = "Access land surface albedo information from data file. [`map_static` (default), `function`, `map_temporal`]"
         arg_type = String

--- a/experiments/ClimaEarth/test/debug_plots_tests.jl
+++ b/experiments/ClimaEarth/test/debug_plots_tests.jl
@@ -20,13 +20,20 @@ struct BucketSimulation{C} <: Interfacer.SurfaceModelSimulation
 end
 Interfacer.name(sim::BucketSimulation) = "BucketSimulation"
 
+struct ClimaLandSimulation{C} <: Interfacer.SurfaceModelSimulation
+    cache::C
+end
+Interfacer.name(sim::ClimaLandSimulation) = "ClimaLandSimulation"
+
 include("../user_io/debug_plots.jl")
 
 Interfacer.get_field(sim::BucketSimulation, ::Val{:surface_field}) = sim.cache.surface_field
+Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:surface_field}) = sim.cache.surface_field
 Interfacer.get_field(sim::Interfacer.SurfaceStub, ::Val{:stub_field}) = sim.cache.stub_field
 
 plot_field_names(sim::ClimaAtmosSimulation) = (:atmos_field,)
 plot_field_names(sim::BucketSimulation) = (:surface_field,)
+plot_field_names(sim::ClimaLandSimulation) = (:surface_field,)
 plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
 
 @testset "import_atmos_fields!" begin
@@ -62,6 +69,7 @@ plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
     model_sims = (;
         atmos_sim = ClimaAtmosSimulation(atmos_fields),
         surface_sim = BucketSimulation(surface_fields),
+        surface_sim2 = ClimaLandSimulation(surface_fields),
         ice_sim = Interfacer.SurfaceStub(stub_fields),
     )
     cs = Interfacer.CoupledSimulation{FT}(
@@ -84,6 +92,7 @@ plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
     @test_logs (:info, "plotting debug in test_debug") match_mode = :any debug(cs, output_plots)
     @test isfile("test_debug/debug_ClimaAtmosSimulation.png")
     @test isfile("test_debug/debug_BucketSimulation.png")
+    @test isfile("test_debug/debug_ClimaLandSimulation.png")
     @test isfile("test_debug/debug_SurfaceStub.png")
     @test isfile("test_debug/debug_coupler.png")
 

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -112,6 +112,7 @@ function get_coupler_args(config_dict::Dict)
     output_dir_root = joinpath(config_dict["coupler_output_dir"], job_id)
 
     # ClimaLand-specific information
+    land_model = config_dict["land_model"]
     land_albedo_type = config_dict["land_albedo_type"]
     land_initial_condition = config_dict["land_initial_condition"]
     land_temperature_anomaly = config_dict["land_temperature_anomaly"]
@@ -137,6 +138,7 @@ function get_coupler_args(config_dict::Dict)
         energy_check,
         conservation_softfail,
         output_dir_root,
+        land_model,
         land_albedo_type,
         land_initial_condition,
         land_temperature_anomaly,

--- a/experiments/ClimaEarth/user_io/debug_plots.jl
+++ b/experiments/ClimaEarth/user_io/debug_plots.jl
@@ -238,7 +238,31 @@ Interfacer.get_field(sim::BucketSimulation, ::Val{:σS}) = sim.integrator.u.buck
 Interfacer.get_field(sim::BucketSimulation, ::Val{:Ws}) = sim.integrator.u.bucket.Ws
 Interfacer.get_field(sim::BucketSimulation, ::Val{:W}) = sim.integrator.u.bucket.W
 
+# additional ClimaLand model debug fields
+Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:soil_water}) = sim.integrator.u.soil.ϑ_l
+Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:soil_ice}) = sim.integrator.u.soil.θ_i
+Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:soil_energy}) = sim.integrator.u.soil.ρe_int
+Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:canopy_temp}) = sim.integrator.u.canopy.energy.T
+Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:canopy_water}) = sim.integrator.u.canopy.hydraulics.ϑ_l.:1
+Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:snow_energy}) = sim.integrator.u.snow.U
+Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:snow_water_equiv}) = sim.integrator.u.snow.S
+Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:snow_liquid_water}) = sim.integrator.u.snow.S_l
+
 # currently selected plot fields
 plot_field_names(sim::Interfacer.SurfaceModelSimulation) = (:area_fraction, :surface_temperature, :surface_humidity)
+plot_field_names(sim::ClimaLandSimulation) = (
+    :area_fraction,
+    :surface_direct_albedo,
+    :surface_diffuse_albedo,
+    :surface_temperature,
+    :soil_water,
+    :soil_ice,
+    :soil_energy,
+    :canopy_temp,
+    :canopy_water,
+    :snow_energy,
+    :snow_water_equiv,
+    :snow_liquid_water,
+)
 plot_field_names(sim::BucketSimulation) = (:area_fraction, :surface_temperature, :surface_humidity, :σS, :Ws, :W)
 plot_field_names(sim::ClimaAtmosSimulation) = (:w, :ρq_tot, :ρe_tot, :liquid_precipitation, :snow_precipitation)

--- a/experiments/ClimaEarth/user_io/diagnostics_plots.jl
+++ b/experiments/ClimaEarth/user_io/diagnostics_plots.jl
@@ -107,6 +107,11 @@ function make_plots_generic(
     grid_pos = 1
 
     for var in vars
+        if all(isnan, var.data)
+            @warn "$(short_name(var)) diagnostic is entirely NaN - skipping plot"
+            vars_left_to_plot -= 1
+            continue
+        end
         if grid_pos > MAX_PLOTS_PER_PAGE
             fig = makefig()
             grid = gridlayout()
@@ -166,7 +171,9 @@ function make_diagnostics_plots(output_path::AbstractString, plot_path::Abstract
         # Use "average" if available, otherwise use the first reduction
         reductions = CAN.available_reductions(simdir; short_name)
         "average" in reductions ? (reduction = "average") : (reduction = first(reductions))
-        vars[i] = get(simdir; short_name, reduction)
+        periods = CAN.available_periods(simdir; short_name, reduction)
+        "1d" in periods ? (period = "1d") : (period = first(periods))
+        vars[i] = get(simdir; short_name, reduction, period)
     end
 
     # Filter vars into 2D and 3D variable diagnostics vectors


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Set up an AMIP simulation using the integrated land model and try running it! Let's see what happens.

Successful 1 month build [here](https://buildkite.com/clima/climacoupler-ci/builds/6185#_)

[Longrun with bucket](https://buildkite.com/clima/climacoupler-longruns/builds/860) - runs for 1 year (not tested for longer)
[Longrun with land](https://buildkite.com/clima/climacoupler-longruns/builds/858) - unstable after 4.5 months

## To-do
- [x] add CLI option for land model type, `land_model`
- [x] small fixes to run integrated land in full simulation
- [x] add AMIP run with integrated land to CI
- [x] run AMIP + integrated land

## Remaining work (for separate PRs)
- [ ] add AMIP longrun with integrated land to CI
- [ ] improve initial conditions used in land model constructor
- [ ] the `compute_surface_fluxes!` method for `ClimaLandSimulation` needs to provide `L_MO`, `ustar`, `buoyancy_flux` to update these properties in the atmosphere. This is high priority because it's currently incorrect. This will require changes in ClimaLand.