### PR TITLE
Close Bucket output writer at end of simulation

### DIFF
--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -27,15 +27,18 @@ It contains the following objects:
 - `model::M`: The `ClimaLand.Bucket.BucketModel`.
 - `integrator::I`: The integrator used in timestepping this model.
 - `area_fraction::A`: A ClimaCore Field representing the surface area fraction of this component model.
+- `output_writer`: The diagnostic file writer.
 """
 struct BucketSimulation{
     M <: ClimaLand.Bucket.BucketModel,
     I <: SciMLBase.AbstractODEIntegrator,
     A <: CC.Fields.Field,
+    OW,
 } <: Interfacer.LandModelSimulation
     model::M
     integrator::I
     area_fraction::A
+    output_writer::OW
 end
 Interfacer.name(::BucketSimulation) = "BucketSimulation"
 
@@ -214,13 +217,14 @@ function BucketSimulation(
 
     # Add diagnostics
     if use_land_diagnostics
-        netcdf_writer = CD.Writers.NetCDFWriter(domain.space.subsurface, output_dir)
+        output_writer = CD.Writers.NetCDFWriter(domain.space.subsurface, output_dir)
         scheduled_diagnostics =
-            CL.default_diagnostics(model, start_date, output_writer = netcdf_writer, average_period = :monthly)
+            CL.default_diagnostics(model, start_date, output_writer = output_writer, average_period = :monthly)
 
         diagnostic_handler = CD.DiagnosticsHandler(scheduled_diagnostics, Y, p, tspan[1]; dt = dt)
         diag_cb = CD.DiagnosticsCallback(diagnostic_handler)
     else
+        output_writer = nothing
         diag_cb = nothing
     end
 
@@ -233,7 +237,7 @@ function BucketSimulation(
         callback = SciMLBase.CallbackSet(diag_cb),
     )
 
-    return BucketSimulation(model, integrator, area_fraction)
+    return BucketSimulation(model, integrator, area_fraction, output_writer)
 end
 
 # extensions required by Interfacer

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -659,6 +659,7 @@ function run!(cs::CoupledSimulation; precompile = (cs.tspan[end] > 2 * cs.Δt_cp
     # Close all diagnostics file writers
     isnothing(cs.diags_handler) || foreach(diag -> close(diag.output_writer), cs.diags_handler.scheduled_diagnostics)
     isnothing(cs.model_sims.atmos_sim.output_writers) || foreach(close, cs.model_sims.atmos_sim.output_writers)
+    isnothing(cs.model_sims.land_sim.output_writer) || close(cs.model_sims.land_sim.output_writer)
     return nothing
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR enables other processes to access BucketSimulation diagnostics without closing the process that ran the model. I think this is small enough not to require a NEWS.md entry.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Added `output_writer` field to `BucketSimulation` and `ClimaLandSimulation`
- closed `output_writer` at the end of `setup_run` 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
