### PR TITLE
Fix calibration test, lower resource requirements

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -328,7 +328,7 @@ steps:
     agents:
       queue: clima
       slurm_mem: 96GB
-      slurm_ntasks: 5
+      slurm_ntasks: 3
       slurm_gpus_per_task: 1
       slurm_cpus_per_task: 4
       slurm_time: 05:00:00

--- a/experiments/calibration/Project.toml
+++ b/experiments/calibration/Project.toml
@@ -31,5 +31,5 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
-ClimaCalibrate = "0.0.10"
+ClimaCalibrate = "0.0.15"
 ClimaTimeSteppers = "0.8.2"

--- a/experiments/calibration/model_config.yml
+++ b/experiments/calibration/model_config.yml
@@ -1,14 +1,14 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/longrun_configs/amip_target_diagedmf.yml"
-checkpoint_dt: "720hours"
+checkpoint_dt: "90000days"
 coupler_toml: ["toml/amip.toml"]
 deep_atmosphere: false
-dt: "240secs"
-dt_cpl: "240secs"
+dt: "480secs"
+dt_cpl: "480secs"
 dz_bottom: 100.0
 energy_check: false
-h_elem: 8
+h_elem: 4
 land_albedo_type: "map_temporal"
 mode_name: "amip"
 netcdf_interpolation_num_points: [90, 45, 31]

--- a/experiments/calibration/model_interface.jl
+++ b/experiments/calibration/model_interface.jl
@@ -9,7 +9,7 @@ function ClimaCalibrate.forward_model(iter, member)
     output_dir_root = config_dict["coupler_output_dir"]
     # Set member parameter file
     sampled_parameter_file = ClimaCalibrate.parameter_path(output_dir_root, iter, member)
-    config_dict["calibration_toml"] = sampled_parameter_file
+    config_dict["coupler_toml"] = [sampled_parameter_file]
     # Set member output directory
     member_output_dir = ClimaCalibrate.path_to_ensemble_member(output_dir_root, iter, member)
     config_dict["coupler_output_dir"] = member_output_dir

--- a/experiments/calibration/run_calibration.jl
+++ b/experiments/calibration/run_calibration.jl
@@ -5,14 +5,16 @@ using ClimaAnalysis
 import ClimaAnalysis: SimDir, get, slice, average_xy
 import ClimaComms
 import EnsembleKalmanProcesses: I, ParameterDistributions.constrained_gaussian
+import EnsembleKalmanProcesses as EKP
+using Statistics
 
 # Ensure ClimaComms doesn't use MPI
 ENV["CLIMACOMMS_CONTEXT"] = "SINGLETON"
 ClimaComms.@import_required_backends
 
-single_member_dims = (1,)
+single_member_dims = 1
 function CAL.observation_map(iteration)
-    G_ensemble = Array{Float64}(undef, single_member_dims..., ensemble_size)
+    G_ensemble = Array{Float64}(undef, single_member_dims, ensemble_size)
 
     for m in 1:ensemble_size
         member_path = CAL.path_to_ensemble_member(output_dir, iteration, m)
@@ -29,9 +31,8 @@ function CAL.observation_map(iteration)
 end
 
 function process_member_data(simdir::SimDir)
-    output = zeros(single_member_dims...)
+    output = zeros(single_member_dims)
     days = 86_400
-    isempty(simdir) && return NaN
 
     rsut = get(simdir; short_name = "rsut", reduction = "average", period = "30d")
     rsut_slice = slice(average_lon(average_lat(rsut)); time = 30days).data
@@ -54,7 +55,6 @@ addprocs(CAL.SlurmManager())
 end
 
 # Experiment Configuration
-ensemble_size = 10
 n_iterations = 5
 noise = 0.1 * I
 prior = constrained_gaussian("total_solar_irradiance", 1000, 500, 250, 2000)
@@ -68,14 +68,20 @@ if !isfile(obs_path)
     touch(joinpath(obs_output_dir, "parameters.toml"))
     CAL.forward_model(0, 0)
     observations = Vector{Float64}(undef, 1)
-    observations .= process_member_data(SimDir(joinpath(obs_output_dir, "amip_config/output_active/clima_atmos")))
+    observations .= process_member_data(SimDir(joinpath(obs_output_dir, "model_config/output_active/clima_atmos")))
     JLD2.save_object(obs_path, observations)
 end
+observations = JLD2.load_object(obs_path)
+@show observations
+u0_mean = [mean(prior)]
+uu0_cov = cov(prior)
+eki = EKP.EnsembleKalmanProcess(
+    EKP.ObservationSeries(EKP.Observation(observations, noise, "rsut")),
+    EKP.Unscented(u0_mean, uu0_cov),
+)
+ensemble_size = EKP.get_N_ens(eki)
 
-# Initialize experiment data
-@everywhere observations = JLD2.load_object(obs_path)
-
-eki = CAL.calibrate(CAL.WorkerBackend, ensemble_size, n_iterations, observations, noise, prior, output_dir)
+eki = CAL.calibrate(CAL.WorkerBackend, eki, n_iterations, prior, output_dir)
 
 # Postprocessing
 import EnsembleKalmanProcesses as EKP


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR fixes the longrun calibration test, closes #1265

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- Re-run the longrun test from this commit to ensure that the tests pass. In-progress build [here](https://buildkite.com/clima/climacoupler-longruns/builds/861). An existing passing build is [here](https://buildkite.com/clima/climacoupler-longruns/builds/857)

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Fixed the parameter filepath argument in `model_interface.jl` and the filepath in the observation generation. These changes alone fix the calibration test.
- Use Unscented Kalman Inversion instead of the default scheme, reducing the number of ensemble members and resources required to run the test
- Set a lower horizontal resolution and a higher timestep for the model config

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
