### PR TITLE
remove `area_mask`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ slurm-*.out
 # ignore vscode artifacts
 *.vscode
 *.DS
+*.qodo

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,13 +6,15 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
-#### Remove `area_mask`. [PR#1268](https://github.com/CliMA/ClimaCoupler.jl/pull/1268/files)
-
+#### Remove `area_mask`, `binary_mask`, `mono_surface`. [PR#1268](https://github.com/CliMA/ClimaCoupler.jl/pull/1268/files)
 Removes all uses of `area_mask`, as multiplying quantities by both `area_fraction`
 and `area_mask` will potentially lead to physically inaccurate results.
 It also defeats the purpose of maintaining that the sum of surface models'
 area fractions is 1 at all points. See issue [#1255](https://github.com/CliMA/ClimaCoupler.jl/issues/1255) for more details.
-Also removes the function `Utilities.binary_mask`, as it's now unused.
+The function `Utilities.binary_mask` is also removed, as it's now unused.
+The option `mono_surface` is no longer supported, as it was rarely exercised
+and did not do what it was documented to do. All simulations now have
+behavior equivalent to using `mono_surface: false` previously.
 
 #### Removed hierarchy experiments. PR[#1277](https://github.com/CliMA/ClimaCoupler.jl/pull/1277)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,14 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Remove `area_mask`. [PR#1268](https://github.com/CliMA/ClimaCoupler.jl/pull/1268/files)
+
+Removes all uses of `area_mask`, as multiplying quantities by both `area_fraction`
+and `area_mask` will potentially lead to physically inaccurate results.
+It also defeats the purpose of maintaining that the sum of surface models'
+area fractions is 1 at all points. See issue [#1255](https://github.com/CliMA/ClimaCoupler.jl/issues/1255) for more details.
+Also removes the function `Utilities.binary_mask`, as it's now unused.
+
 #### Removed hierarchy experiments. PR[#1277](https://github.com/CliMA/ClimaCoupler.jl/pull/1277)
 
 The hierarchy experiments have been removed. The last commit that contains them

--- a/config/amip_configs/amip.yml
+++ b/config/amip_configs/amip.yml
@@ -13,7 +13,6 @@ energy_check: false
 h_elem: 16
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 netcdf_output_at_levels: true
 output_default_diagnostics: true
 radiation_reset_rng_seed: true

--- a/config/benchmark_configs/amip_diagedmf.yml
+++ b/config/benchmark_configs/amip_diagedmf.yml
@@ -9,7 +9,6 @@ dt_save_to_sol: "Inf"
 energy_check: false
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 monthly_checkpoint: false
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 prescribe_ozone: true

--- a/config/benchmark_configs/amip_diagedmf_io.yml
+++ b/config/benchmark_configs/amip_diagedmf_io.yml
@@ -9,7 +9,6 @@ dt_save_to_sol: "12hours"
 energy_check: false
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 monthly_checkpoint: false
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 prescribe_ozone: true

--- a/config/ci_configs/amip_coarse_ft32.yml
+++ b/config/ci_configs/amip_coarse_ft32.yml
@@ -7,7 +7,6 @@ energy_check: false
 h_elem: 6
 mode_name: "amip"
 moist: "equil"
-mono_surface: false
 precip_model: "0M"
 rad: "allskywithclear"
 t_end: "10days"

--- a/config/ci_configs/amip_coarse_ft64_hourly_checkpoints.yml
+++ b/config/ci_configs/amip_coarse_ft64_hourly_checkpoints.yml
@@ -5,7 +5,6 @@ energy_check: false
 h_elem: 6
 mode_name: "amip"
 moist: "equil"
-mono_surface: false
 precip_model: "0M"
 rad: "allskywithclear"
 t_end: "10days"

--- a/config/ci_configs/amip_coarse_ft64_hourly_checkpoints_restart.yml
+++ b/config/ci_configs/amip_coarse_ft64_hourly_checkpoints_restart.yml
@@ -6,7 +6,6 @@ energy_check: false
 h_elem: 6
 mode_name: "amip"
 moist: "equil"
-mono_surface: false
 precip_model: "0M"
 rad: "allskywithclear"
 t_end: "800secs"

--- a/config/ci_configs/amip_coarse_mpi.yml
+++ b/config/ci_configs/amip_coarse_mpi.yml
@@ -5,7 +5,6 @@ energy_check: false
 h_elem: 4
 mode_name: "amip"
 moist: "equil"
-mono_surface: false
 precip_model: "0M"
 rad: "allskywithclear"
 t_end: "10days"

--- a/config/ci_configs/amip_component_dts.yml
+++ b/config/ci_configs/amip_component_dts.yml
@@ -13,7 +13,6 @@ energy_check: false
 h_elem: 16
 mode_name: "amip"
 moist: "equil"
-mono_surface: false
 precip_model: "0M"
 rad: "gray"
 rayleigh_sponge: true

--- a/config/ci_configs/amip_n1_shortrun.yml
+++ b/config/ci_configs/amip_n1_shortrun.yml
@@ -10,7 +10,6 @@ energy_check: false
 h_elem: 16
 mode_name: "amip"
 moist: "equil"
-mono_surface: false
 precip_model: "0M"
 rad: "gray"
 rayleigh_sponge: true

--- a/config/ci_configs/amip_target_topo_diagedmf_shortrun.yml
+++ b/config/ci_configs/amip_target_topo_diagedmf_shortrun.yml
@@ -12,7 +12,6 @@ energy_check: false
 insolation: "timevarying"
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 netcdf_output_at_levels: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"

--- a/config/ci_configs/slabplanet_albedo_function.yml
+++ b/config/ci_configs/slabplanet_albedo_function.yml
@@ -7,7 +7,6 @@ h_elem: 4
 land_albedo_type: "function"
 mode_name: "slabplanet"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 t_end: "10days"

--- a/config/ci_configs/slabplanet_atmos_diags.yml
+++ b/config/ci_configs/slabplanet_atmos_diags.yml
@@ -6,7 +6,6 @@ energy_check: true
 h_elem: 4
 mode_name: "slabplanet"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 t_end: "10days"

--- a/config/ci_configs/slabplanet_default.yml
+++ b/config/ci_configs/slabplanet_default.yml
@@ -6,7 +6,6 @@ energy_check: true
 h_elem: 4
 mode_name: "slabplanet"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 t_end: "10days"

--- a/config/ci_configs/slabplanet_dry_norad.yml
+++ b/config/ci_configs/slabplanet_dry_norad.yml
@@ -7,7 +7,6 @@ energy_check: true
 h_elem: 4
 mode_name: "slabplanet"
 moist: "dry"
-mono_surface: true
 output_default_diagnostics: false
 precip_model: nothing
 rad: nothing

--- a/config/ci_configs/slabplanet_eisenman.yml
+++ b/config/ci_configs/slabplanet_eisenman.yml
@@ -7,7 +7,6 @@ energy_check: true
 h_elem: 6
 mode_name: "slabplanet_eisenman"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 surface_setup: "PrescribedSurface"

--- a/config/ci_configs/slabplanet_nonmono.yml
+++ b/config/ci_configs/slabplanet_nonmono.yml
@@ -6,7 +6,6 @@ energy_check: true
 h_elem: 4
 mode_name: "slabplanet"
 moist: "equil"
-mono_surface: false
 precip_model: "0M"
 rad: "gray"
 t_end: "10days"

--- a/config/ci_configs/slabplanet_partitioned_fluxes.yml
+++ b/config/ci_configs/slabplanet_partitioned_fluxes.yml
@@ -6,7 +6,6 @@ energy_check: true
 h_elem: 4
 mode_name: "slabplanet"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 t_end: "10days"

--- a/config/ci_configs/slabplanet_realinsol_rayleigh.yml
+++ b/config/ci_configs/slabplanet_realinsol_rayleigh.yml
@@ -9,7 +9,6 @@ h_elem: 6
 insolation: "timevarying"
 mode_name: "slabplanet"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 rayleigh_sponge: true

--- a/config/longrun_configs/amip_target.yml
+++ b/config/longrun_configs/amip_target.yml
@@ -11,7 +11,6 @@ energy_check: false
 insolation: "timevarying"
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 prescribe_ozone: true
 rad: "allskywithclear"

--- a/config/longrun_configs/amip_target_topo.yml
+++ b/config/longrun_configs/amip_target_topo.yml
@@ -12,7 +12,6 @@ energy_check: false
 insolation: "timevarying"
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 netcdf_interpolate_z_over_msl: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 prescribe_ozone: true

--- a/config/longrun_configs/amip_target_topo_diagedmf_cpu.yml
+++ b/config/longrun_configs/amip_target_topo_diagedmf_cpu.yml
@@ -13,7 +13,6 @@ energy_check: false
 insolation: "timevarying"
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 netcdf_output_at_levels: true
 output_default_diagnostics: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]

--- a/config/longrun_configs/amip_target_topo_diagedmf_gpu.yml
+++ b/config/longrun_configs/amip_target_topo_diagedmf_gpu.yml
@@ -13,7 +13,6 @@ energy_check: false
 insolation: "timevarying"
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 netcdf_output_at_levels: true
 output_default_diagnostics: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]

