### PR TITLE
remove `nans_to_zero`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Remove `nans_to_zero`. PR[#1278](https://github.com/CliMA/ClimaCoupler.jl/pull/1278)
+Instead of zeroing out all NaNs in a surface field, we zero out all values
+where the area fraction is 0, which is logically what we want to do.
+
 #### Remove `area_mask`, `binary_mask`, `mono_surface`. [PR#1268](https://github.com/CliMA/ClimaCoupler.jl/pull/1268/files)
 Removes all uses of `area_mask`, as multiplying quantities by both `area_fraction`
 and `area_mask` will potentially lead to physically inaccurate results.

--- a/docs/src/fieldexchanger.md
+++ b/docs/src/fieldexchanger.md
@@ -30,5 +30,4 @@ If an `update_field!` function is not defined for a particular component model, 
 ```@docs
     ClimaCoupler.FieldExchanger.combine_surfaces!
     ClimaCoupler.FieldExchanger.dummmy_remap!
-    ClimaCoupler.FieldExchanger.nans_to_zero
 ```


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Instead of zeroing out all NaNs in a surface field, we zero out all values where the area fraction is 0. This ensures that a surface model does indeed not contribute where it isn't present, and that meaningful (i.e. bug- or instability-indicating) NaNs are not removed.

closes #1267

This PR is similar in intention to #1268

