### PR TITLE
allow < 3 surface models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,12 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Allow < 3 surface models. PR[#1286](https://github.com/CliMA/ClimaCoupler.jl/pull/1286)
+
+Previously, land, ocean, and sea ice were all required to be defined, and the
+area fraction of a model would be set to 0 to exclude it. Now, a `CoupledSimulation`
+can be created with fewer than 4 components in `model_sims`.
+
 #### Change signature for `turbulent_fluxes!`. PR[#1327](https://github.com/CliMA/ClimaCoupler.jl/pull/1327)
 
 `FluxCalculator.turbulent_fluxes!` can now be called in two ways:
@@ -21,7 +27,7 @@ The new signature simplifies calling the function, ensures that the mutating
 convention is respected (`turbulent_fluxes!` mutates `coupler_fields`), and
 removes unnecessary arguments and type restrictions.
 
-Similarly, `get_surface_fluxes!` was renamed to `get_surface_fluxes`. 
+Similarly, `get_surface_fluxes!` was renamed to `get_surface_fluxes`.
 
 #### Simplify initial component model exchange. PR[#1305](https://github.com/CliMA/ClimaCoupler.jl/pull/1305)
 

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -97,7 +97,8 @@ end
 
 # Extension of CA.set_surface_albedo! to set the surface albedo to 0.38 at the beginning of the simulation,
 # so the initial callback initialization doesn't lead to NaNs in the radiation model.
-# Subsequently, the surface albedo will be updated by the coupler, via water_albedo_from_atmosphere!.
+# Subsequently, the surface albedo will be updated by the coupler, via
+# water_albedo_from_atmosphere!.
 function CA.set_surface_albedo!(Y, p, t, ::CA.CouplerAlbedo)
     if float(t) == 0
         FT = eltype(Y)
@@ -393,10 +394,17 @@ function Interfacer.add_coupler_fields!(coupler_field_names, atmos_sim::ClimaAtm
     push!(coupler_field_names, atmos_coupler_fields...)
 end
 
+"""
+    Interfacer.close_output_writers(sim::ClimaAtmosSimulation)
+
+Close all output writers used by the atmos simulation.
+"""
+Interfacer.close_output_writers(sim::ClimaAtmosSimulation) =
+    isnothing(sim.output_writers) || foreach(close, sim.output_writers)
+
 function FieldExchanger.update_sim!(sim::ClimaAtmosSimulation, csf)
     # TODO: This function should be removed once we remove cos_zenith_angle as
     # one of the exchange fields (and use the default method in FieldExchanger)
-
     u = sim.integrator.u
     p = sim.integrator.p
     t = sim.integrator.t
@@ -547,7 +555,6 @@ end
 
 """
     FluxCalculator.water_albedo_from_atmosphere!(sim::ClimaAtmosSimulation, direct_albedo::CC.Fields.Field, diffuse_albedo::CC.Fields.Field)
-
 Extension to calculate the water surface albedo from wind speed and insolation. It can be used for prescribed ocean and lakes.
 """
 function FluxCalculator.water_albedo_from_atmosphere!(

--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -302,8 +302,8 @@ function Interfacer.update_field!(sim::BucketSimulation, ::Val{:turbulent_moistu
     parent(sim.integrator.p.bucket.turbulent_fluxes.vapor_flux) .= parent(field ./ ρ_liq) # TODO: account for sublimation
 end
 
-# extensions required by FieldExchanger
 Interfacer.step!(sim::BucketSimulation, t) = Interfacer.step!(sim.integrator, t - sim.integrator.t, true)
+Interfacer.close_output_writers(sim::BucketSimulation) = isnothing(sim.output_writer) || close(sim.output_writer)
 
 """
 Extend Interfacer.add_coupler_fields! to add the fields required for BucketSimulation.

--- a/experiments/ClimaEarth/components/land/climaland_integrated.jl
+++ b/experiments/ClimaEarth/components/land/climaland_integrated.jl
@@ -426,6 +426,7 @@ function Interfacer.update_field!(sim::ClimaLandSimulation, ::Val{:cos_zenith}, 
 end
 
 Interfacer.step!(sim::ClimaLandSimulation, t) = Interfacer.step!(sim.integrator, t - sim.integrator.t, true)
+Interfacer.close_output_writers(sim::ClimaLandSimulation) = isnothing(sim.output_writer) || close(sim.output_writer)
 
 function FieldExchanger.update_sim!(sim::ClimaLandSimulation, csf, area_fraction)
     # update fields for radiative transfer

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -258,11 +258,11 @@ function CoupledSimulation(config_dict::AbstractDict)
     =#
 
     @info(sim_mode)
+    land_sim = ice_sim = ocean_sim = nothing
     if sim_mode <: AMIPMode
         @info("AMIP boundary conditions - do not expect energy conservation")
 
         ## land model
-        land_sim = nothing
         if land_model == "bucket"
             land_sim = BucketSimulation(
                 FT;
@@ -322,7 +322,6 @@ function CoupledSimulation(config_dict::AbstractDict)
 
     elseif (sim_mode <: AbstractSlabplanetSimulationMode)
 
-
         land_fraction = sim_mode <: SlabplanetAquaMode ? land_fraction .* 0 : land_fraction
         land_fraction = sim_mode <: SlabplanetTerraMode ? land_fraction .* 0 .+ 1 : land_fraction
 
@@ -357,22 +356,7 @@ function CoupledSimulation(config_dict::AbstractDict)
             evolving = evolving_ocean,
         )
 
-        ## sea ice stub (here set to zero area coverage)
-        ice_sim = Interfacer.SurfaceStub((;
-            T_sfc = ones(boundary_space),
-            ρ_sfc = zeros(boundary_space),
-            z0m = FT(0),
-            z0b = FT(0),
-            beta = FT(1),
-            α_direct = ones(boundary_space),
-            α_diffuse = ones(boundary_space),
-            area_fraction = zeros(boundary_space),
-            phase = TD.Ice(),
-            thermo_params = thermo_params,
-        ))
-
         Utilities.show_memory_usage()
-
     end
 
     #=
@@ -383,8 +367,10 @@ function CoupledSimulation(config_dict::AbstractDict)
     global `CoupledSimulation` struct, `cs`, below.
     =#
 
-    ## model simulations
-    model_sims = (atmos_sim = atmos_sim, ice_sim = ice_sim, land_sim = land_sim, ocean_sim = ocean_sim)
+    ## collect component model simulations that have been initialized
+    model_sims = (; atmos_sim, ice_sim, land_sim, ocean_sim)
+    model_sims = NamedTuple{filter(key -> !isnothing(model_sims[key]), keys(model_sims))}(model_sims)
+    @info "Component models initialized: $(keys(model_sims))"
 
     ## coupler exchange fields
     coupler_field_names = Interfacer.default_coupler_fields()
@@ -585,8 +571,8 @@ function run!(cs::CoupledSimulation; precompile = (cs.tspan[end] > 2 * cs.Δt_cp
 
     # Close all diagnostics file writers
     isnothing(cs.diags_handler) || foreach(diag -> close(diag.output_writer), cs.diags_handler.scheduled_diagnostics)
-    isnothing(cs.model_sims.atmos_sim.output_writers) || foreach(close, cs.model_sims.atmos_sim.output_writers)
-    isnothing(cs.model_sims.land_sim.output_writer) || close(cs.model_sims.land_sim.output_writer)
+    foreach(Interfacer.close_output_writers, cs.model_sims)
+
     return nothing
 end
 
@@ -652,7 +638,6 @@ require multiple steps in some of the component models.
 """
 function step!(cs::CoupledSimulation)
     (; model_sims, Δt_cpl, tspan, comms_ctx) = cs
-    (; atmos_sim, land_sim, ocean_sim, ice_sim) = model_sims
 
     # Update the current time
     cs.t[] += Δt_cpl

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -20,6 +20,8 @@ export update_sim!, update_model_sims!, step_model_sims!, exchange!
 Updates dynamically changing area fractions.
 Maintains the invariant that the sum of area fractions is 1 at all points.
 
+If a surface model is not present, the area fraction is set to 0.
+
 # Arguments
 - `cs`: [Interfacer.CoupledSimulation] containing area fraction information.
 """
@@ -28,24 +30,37 @@ function update_surface_fractions!(cs::Interfacer.CoupledSimulation)
     FT = CC.Spaces.undertype(boundary_space)
 
     # land fraction is static
-    land_fraction = Interfacer.get_field(cs.model_sims.land_sim, Val(:area_fraction), boundary_space)
+    if haskey(cs.model_sims, :land_sim)
+        land_fraction = Interfacer.get_field(cs.model_sims.land_sim, Val(:area_fraction), boundary_space)
+    else
+        cs.fields.temp1 .= 0
+        land_fraction = cs.fields.temp1
+    end
 
     # ice and ocean fractions are dynamic
-    ice_fraction_before = Interfacer.get_field(cs.model_sims.ice_sim, Val(:area_fraction), boundary_space)
-    # max needed to avoid Float32 errors (see issue #271; Heisenbug on HPC)
-    Interfacer.update_field!(
-        cs.model_sims.ice_sim,
-        Val(:area_fraction),
-        max.(min.(ice_fraction_before, FT(1) .- land_fraction), FT(0)),
-    )
-    ice_fraction = Interfacer.get_field(cs.model_sims.ice_sim, Val(:area_fraction), boundary_space)
+    if haskey(cs.model_sims, :ice_sim)
+        ice_sim = cs.model_sims.ice_sim
+        ice_fraction_before = Interfacer.get_field(ice_sim, Val(:area_fraction), boundary_space)
+        # max needed to avoid Float32 errors (see issue #271; Heisenbug on HPC)
+        Interfacer.update_field!(
+            ice_sim,
+            Val(:area_fraction),
+            max.(min.(ice_fraction_before, FT(1) .- land_fraction), FT(0)),
+        )
+        ice_fraction = Interfacer.get_field(ice_sim, Val(:area_fraction), boundary_space)
+    else
+        cs.fields.temp1 .= 0
+        ice_fraction = cs.fields.temp1
+    end
 
-    Interfacer.update_field!(
-        cs.model_sims.ocean_sim,
-        Val(:area_fraction),
-        max.(FT(1) .- ice_fraction .- land_fraction, FT(0)),
-    )
-    ocean_fraction = Interfacer.get_field(cs.model_sims.ocean_sim, Val(:area_fraction), boundary_space)
+    if haskey(cs.model_sims, :ocean_sim)
+        ocean_sim = cs.model_sims.ocean_sim
+        Interfacer.update_field!(ocean_sim, Val(:area_fraction), max.(FT(1) .- ice_fraction .- land_fraction, FT(0)))
+        ocean_fraction = Interfacer.get_field(ocean_sim, Val(:area_fraction), boundary_space)
+    else
+        cs.fields.temp1 .= 0
+        ocean_fraction = cs.fields.temp1
+    end
 
     # check that the sum of area fractions is 1
     @assert minimum(ice_fraction .+ land_fraction .+ ocean_fraction) ≈ FT(1)

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -322,6 +322,16 @@ function will be called and an error will be raised.
 """
 step!(sim::ComponentModelSimulation, t) = error("undefined step! for $(nameof(sim))")
 
+"""
+    close_output_writers(sim::ComponentModelSimulation)
+
+A function to close all output writers associated with the given
+component model, at the end of a simulation.
+
+This should be extended for any component model that uses
+an output writer.
+"""
+close_output_writers(sim::ComponentModelSimulation) = nothing
 
 # Include file containing the surface stub simulation type.
 include("surface_stub.jl")


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Don't hardcode 4 component models (atmos, land, ocean, sea ice).
closes #1069


## To-do
- [x] generalize output writer closing via `Interfacer.close_output_writers!` function
- [x] in `model_sims`, only include surface models that are present
- [x] write `update_surface_fractions` to handle case of a surface model not present

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