--- a/config/longrun_configs/longrun_amip_dyamond.yml
+++ b/config/longrun_configs/longrun_amip_dyamond.yml
@@ -7,7 +7,6 @@ dt_save_to_sol: "0.5days"
 energy_check: false
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 monthly_checkpoint: false
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 prescribe_ozone: true

--- a/config/longrun_configs/slabplanet_aqua_atmos_sf_couple.yml
+++ b/config/longrun_configs/slabplanet_aqua_atmos_sf_couple.yml
@@ -8,7 +8,6 @@ h_elem: 6
 land_albedo_type: "function"
 mode_name: "slabplanet_aqua"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 start_date: "20100101"

--- a/config/longrun_configs/slabplanet_aqua_atmos_sf_nocouple.yml
+++ b/config/longrun_configs/slabplanet_aqua_atmos_sf_nocouple.yml
@@ -8,7 +8,6 @@ h_elem: 6
 land_albedo_type: "function"
 mode_name: "slabplanet_aqua"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 start_date: "20100101"

--- a/config/longrun_configs/slabplanet_aqua_coupler_sf.yml
+++ b/config/longrun_configs/slabplanet_aqua_coupler_sf.yml
@@ -8,7 +8,6 @@ h_elem: 6
 land_albedo_type: "function"
 mode_name: "slabplanet_aqua"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 start_date: "20100101"

