### PR TITLE
Remove surface_scheme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,11 @@ ClimaCoupler.jl Release Notes
 Instead of zeroing out all NaNs in a surface field, we zero out all values
 where the area fraction is 0, which is logically what we want to do.
 
+#### Removed `SurfaceScheme`. PR[#1280](https://github.com/CliMA/ClimaCoupler.jl/pull/1280)
+
+The `BulkScheme` option for computing fluxes was removed. Now, fluxes
+are always computed with the `MoninObukhovScheme`.
+
 #### Removed `CombinedStateFluxes`. PR[#1276](https://github.com/CliMA/ClimaCoupler.jl/pull/1276)
 
 The `CombinedStateFluxes` option for computing fluxes was removed. Now, fluxes

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -520,38 +520,6 @@ function get_atmos_config_dict(coupler_dict::Dict, job_id::String, atmos_output_
 end
 
 
-# flux calculation borrowed from atmos
-"""
-    CoupledMoninObukhov()
-A modified version of a Monin-Obukhov surface for the Coupler, see the link below for more information
-https://clima.github.io/SurfaceFluxes.jl/dev/SurfaceFluxes/#Monin-Obukhov-Similarity-Theory-(MOST)
-"""
-struct CoupledMoninObukhov end
-"""
-    coupler_surface_setup(::CoupledMoninObukhov, p, csf_sfc = (; T = nothing, z0m = nothing, z0b = nothing, beta = nothing, q_vap = nothing))
-
-Sets up `surface_setup` as a `CC.Fields.Field` of `SurfaceState`s.
-"""
-function coupler_surface_setup(
-    ::CoupledMoninObukhov,
-    p,
-    T = nothing,
-    z0m = nothing,
-    z0b = nothing,
-    beta = nothing,
-    q_vap = nothing,
-)
-
-    surface_state(z0m, z0b, T, beta, q_vap) = CA.SurfaceConditions.SurfaceState(;
-        parameterization = CA.SurfaceConditions.MoninObukhov(; z0m, z0b),
-        T,
-        beta,
-        q_vap,
-    )
-    surface_state_field = @. surface_state(z0m, z0b, T, beta, q_vap)
-    return surface_state_field
-end
-
 """
     get_thermo_params(sim::ClimaAtmosSimulation)
 

--- a/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/eisenman_seaice.jl
@@ -238,12 +238,11 @@ function FluxCalculator.differentiate_turbulent_fluxes!(
     fluxes;
     δT_sfc = 0.1,
 )
-    (; thermo_state_int, surface_params, surface_scheme) = input_args
+    (; thermo_state_int, surface_params) = input_args
     thermo_state_sfc_dT = FluxCalculator.surface_thermo_state(sim, thermo_params, thermo_state_int, δT_sfc = δT_sfc)
     input_args = merge(input_args, (; thermo_state_sfc = thermo_state_sfc_dT))
 
-    # set inputs based on whether the surface_scheme is `MoninObukhovScheme` or `BulkScheme`
-    inputs = FluxCalculator.surface_inputs(surface_scheme, input_args)
+    inputs = FluxCalculator.surface_inputs(input_args)
 
     # calculate the surface fluxes
     area_fraction = Interfacer.get_field(sim, Val(:area_fraction))

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -541,13 +541,7 @@ function CoupledSimulation(config_dict::AbstractDict)
         # turbulent surface fluxes
 
         ## calculate turbulent fluxes in surface models and save the weighted average in coupler fields
-        FluxCalculator.turbulent_fluxes!(
-            cs.model_sims,
-            cs.fields,
-            cs.boundary_space,
-            FluxCalculator.MoninObukhovScheme(),
-            cs.thermo_params,
-        )
+        FluxCalculator.turbulent_fluxes!(cs.model_sims, cs.fields, cs.boundary_space, cs.thermo_params)
 
         # Updating only surface temperature because it is required by the RRTGMP callback (
         # called below at reinit). Turbulent fluxes in atmos are updated in `update_model_sims`.
@@ -720,13 +714,7 @@ function step!(cs::CoupledSimulation)
     ## update the coupler with the new surface properties and calculate the turbulent fluxes
     FieldExchanger.import_combined_surface_fields!(cs.fields, cs.model_sims) # i.e. T_sfc, surface_albedo, z0, beta
     ## calculate turbulent fluxes in surfaces and save the weighted average in coupler fields
-    FluxCalculator.turbulent_fluxes!(
-        cs.model_sims,
-        cs.fields,
-        cs.boundary_space,
-        FluxCalculator.MoninObukhovScheme(),
-        cs.thermo_params,
-    )
+    FluxCalculator.turbulent_fluxes!(cs.model_sims, cs.fields, cs.boundary_space, cs.thermo_params)
 
     Interfacer.update_field!(atmos_sim, Val(:surface_temperature), cs.fields)
 

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -125,10 +125,9 @@ for FT in (Float32, Float64)
     end
 
     @testset "calculate correct fluxes: dry for FT=$FT" begin
-        scheme = FluxCalculator.MoninObukhovScheme()
         boundary_space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4)
 
-        params = (; surface_scheme = scheme, FT = FT)
+        params = (; FT = FT)
 
         # atmos
         p = (;
@@ -188,11 +187,11 @@ for FT in (Float32, Float64)
 
         # calculate turbulent fluxes
         thermo_params = get_thermo_params(atmos_sim)
-        FluxCalculator.turbulent_fluxes!(model_sims, fields, boundary_space, scheme, thermo_params)
+        FluxCalculator.turbulent_fluxes!(model_sims, fields, boundary_space, thermo_params)
 
         # calculating the fluxes twice ensures that no accumulation occurred (i.e. fluxes are reset to zero each time)
         # TODO: this will need to be extended once flux accumulation is re-enabled
-        FluxCalculator.turbulent_fluxes!(model_sims, fields, boundary_space, scheme, thermo_params)
+        FluxCalculator.turbulent_fluxes!(model_sims, fields, boundary_space, thermo_params)
 
         windspeed = @. hypot(atmos_sim.integrator.p.u, atmos_sim.integrator.p.v)
 


### PR DESCRIPTION
Now that PartitionedStateFluxes is the default flux calculator, we can
remove options for surface schemes and focus on the one we want to use.

I also found this `CoupledMoninObukhov()` in `climaatmos.jl` which I
don't think we are using, so I removed that too.