--- a/config/longrun_configs/slabplanet_aqua_coupler_sf_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_aqua_coupler_sf_evolve_ocn.yml
@@ -7,7 +7,6 @@ h_elem: 6
 land_albedo_type: "function"
 mode_name: "slabplanet_aqua"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 start_date: "20100101"

--- a/config/longrun_configs/slabplanet_aqua_target.yml
+++ b/config/longrun_configs/slabplanet_aqua_target.yml
@@ -9,7 +9,6 @@ energy_check: false
 evolving_ocean: false
 land_albedo_type: "function"
 mode_name: "slabplanet_aqua"
-mono_surface: false
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "120days"

--- a/config/longrun_configs/slabplanet_aqua_target_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_aqua_target_evolve_ocn.yml
@@ -9,7 +9,6 @@ energy_check: false
 evolving_ocean: true
 land_albedo_type: "function"
 mode_name: "slabplanet_aqua"
-mono_surface: false
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "120days"

--- a/config/longrun_configs/slabplanet_aqua_target_nocouple.yml
+++ b/config/longrun_configs/slabplanet_aqua_target_nocouple.yml
@@ -9,7 +9,6 @@ energy_check: false
 evolving_ocean: false
 land_albedo_type: "function"
 mode_name: "slabplanet_aqua"
-mono_surface: false
 start_date: "20100101"
 surface_setup: "DefaultMoninObukhov"
 t_end: "120days"

--- a/config/longrun_configs/slabplanet_coupler_sf_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_coupler_sf_evolve_ocn.yml
@@ -7,7 +7,6 @@ h_elem: 6
 land_albedo_type: "function"
 mode_name: "slabplanet"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 start_date: "20100101"

--- a/config/longrun_configs/slabplanet_target.yml
+++ b/config/longrun_configs/slabplanet_target.yml
@@ -9,7 +9,6 @@ energy_check: false
 evolving_ocean: false
 land_albedo_type: "function"
 mode_name: "slabplanet"
-mono_surface: false
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "120days"

--- a/config/longrun_configs/slabplanet_target_evolve_ocn.yml
+++ b/config/longrun_configs/slabplanet_target_evolve_ocn.yml
@@ -9,7 +9,6 @@ energy_check: false
 evolving_ocean: true
 land_albedo_type: "function"
 mode_name: "slabplanet"
-mono_surface: false
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "120days"

--- a/config/longrun_configs/slabplanet_terra.yml
+++ b/config/longrun_configs/slabplanet_terra.yml
@@ -7,7 +7,6 @@ h_elem: 4
 land_albedo_type: "function"
 mode_name: "slabplanet_terra"
 moist: "equil"
-mono_surface: true
 precip_model: "0M"
 rad: "gray"
 start_date: "20100101"

--- a/config/nightly_configs/amip_coarse.yml
+++ b/config/nightly_configs/amip_coarse.yml
@@ -12,7 +12,6 @@ energy_check: false
 h_elem: 8
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: true

--- a/config/nightly_configs/amip_coarse_edonly.yml
+++ b/config/nightly_configs/amip_coarse_edonly.yml
@@ -12,7 +12,6 @@ energy_check: false
 h_elem: 8
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: true

--- a/config/nightly_configs/amip_coarse_random.yml
+++ b/config/nightly_configs/amip_coarse_random.yml
@@ -13,7 +13,6 @@ energy_check: false
 h_elem: 8
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: true

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -13,5 +13,4 @@ ClimaCoupler.Utilities.get_device
 ClimaCoupler.Utilities.show_memory_usage
 ClimaCoupler.Utilities.setup_output_dirs
 ClimaCoupler.Utilities.time_to_seconds
-ClimaCoupler.Utilities.binary_mask
 ```

--- a/experiments/ClimaEarth/cli_options.jl
+++ b/experiments/ClimaEarth/cli_options.jl
@@ -97,10 +97,6 @@ function argparse_settings()
         help = "Boolean flag indicating whether to use a dynamic slab ocean model, as opposed to constant surface temperatures [`true` (default), `false`]"
         arg_type = Bool
         default = true
-        "--mono_surface"
-        help = "Boolean flag indicating whether (1st order) monotone and conservative remapping is applied. [`false` (default), `true`]"
-        arg_type = Bool
-        default = false
         "--turb_flux_partition"
         help = "Method to partition turbulent fluxes. [`PartitionedStateFluxes`, `CombinedStateFluxesMOST` (default)]"
         arg_type = String

--- a/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
@@ -249,8 +249,10 @@ function FluxCalculator.differentiate_turbulent_fluxes!(
 
     # calculate the surface fluxes
     area_fraction = Interfacer.get_field(sim, Val(:area_fraction))
-    _, _, F_shf_δT_sfc, F_lhf_δT_sfc, _ = FluxCalculator.get_surface_fluxes!(inputs, surface_params, area_fraction)
+    _, _, F_shf_δT_sfc, F_lhf_δT_sfc, _ = FluxCalculator.get_surface_fluxes!(inputs, surface_params)
 
+    F_shf_δT_sfc .*= area_fraction
+    F_lhf_δT_sfc .*= area_fraction
     (; F_shf, F_lhf) = fluxes
 
     # calculate the derivative

--- a/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
@@ -409,5 +409,5 @@ function ∑tendencies(dY, Y, cache, _)
     @. dY.q_sfc = -Y.q_sfc / Δt
 
     # update ice area fraction (binary mask for now)
-    cache.ice_area_fraction .= Utilities.binary_mask.(Y.h_ice)
+    @. cache.ice_area_fraction = ifelse(Y.h_ice > 0, one(Y.h_ice), zero(Y.h_ice))
 end

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -181,7 +181,7 @@ function slab_ocean_rhs!(dY, Y, cache, t)
     p, F_turb_energy, F_radiative, area_fraction = cache
     FT = eltype(Y.T_sfc)
     rhs = @. -(F_turb_energy + F_radiative) / (p.h * p.ρ * p.c)
-    @. dY.T_sfc = rhs * Utilities.binary_mask(area_fraction) * p.evolving_switch
+    @. dY.T_sfc = rhs * area_fraction * p.evolving_switch
     @. cache.q_sfc = TD.q_vap_saturation_generic.(cache.thermo_params, Y.T_sfc, cache.ρ_sfc, TD.Liquid())
 end
 

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -178,10 +178,12 @@ end
 ###
 # ode
 function slab_ocean_rhs!(dY, Y, cache, t)
-    p, F_turb_energy, F_radiative, area_fraction = cache
-    FT = eltype(Y.T_sfc)
+    p, F_turb_energy, F_radiative = cache
     rhs = @. -(F_turb_energy + F_radiative) / (p.h * p.ρ * p.c)
-    @. dY.T_sfc = rhs * area_fraction * p.evolving_switch
+
+    # Note that the area fraction has already been applied to the fluxes,
+    #  so we don't need to multiply by it here.
+    @. dY.T_sfc = rhs * p.evolving_switch
     @. cache.q_sfc = TD.q_vap_saturation_generic.(cache.thermo_params, Y.T_sfc, cache.ρ_sfc, TD.Liquid())
 end
 

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -241,10 +241,7 @@ function CoupledSimulation(config_dict::AbstractDict)
 
     # Preprocess the file to be 1s and 0s before remapping into onto the grid
     land_fraction = SpaceVaryingInput(land_mask_data, "landsea", boundary_space)
-    if !mono_surface
-        land_fraction = Utilities.binary_mask.(land_fraction)
-    end
-    Utilities.show_memory_usage()
+    land_fraction = !mono_surface ? ifelse.(land_fraction .> eps(FT), FT(1), FT(0)) : land_fraction
 
     #=
     ### Surface Models: AMIP and SlabPlanet Modes
@@ -296,7 +293,6 @@ function CoupledSimulation(config_dict::AbstractDict)
             thermo_params = thermo_params,
             comms_ctx,
             start_date,
-            mono_surface,
             land_fraction,
         )
 

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -125,7 +125,6 @@ function CoupledSimulation(config_dict::AbstractDict)
         use_land_diagnostics,
         diagnostics_dt,
         evolving_ocean,
-        mono_surface,
         turb_flux_partition,
         land_albedo_type,
         land_initial_condition,
@@ -241,7 +240,7 @@ function CoupledSimulation(config_dict::AbstractDict)
 
     # Preprocess the file to be 1s and 0s before remapping into onto the grid
     land_fraction = SpaceVaryingInput(land_mask_data, "landsea", boundary_space)
-    land_fraction = !mono_surface ? ifelse.(land_fraction .> eps(FT), FT(1), FT(0)) : land_fraction
+    land_fraction = ifelse.(land_fraction .> eps(FT), FT(1), FT(0))
 
     #=
     ### Surface Models: AMIP and SlabPlanet Modes

--- a/experiments/ClimaEarth/test/amip_test.yml
+++ b/experiments/ClimaEarth/test/amip_test.yml
@@ -12,7 +12,6 @@ h_elem: 8
 checkpoint_dt: "720hours"
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: true

--- a/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
@@ -1,5 +1,6 @@
 import Test: @test, @testset
 import Dates
+import NCDatasets
 import ClimaCore as CC
 import Thermodynamics.Parameters as TDP
 import ClimaParams # required for TDP
@@ -68,8 +69,7 @@ for FT in (Float32, Float64)
         # check that extracting expected T due to input atmopsheric fluxes
         dY, Y, p = test_sea_ice_rhs(F_radiative = 1.0)
         dT_expected = -1.0 / (p.params.h * p.params.ρ * p.params.c)
-        @test minimum(dY) ≈ FT(dT_expected)
-        @test maximum(dY) ≈ FT(0)
+        @test all(extrema(dY) .≈ FT(dT_expected))
 
         # check that tendency will not result in above freezing T
         dY, Y, p = test_sea_ice_rhs(F_radiative = 0.0, T_base = 330.0) # Float32 requires a large number here!

--- a/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
@@ -41,12 +41,11 @@ for FT in (Float32, Float64)
             # Get initial SIC values and use them to calculate ice fraction
             SIC_init = CC.Fields.zeros(space)
             evaluate!(SIC_init, SIC_timevaryinginput, t_start)
-            ice_fraction = get_ice_fraction.(SIC_init, false)
 
             cache = (;
                 F_turb_energy = CC.Fields.zeros(space),
                 F_radiative = CC.Fields.zeros(space) .+ FT(F_radiative),
-                area_fraction = ice_fraction,
+                area_fraction = SIC_init,
                 SIC_timevaryinginput = SIC_timevaryinginput,
                 land_fraction = CC.Fields.zeros(space),
                 q_sfc = CC.Fields.zeros(space),

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -103,7 +103,6 @@ function get_coupler_args(config_dict::Dict)
 
     # Physical simulation information
     evolving_ocean = config_dict["evolving_ocean"]
-    mono_surface = config_dict["mono_surface"]
     turb_flux_partition = config_dict["turb_flux_partition"]
 
     # Conservation information
@@ -136,7 +135,6 @@ function get_coupler_args(config_dict::Dict)
         use_coupler_diagnostics,
         diagnostics_dt,
         evolving_ocean,
-        mono_surface,
         turb_flux_partition,
         energy_check,
         conservation_softfail,

--- a/experiments/calibration/model_config.yml
+++ b/experiments/calibration/model_config.yml
@@ -11,7 +11,6 @@ energy_check: false
 h_elem: 8
 land_albedo_type: "map_temporal"
 mode_name: "amip"
-mono_surface: false
 netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: false

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -184,17 +184,15 @@ function update_sim!(sim::Interfacer.SurfaceModelSimulation, csf, turbulent_flux
     Interfacer.update_field!(sim, Val(:air_density), csf.ρ_sfc)
 
     # turbulent fluxes
-    mask = Utilities.binary_mask.(area_fraction)
-
     # when PartitionedStateFluxes, turbulent fluxes are updated during the flux calculation
     if turbulent_fluxes isa FluxCalculator.CombinedStateFluxesMOST
-        F_turb_energy_masked = FT.(mask .* csf.F_turb_energy)
+        F_turb_energy_masked = FT.(area_fraction .* csf.F_turb_energy)
         Interfacer.update_field!(sim, Val(:turbulent_energy_flux), F_turb_energy_masked)
-        Interfacer.update_field!(sim, Val(:turbulent_moisture_flux), FT.(mask .* csf.F_turb_moisture))
+        Interfacer.update_field!(sim, Val(:turbulent_moisture_flux), FT.(area_fraction .* csf.F_turb_moisture))
     end
 
     # radiative fluxes
-    Interfacer.update_field!(sim, Val(:radiative_energy_flux_sfc), FT.(mask .* csf.F_radiative))
+    Interfacer.update_field!(sim, Val(:radiative_energy_flux_sfc), FT.(area_fraction .* csf.F_radiative))
 
     # precipitation
     Interfacer.update_field!(sim, Val(:liquid_precipitation), csf.P_liq)

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -468,8 +468,6 @@ function compute_surface_fluxes!(
 
     # get area fraction (min = 0, max = 1)
     area_fraction = Interfacer.get_field(sim, Val(:area_fraction))
-    # get area mask [0, 1], where area_mask = 1 if area_fraction > 0
-    area_mask = Utilities.binary_mask.(area_fraction)
 
     thermo_state_sfc = FluxCalculator.surface_thermo_state(sim, thermo_params, thermo_state_int)
 
@@ -512,31 +510,31 @@ function compute_surface_fluxes!(
     # add the flux contributing from this surface to the coupler field
     # note that the fluxes are area-weighted, so if a surface model is
     #  not present at this point, the fluxes are zero
-    @. csf.F_turb_ρτxz += F_turb_ρτxz * area_fraction * area_mask
-    @. csf.F_turb_ρτyz += F_turb_ρτyz * area_fraction * area_mask
-    @. csf.F_turb_energy += (F_shf .+ F_lhf) * area_fraction * area_mask
-    @. csf.F_turb_moisture += F_turb_moisture * area_fraction * area_mask
+    @. csf.F_turb_ρτxz += F_turb_ρτxz * area_fraction
+    @. csf.F_turb_ρτyz += F_turb_ρτyz * area_fraction
+    @. csf.F_turb_energy += (F_shf .+ F_lhf) * area_fraction
+    @. csf.F_turb_moisture += F_turb_moisture * area_fraction
 
     # NOTE: This is still an area weighted contribution, which maybe doesn't make
     # too much sense for these quantities...
 
     # L_MO can be Inf. We don't want to multiply Inf * 0, so we can handle this
     # separately.
-    @. csf.L_MO += ifelse(isinf(fluxes.L_MO), fluxes.L_MO, fluxes.L_MO * area_fraction * area_mask)
-    @. csf.ustar += fluxes.ustar * area_fraction * area_mask
-    @. csf.buoyancy_flux += fluxes.buoyancy_flux * area_fraction * area_mask
+    @. csf.L_MO += ifelse(isinf(fluxes.L_MO), fluxes.L_MO, fluxes.L_MO * area_fraction)
+    @. csf.ustar += fluxes.ustar * area_fraction
+    @. csf.buoyancy_flux += fluxes.buoyancy_flux * area_fraction
 
     z0m = Interfacer.get_field(sim, Val(:roughness_momentum))
     z0b = Interfacer.get_field(sim, Val(:roughness_buoyancy))
     beta = Interfacer.get_field(sim, Val(:beta))
 
-    @. csf.z0m_sfc += z0m * area_fraction * area_mask
-    @. csf.z0b_sfc += z0b * area_fraction * area_mask
-    @. csf.beta += beta * area_fraction * area_mask
+    @. csf.z0m_sfc += z0m * area_fraction
+    @. csf.z0b_sfc += z0b * area_fraction
+    @. csf.beta += beta * area_fraction
 
     # NOTE: This is essentially setting q_sfc to the Atmos q_sfc (because we compute the
     # thermo_state_sfc by extrapolating the atmos properties onto the surface)
-    @. csf.q_sfc += TD.total_specific_humidity.(thermo_params, thermo_state_sfc) * area_fraction * area_mask
+    @. csf.q_sfc += TD.total_specific_humidity.(thermo_params, thermo_state_sfc) * area_fraction
     return nothing
 end
 

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -314,14 +314,14 @@ function extrapolate_ρ_to_sfc(thermo_params, ts_in, T_sfc)
 end
 
 """
-    get_surface_fluxes!(inputs, surface_params::SF.Parameters.SurfaceFluxesParameters, area_fraction)
+    get_surface_fluxes!(inputs, surface_params::SF.Parameters.SurfaceFluxesParameters)
 
 Uses SurfaceFluxes.jl to calculate turbulent surface fluxes. It should be atmos model agnostic, and columnwise.
-Fluxes where the area fraction is zero are set to zero.
+Fluxes are computed over the entire surface, even where the relevant surface model is not present.
 
 When available, it also computes ancillary quantities, such as the Monin-Obukov lengthscale.
 """
-function get_surface_fluxes!(inputs, surface_params::SF.Parameters.SurfaceFluxesParameters, area_fraction)
+function get_surface_fluxes!(inputs, surface_params::SF.Parameters.SurfaceFluxesParameters)
     # calculate all fluxes (saturated surface conditions)
     outputs = SF.surface_conditions.(surface_params, inputs)
 
@@ -339,17 +339,6 @@ function get_surface_fluxes!(inputs, surface_params::SF.Parameters.SurfaceFluxes
     L_MO = outputs.L_MO
     ustar = outputs.ustar
     buoyancy_flux = outputs.buoy_flux
-
-    # Zero out fluxes where the area fraction is zero
-    @. F_turb_ρτxz = ifelse(area_fraction ≈ 0, zero(F_turb_ρτxz), F_turb_ρτxz)
-    @. F_turb_ρτyz = ifelse(area_fraction ≈ 0, zero(F_turb_ρτyz), F_turb_ρτyz)
-    @. F_shf = ifelse(area_fraction ≈ 0, zero(F_shf), F_shf)
-    @. F_lhf = ifelse(area_fraction ≈ 0, zero(F_lhf), F_lhf)
-    @. F_turb_moisture = ifelse(area_fraction ≈ 0, zero(F_turb_moisture), F_turb_moisture)
-
-    @. L_MO = ifelse(area_fraction ≈ 0, zero(L_MO), L_MO)
-    @. ustar = ifelse(area_fraction ≈ 0, zero(ustar), ustar)
-    @. buoyancy_flux = ifelse(area_fraction ≈ 0, zero(buoyancy_flux), buoyancy_flux)
 
     return (; F_turb_ρτxz, F_turb_ρτyz, F_shf, F_lhf, F_turb_moisture, L_MO, ustar, buoyancy_flux)
 end
@@ -490,39 +479,58 @@ function compute_surface_fluxes!(
     inputs = FluxCalculator.surface_inputs(surface_scheme, input_args)
 
     # calculate the surface fluxes
-    fluxes = FluxCalculator.get_surface_fluxes!(inputs, surface_params, area_fraction)
-    (; F_turb_ρτxz, F_turb_ρτyz, F_shf, F_lhf, F_turb_moisture) = fluxes
+    fluxes = FluxCalculator.get_surface_fluxes!(inputs, surface_params)
+    (; F_turb_ρτxz, F_turb_ρτyz, F_shf, F_lhf, F_turb_moisture, L_MO, ustar, buoyancy_flux) = fluxes
+
+
+    # Zero out fluxes where the area fraction is zero
+    # Multiplying by `area_fraction` is not sufficient because the fluxes may
+    # be NaN where the area fraction is zero.
+    @. F_turb_ρτxz = ifelse(area_fraction ≈ 0, zero(F_turb_ρτxz), F_turb_ρτxz)
+    @. F_turb_ρτyz = ifelse(area_fraction ≈ 0, zero(F_turb_ρτyz), F_turb_ρτyz)
+    @. F_shf = ifelse(area_fraction ≈ 0, zero(F_shf), F_shf)
+    @. F_lhf = ifelse(area_fraction ≈ 0, zero(F_lhf), F_lhf)
+    @. F_turb_moisture = ifelse(area_fraction ≈ 0, zero(F_turb_moisture), F_turb_moisture)
+    @. L_MO = ifelse(area_fraction ≈ 0, zero(L_MO), L_MO)
+    @. ustar = ifelse(area_fraction ≈ 0, zero(ustar), ustar)
+    @. buoyancy_flux = ifelse(area_fraction ≈ 0, zero(buoyancy_flux), buoyancy_flux)
+
+    # multiply fluxes by area fraction
+    F_turb_ρτxz .*= area_fraction
+    F_turb_ρτyz .*= area_fraction
+    F_shf .*= area_fraction
+    F_lhf .*= area_fraction
+    F_turb_moisture .*= area_fraction
 
     # perform additional diagnostics if required
     FluxCalculator.differentiate_turbulent_fluxes!(sim, (thermo_params, input_args, fluxes))
 
-    # update fluxes in the coupler
+    # update the fluxes, which are now area-weighted, of this surface model
     fields = (;
         F_turb_ρτxz = F_turb_ρτxz,
         F_turb_ρτyz = F_turb_ρτyz,
         F_turb_energy = F_shf .+ F_lhf,
         F_turb_moisture = F_turb_moisture,
     )
-
-    # update the fluxes of this surface model
     FluxCalculator.update_turbulent_fluxes!(sim, fields)
 
+    # update fluxes in the coupler fields
     # add the flux contributing from this surface to the coupler field
-    # note that the fluxes are area-weighted, so if a surface model is
-    #  not present at this point, the fluxes are zero
-    @. csf.F_turb_ρτxz += F_turb_ρτxz * area_fraction
-    @. csf.F_turb_ρτyz += F_turb_ρτyz * area_fraction
-    @. csf.F_turb_energy += (F_shf .+ F_lhf) * area_fraction
-    @. csf.F_turb_moisture += F_turb_moisture * area_fraction
+    # note that the fluxes area-weighted, so if a surface model is
+    #  not present at a point, the fluxes are zero
+    @. csf.F_turb_ρτxz += F_turb_ρτxz
+    @. csf.F_turb_ρτyz += F_turb_ρτyz
+    @. csf.F_turb_energy += (F_shf .+ F_lhf)
+    @. csf.F_turb_moisture += F_turb_moisture
 
     # NOTE: This is still an area weighted contribution, which maybe doesn't make
     # too much sense for these quantities...
 
     # L_MO can be Inf. We don't want to multiply Inf * 0, so we can handle this
     # separately.
-    @. csf.L_MO += ifelse(isinf(fluxes.L_MO), fluxes.L_MO, fluxes.L_MO * area_fraction)
-    @. csf.ustar += fluxes.ustar * area_fraction
-    @. csf.buoyancy_flux += fluxes.buoyancy_flux * area_fraction
+    @. csf.L_MO += ifelse(isinf(L_MO), L_MO, L_MO * area_fraction)
+    @. csf.ustar += ustar * area_fraction
+    @. csf.buoyancy_flux += buoyancy_flux * area_fraction
 
     z0m = Interfacer.get_field(sim, Val(:roughness_momentum))
     z0b = Interfacer.get_field(sim, Val(:roughness_buoyancy))

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -11,30 +11,7 @@ import ClimaCore as CC
 import Logging
 import ClimaUtilities.OutputPathGenerator: generate_output_path
 
-export binary_mask, swap_space!, get_device, get_comms_context, show_memory_usage, setup_output_dirs, time_to_seconds
-
-"""
-    binary_mask(var, threshold)
-
-Converts a number `var` to 1, if `var` is greater or equal than a given `threshold` value,
-or 0 otherwise, keeping the same type.
-
-# Arguments
-- `var`: [FT] value to be converted.
-- `threshold`: [FT] cutoff value for conversions.
-"""
-binary_mask(var, threshold) = var >= threshold ? one(var) : zero(var)
-
-"""
-    binary_mask(var)
-
-Converts a number `var` to 1, if `var` is greater or equal than `eps(FT)`,
-or 0 otherwise, keeping the same type.
-
-# Arguments
-- `var`: [FT] value to be converted.
-"""
-binary_mask(var) = binary_mask(var, eps(eltype(var)))
+export swap_space!, get_device, get_comms_context, show_memory_usage, setup_output_dirs, time_to_seconds
 
 """
     swap_space!(space_out::CC.Spaces.AbstractSpace, field_in::CC.Fields.Field)

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -224,11 +224,11 @@ for FT in (Float32, Float64)
             coupler_fields =
                 NamedTuple{coupler_names}(ntuple(i -> CC.Fields.zeros(boundary_space), length(coupler_names)))
             FieldExchanger.import_atmos_fields!(coupler_fields, model_sims, t)
-            @test Array(parent(coupler_fields.F_turb_energy))[1] == results[i]
-            @test Array(parent(coupler_fields.F_turb_moisture))[1] == results[i]
-            @test Array(parent(coupler_fields.F_radiative))[1] == results[1]
-            @test Array(parent(coupler_fields.P_liq))[1] == results[1]
-            @test Array(parent(coupler_fields.P_snow))[1] == results[1]
+            @test all(Array(parent(coupler_fields.F_turb_energy)) .== results[i])
+            @test all(Array(parent(coupler_fields.F_turb_moisture)) .== results[i])
+            @test all(Array(parent(coupler_fields.F_radiative)) .== results[1])
+            @test all(Array(parent(coupler_fields.P_liq)) .== results[1])
+            @test all(Array(parent(coupler_fields.P_snow)) .== results[1])
         end
     end
 
@@ -323,32 +323,32 @@ for FT in (Float32, Float64)
             FieldExchanger.update_model_sims!(model_sims, coupler_fields, t)
 
             # test atmos
-            @test Array(parent(model_sims.atmos_sim.cache.albedo_direct))[1] == results[2]
-            @test Array(parent(model_sims.atmos_sim.cache.albedo_diffuse))[1] == results[3]
+            @test all(Array(parent(model_sims.atmos_sim.cache.albedo_direct)) .== results[2])
+            @test all(Array(parent(model_sims.atmos_sim.cache.albedo_diffuse)) .== results[3])
             if t isa FluxCalculator.CombinedStateFluxesMOST
-                @test Array(parent(model_sims.atmos_sim.cache.roughness_momentum))[1] == results[2]
+                @test all(Array(parent(model_sims.atmos_sim.cache.roughness_momentum)) .== results[2])
             else
-                @test Array(parent(model_sims.atmos_sim.cache.roughness_momentum))[1] == results[1]
+                @test all(Array(parent(model_sims.atmos_sim.cache.roughness_momentum)) .== results[1])
             end
 
             # test variables without updates
-            @test Array(parent(model_sims.atmos_sim.cache.surface_temperature))[1] == results[1]
-            @test Array(parent(model_sims.atmos_sim.cache.beta))[1] == results[1]
-            @test Array(parent(model_sims.atmos_sim.cache.roughness_buoyancy))[1] == results[1]
+            @test all(Array(parent(model_sims.atmos_sim.cache.surface_temperature)) .== results[1])
+            @test all(Array(parent(model_sims.atmos_sim.cache.beta)) .== results[1])
+            @test all(Array(parent(model_sims.atmos_sim.cache.roughness_buoyancy)) .== results[1])
 
-            # test surface
-            @test Array(parent(model_sims.land_sim.cache.turbulent_energy_flux))[1] == results[2] # assuming units / m2
-            @test Array(parent(model_sims.land_sim.cache.turbulent_moisture_flux))[1] == results[2]
+            # test surface (fluxes must be multiplied by this surface's area fraction)
+            area_fraction = Interfacer.get_field(model_sims.land_sim, Val(:area_fraction))
+            @test all(Array(parent(model_sims.land_sim.cache.turbulent_energy_flux)) .== results[2] .* area_fraction) # assuming units / m2
+            @test all(Array(parent(model_sims.land_sim.cache.turbulent_moisture_flux)) .== results[2] .* area_fraction)
 
             # test variables without updates
-            @test Array(parent(model_sims.land_sim.cache.radiative_energy_flux_sfc))[1] == results[1]
-            @test Array(parent(model_sims.land_sim.cache.liquid_precipitation))[1] == results[1]
-            @test Array(parent(model_sims.land_sim.cache.snow_precipitation))[1] == results[1]
+            @test all(Array(parent(model_sims.land_sim.cache.radiative_energy_flux_sfc)) .== results[1])
+            @test all(Array(parent(model_sims.land_sim.cache.liquid_precipitation)) .== results[1])
+            @test all(Array(parent(model_sims.land_sim.cache.snow_precipitation)) .== results[1])
 
             # test stub - albedo should be updated by update_sim!
-            @test Array(parent(model_sims.stub_sim.cache.albedo_direct))[1] == results[2]
-            @test Array(parent(model_sims.stub_sim.cache.albedo_diffuse))[1] == results[2]
-
+            @test all(Array(parent(model_sims.stub_sim.cache.albedo_direct)) .== results[2])
+            @test all(Array(parent(model_sims.stub_sim.cache.albedo_diffuse)) .== results[2])
         end
     end
     @testset "reinit_model_sims! for FT=$FT" begin

--- a/test/utilities_tests.jl
+++ b/test/utilities_tests.jl
@@ -55,12 +55,4 @@ for FT in (Float32, Float64)
         @test typeof(Utilities.get_comms_context(parsed_args)) ==
               typeof(ClimaComms.context(ClimaComms.CPUSingleThreaded()))
     end
-
-    @testset "test binary_mask" begin
-        space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4)
-        @test all(parent(Utilities.binary_mask.(zeros(space))) .== 0)
-        @test all(parent(Utilities.binary_mask.(ones(space))) .== 1)
-        @test all(parent(Utilities.binary_mask.(fill(FT(0.5), space), FT(0.6))) .== 0)
-        @test all(parent(Utilities.binary_mask.(fill(FT(0.5), space), FT(0.4))) .== 1)
-    end
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #1255

## Content
- remove `area_mask` and use `area_fraction` instead, which is maintained to sum to 1 across components at each point
- remove the `mono_surface` option, which was rarely used and did not do what it was documented to do
- don't multiply by `area_fraction` in RHS calculations; only use `area_fraction` for flux calculations/exchanges
  - While multiplying the RHS by area fraction should be okay when using a binary area fraction, it may lead to incorrect values along coasts when using fractional area fractions because we multiply by the area fraction multiple times (fluxes and RHS). Now, the use of area fractions is limited to flux calcuations.

Note that simulations which previously used `mono_surface: true` will have changed results because we're no longer using fractional area fractions along coastlines. Among other things, this results in conservation changes - conservation is slightly improved after this PR.