### PR TITLE
create atmos, surface thermo states from remapped T, q, rho

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,12 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Construct thermo states from exchanged T, q, ρ. PR[#1293](https://github.com/CliMA/ClimaCoupler.jl/pull/1293)
+
+Instead of exchanging atmosphere and surface thermo states, exchange T, q, ρ
+and use these to construct the thermo states. This will be necessary as we
+run with models on different grids and require real remapping.
+
 #### Allow < 3 surface models. PR[#1286](https://github.com/CliMA/ClimaCoupler.jl/pull/1286)
 
 Previously, land, ocean, and sea ice were all required to be defined, and the

--- a/docs/src/fieldexchanger.md
+++ b/docs/src/fieldexchanger.md
@@ -28,6 +28,7 @@ If an `update_field!` function is not defined for a particular component model, 
     ClimaCoupler.FieldExchanger.step_model_sims!
     ClimaCoupler.FieldExchanger.update_surface_fractions!
     ClimaCoupler.FieldExchanger.exchange!
+    ClimaCoupler.FieldExchanger.set_caches!
 ```
 
 ## FieldExchanger Internal Functions

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -106,6 +106,13 @@ this function for both `AtmosModelSimulation` and
 the coupler. This function will need to be extended for any model
 that requires additional fields (specified via `add_coupler_fields!`).
 
+- `set_cache!(sim::ComponentModelSimulation)`: A function to perform any
+initialization of the component model caches that isn't done during the model
+simulation initialization, and that must be done after the initial exchange.
+This is necessary, for example, when component models have cache
+interdependencies that must be handled in a specific order.
+Cache variables that are computed as part of the tendencies do not need to be set here.
+
 ### AtmosModelSimulation - required functions
 In addition to the functions required for a general
 `ComponentModelSimulation`, an `AtmosModelSimulation` requires the
@@ -117,7 +124,9 @@ for the following properties:
 
 | Coupler name                | Description                                                               | Units      |
 |-----------------------------+---------------------------------------------------------------------------+------------|
-| `air_density`               | air density of the atmosphere                                             | kg m⁻³     |
+| `air_density`               | air density at the bottom cell centers of the atmosphere                  | kg m⁻³     |
+| `air_pressure`              | air pressure at the bottom cell centers of the atmosphere                 | Pa         |
+| `air_temperature`           | air temperature at the bottom cell centers of the atmosphere              | K          |
 | `height_int`                | height at the first internal model level                                  | m          |
 | `height_sfc`                | height at the surface                                                     | m          |
 | `liquid_precipitation`      | liquid precipitation at the surface                                       | kg m⁻² s⁻¹ |
@@ -171,8 +180,6 @@ for the following properties:
 
 | Coupler name        | Description                                                    | Units   |
 |---------------------+----------------------------------------------------------------+---------|
-| `air_pressure`      | air pressure at the bottom cell centers of the atmosphere      | Pa      |
-| `air_temperature`   | air temperature at the bottom cell centers of the atmosphere   | K       |
 | `cos_zenith`        | cosine of the zenith angle                                     |         |
 | `co2`               | global mean co2                                                | ppm     |
 | `diffuse_fraction`  | fraction of downwards shortwave flux that is direct            |         |
@@ -180,7 +187,7 @@ for the following properties:
 | `LW_d`              | downwards longwave flux                                        | W m⁻²   |
 | `SW_d`              | downwards shortwave flux                                       | W m⁻²   |
 
-Note that `air_temperature`, `air_pressure`, `cos_zenith`, `co2`, `diffuse_fraction`, `LW_d` and
+Note that `cos_zenith`, `co2`, `diffuse_fraction`, `LW_d` and
 `SW_d` will not be present in a `ClimaAtmosSimulation` if the model is setup with no radiation.
 Because of this, a `ClimaAtmosSimulation` must have radiation if running with the full `ClimaLand` model.
 
@@ -199,7 +206,6 @@ for the following properties:
 | `roughness_momentum`     | aerodynamic roughness length for momentum                      | m       |
 | `surface_direct albedo`  | bulk direct surface albedo                                     |         |
 | `surface_diffuse albedo` | bulk diffuse surface albedo                                    |         |
-| `surface_humidity`       | surface humidity                                               | kg kg⁻¹ |
 | `surface_temperature`    | surface temperature                                            | K       |
 
 
@@ -290,6 +296,7 @@ end
     ClimaCoupler.Interfacer.SlabplanetMode
     ClimaCoupler.Interfacer.SlabplanetAquaMode
     ClimaCoupler.Interfacer.SlabplanetTerraMode
+    ClimaCoupler.Interfacer.set_cache!
     ClimaCoupler.Interfacer.remap
     ClimaCoupler.Interfacer.remap!
 ```

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -226,6 +226,8 @@ Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:air_temperature}) =
         sim.integrator.p.params.thermodynamics_params,
         CC.Fields.level(sim.integrator.p.precomputed.ᶜts, 1),
     )
+Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:air_density}) =
+    TD.air_density.(sim.integrator.p.params.thermodynamics_params, CC.Fields.level(sim.integrator.p.precomputed.ᶜts, 1))
 function Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:cos_zenith})
     hasradiation(sim.integrator) || return nothing
     return CC.Fields.array2field(
@@ -271,7 +273,6 @@ function Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:LW_d})
 end
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:specific_humidity}) =
     CC.Fields.level(ρq_tot(sim.integrator.p.atmos.moisture_model, sim.integrator) ./ sim.integrator.u.c.ρ, 1)
-Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:air_density}) = CC.Fields.level(sim.integrator.u.c.ρ, 1)
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:radiative_energy_flux_sfc}) =
     surface_radiation_flux(sim.integrator.p.atmos.radiation_mode, sim.integrator)
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:snow_precipitation}) =
@@ -293,11 +294,21 @@ function Interfacer.update_field!(sim::ClimaAtmosSimulation, ::Val{:surface_temp
     # it.
     # The rrtmgp_model.surface_temperature field is updated by the RRTMGP callback using the
     # sfc_conditions.ts, so all we need to do is update sfc_conditions.ts
+
+    # Note also that this method updates the entire thermo state, not just the temperature
+
+    ρ_sfc =
+        FluxCalculator.extrapolate_ρ_to_sfc.(
+            get_thermo_params(sim),
+            sim.integrator.p.precomputed.sfc_conditions.ts,
+            csf.T_sfc,
+        )
+
     if sim.integrator.p.atmos.moisture_model isa CA.DryModel
-        sim.integrator.p.precomputed.sfc_conditions.ts .= TD.PhaseDry_ρT.(get_thermo_params(sim), csf.ρ_sfc, csf.T_sfc)
+        sim.integrator.p.precomputed.sfc_conditions.ts .= TD.PhaseDry_ρT.(get_thermo_params(sim), ρ_sfc, csf.T_sfc)
     else
         sim.integrator.p.precomputed.sfc_conditions.ts .=
-            TD.PhaseNonEquil_ρTq.(get_thermo_params(sim), csf.ρ_sfc, csf.T_sfc, TD.PhasePartition.(csf.q_sfc))
+            TD.PhaseNonEquil_ρTq.(get_thermo_params(sim), ρ_sfc, csf.T_sfc, TD.PhasePartition.(csf.q_sfc))
     end
 end
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:height_int}) =
@@ -383,14 +394,10 @@ Extend Interfacer.add_coupler_fields! to add the fields required for ClimaAtmosS
 The fields added are:
 - `:surface_direct_albedo` (for radiation)
 - `:surface_diffuse_albedo` (for radiation)
-- `:T_sfc` (for radiation)
-- `:q_sfc` (for moisture)
-- `:ρ_sfc` (for the thermal state)
 - `:ustar`, `:L_MO`, `:buoyancy_flux` (for EDMF boundary conditions)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, atmos_sim::ClimaAtmosSimulation)
-    atmos_coupler_fields =
-        [:surface_direct_albedo, :surface_diffuse_albedo, :T_sfc, :q_sfc, :ρ_sfc, :ustar, :L_MO, :buoyancy_flux]
+    atmos_coupler_fields = [:surface_direct_albedo, :surface_diffuse_albedo, :ustar, :L_MO, :buoyancy_flux]
     push!(coupler_field_names, atmos_coupler_fields...)
 end
 
@@ -420,19 +427,33 @@ function FieldExchanger.update_sim!(sim::ClimaAtmosSimulation, csf)
     Interfacer.update_field!(sim, Val(:turbulent_fluxes), csf)
 end
 
-"""
-    FluxCalculator.calculate_surface_air_density(sim::ClimaAtmosSimulation, T_sfc::CC.Fields.Field)
-
-Extension for this function to calculate surface density.
-"""
-function FluxCalculator.calculate_surface_air_density(sim::ClimaAtmosSimulation, T_sfc::CC.Fields.Field)
-    thermo_params = get_thermo_params(sim)
-    ts_int = Interfacer.get_field(sim, Val(:thermo_state_int))
-    FluxCalculator.extrapolate_ρ_to_sfc.(Ref(thermo_params), ts_int, Utilities.swap_space!(axes(ts_int.ρ), T_sfc))
-end
-
 # FluxCalculator.get_surface_params required by FluxCalculator (partitioned fluxes)
 FluxCalculator.get_surface_params(sim::ClimaAtmosSimulation) = CAP.surface_fluxes_params(sim.integrator.p.params)
+
+"""
+    Interfacer.set_cache!(sim::ClimaAtmosSimulation)
+
+Set cache variables that cannot be initialized before the initial exchange.
+Radiation must be called here because it requires the surface model initial
+temperatures, which are set in the atmosphere during the initial exchange.
+Any other callbacks which modify the cache should be called here as well.
+
+This function does not set all the cache variables, because many are computed
+as part of the tendendencies.
+"""
+function Interfacer.set_cache!(sim::ClimaAtmosSimulation)
+    if hasradiation(sim.integrator)
+        CA.rrtmgp_model_callback!(sim.integrator)
+        if pkgversion(CA) == v"0.30" && !isnothing(sim.integrator.p.atmos.non_orographic_gravity_wave)
+            # In version 0.30, nogw_model_callback crashes when there are no gravity waves,
+            # see CA #3792
+            CA.nogw_model_callback!(sim.integrator)
+        else
+            pkgversion(CA) > v"0.30" && CA.nogw_model_callback!(sim.integrator)
+        end
+    end
+    return nothing
+end
 
 ###
 ### ClimaAtmos.jl model-specific functions (not explicitly required by ClimaCoupler.jl)

--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -328,33 +328,6 @@ function FluxCalculator.update_turbulent_fluxes!(sim::BucketSimulation, fields::
     return nothing
 end
 
-# extension of FluxCalculator.FluxCalculator.surface_thermo_state, overriding the saturated-surface default
-function FluxCalculator.surface_thermo_state(
-    sim::BucketSimulation,
-    thermo_params::TD.Parameters.ThermodynamicsParameters,
-    atmos_sim::Interfacer.AtmosModelSimulation,
-)
-    T_sfc = Interfacer.get_field(sim, Val(:surface_temperature))
-    FieldExchanger.compute_surface_humidity!(
-        sim.integrator.p.bucket.q_sfc,
-        Interfacer.get_field(atmos_sim, Val(:air_temperature)),
-        Interfacer.get_field(atmos_sim, Val(:specific_humidity)),
-        Interfacer.get_field(atmos_sim, Val(:air_density)),
-        T_sfc,
-        thermo_params,
-    )
-    # Note that the surface air density, ρ_sfc, is computed using the atmospheric state at the first level and making ideal gas
-    # and hydrostatic balance assumptions. The land model does not compute the surface air density so this is
-    # a reasonable stand-in.
-    ρ_sfc =
-        FluxCalculator.extrapolate_ρ_to_sfc.(
-            thermo_params,
-            Interfacer.get_field(atmos_sim, Val(:thermo_state_int)),
-            T_sfc,
-        )
-    return @. TD.PhaseEquil_ρTq.(thermo_params, ρ_sfc, T_sfc, sim.integrator.p.bucket.q_sfc)
-end
-
 """
     Checkpointer.get_model_prog_state(sim::BucketSimulation)
 

--- a/experiments/ClimaEarth/components/land/climaland_integrated.jl
+++ b/experiments/ClimaEarth/components/land/climaland_integrated.jl
@@ -437,9 +437,9 @@ function FieldExchanger.update_sim!(sim::ClimaLandSimulation, csf, area_fraction
 
     # update fields for canopy conductance and photosynthesis
     Interfacer.update_field!(sim, Val(:c_co2), csf.c_co2)
-    Interfacer.update_field!(sim, Val(:air_temperature), csf.T_air)
-    Interfacer.update_field!(sim, Val(:air_pressure), csf.P_air)
-    Interfacer.update_field!(sim, Val(:air_humidity), csf.q_air)
+    Interfacer.update_field!(sim, Val(:air_temperature), csf.T_atmos)
+    Interfacer.update_field!(sim, Val(:air_pressure), csf.P_atmos)
+    Interfacer.update_field!(sim, Val(:air_humidity), csf.q_atmos)
 
     # precipitation
     Interfacer.update_field!(sim, Val(:liquid_precipitation), csf.P_liq)
@@ -451,9 +451,9 @@ function FieldExchanger.import_atmos_fields!(csf, sim::ClimaLandSimulation, atmo
     Interfacer.get_field!(csf.SW_d, atmos_sim, Val(:SW_d))
     Interfacer.get_field!(csf.LW_d, atmos_sim, Val(:LW_d))
     Interfacer.get_field!(csf.cos_zenith, atmos_sim, Val(:cos_zenith))
-    Interfacer.get_field!(csf.P_air, atmos_sim, Val(:air_pressure))
-    Interfacer.get_field!(csf.T_air, atmos_sim, Val(:air_temperature))
-    Interfacer.get_field!(csf.q_air, atmos_sim, Val(:specific_humidity))
+    Interfacer.get_field!(csf.P_atmos, atmos_sim, Val(:air_pressure))
+    Interfacer.get_field!(csf.T_atmos, atmos_sim, Val(:air_temperature))
+    Interfacer.get_field!(csf.q_atmos, atmos_sim, Val(:specific_humidity))
     Interfacer.get_field!(csf.P_liq, atmos_sim, Val(:liquid_precipitation))
     Interfacer.get_field!(csf.P_snow, atmos_sim, Val(:snow_precipitation))
     # CO2 is a scalar for now so it doesn't need remapping
@@ -470,15 +470,15 @@ The fields added are:
 - `:cos_zenith` (for radiative transfer)
 - `:diffuse_fraction` (for radiative transfer)
 - `:c_co2` (for photosynthesis, biogeochemistry)
-- `:P_air` (for canopy conductance)
-- `:T_air` (for canopy conductance)
-- `:q_air` (for canopy conductance)
+- `:P_atmos` (for canopy conductance)
+- `:T_atmos` (for canopy conductance)
+- `:q_atmos` (for canopy conductance)
 - `P_liq` (for moisture fluxes)
 - `P_snow` (for moisture fluxes)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::ClimaLandSimulation)
     land_coupler_fields =
-        [:SW_d, :LW_d, :cos_zenith, :diffuse_fraction, :c_co2, :P_air, :T_air, :q_air, :P_liq, :P_snow]
+        [:SW_d, :LW_d, :cos_zenith, :diffuse_fraction, :c_co2, :P_atmos, :T_atmos, :q_atmos, :P_liq, :P_snow]
     push!(coupler_field_names, land_coupler_fields...)
 end
 

--- a/experiments/ClimaEarth/components/land/climaland_integrated.jl
+++ b/experiments/ClimaEarth/components/land/climaland_integrated.jl
@@ -156,7 +156,12 @@ function ClimaLandSimulation(
     Y.snow.S_l .= FT(0)
     Y.snow.U .= FT(0)
 
-    set_initial_cache! = CL.make_set_initial_cache(model)
+    # Initialize the surface temperature so the atmosphere can compute radiation.
+    # This cache variable is normally computed using `p.drivers.LW_d`, which is
+    #  set after the radiation calculation and exchange, but the radiation
+    #  code itself requires a surface temperature as input.
+    @. p.T_sfc = orog_adjusted_T_surface
+
     exp_tendency! = CL.make_exp_tendency(model)
     imp_tendency! = CL.make_imp_tendency(model)
     jacobian! = CL.make_jacobian(model)
@@ -454,6 +459,7 @@ function FieldExchanger.import_atmos_fields!(csf, sim::ClimaLandSimulation, atmo
     Interfacer.get_field!(csf.P_atmos, atmos_sim, Val(:air_pressure))
     Interfacer.get_field!(csf.T_atmos, atmos_sim, Val(:air_temperature))
     Interfacer.get_field!(csf.q_atmos, atmos_sim, Val(:specific_humidity))
+    Interfacer.get_field!(csf.ρ_atmos, atmos_sim, Val(:air_density))
     Interfacer.get_field!(csf.P_liq, atmos_sim, Val(:liquid_precipitation))
     Interfacer.get_field!(csf.P_snow, atmos_sim, Val(:snow_precipitation))
     # CO2 is a scalar for now so it doesn't need remapping
@@ -503,7 +509,7 @@ end
 
 ## Extend functions for land-specific flux calculation
 """
-    compute_surface_fluxes!(csf, sim::ClimaLandSimulation, atmos_sim, boundary_space, thermo_params, surface_scheme)
+    compute_surface_fluxes!(csf, sim::ClimaLandSimulation, atmos_sim, thermo_params)
 
 This function computes surface fluxes between the integrated land model
 simulation and the atmosphere.
@@ -520,25 +526,25 @@ The land model cache is updated with the computed fluxes for each sub-component.
 - `csf`: [CC.Fields.Field] containing a NamedTuple of turbulent flux fields: `F_turb_ρτxz`, `F_turb_ρτyz`, `F_lh`, `F_sh`, `F_turb_moisture`.
 - `sim`: [ClimaLandSimulation] the integrated land simulation to compute fluxes for.
 - `atmos_sim`: [Interfacer.AtmosModelSimulation] the atmosphere simulation to compute fluxes with.
-- unused arguments: `boundary_space`, `thermo_params`, `surface_scheme`
+- `thermo_params`: [ClimaParams.ThermodynamicParameters] the thermodynamic parameters for the simulation.
 """
 function FluxCalculator.compute_surface_fluxes!(
     csf,
     sim::ClimaLandSimulation,
     atmos_sim::Interfacer.AtmosModelSimulation,
-    _...,
+    thermo_params,
 )
+    boundary_space = axes(csf)
     # We should change this to be on the boundary_space
     land_space = axes(sim.integrator.p.soil.turbulent_fluxes)
     coupled_atmos = sim.model.soil.boundary_conditions.top.atmos
 
-    # `_int` refers to atmos state of center level 1
-    z_int = Interfacer.get_field!(coupled_atmos.h, atmos_sim, Val(:height_int))
+    # Update the land simulation's coupled atmosphere state
+    Interfacer.get_field!(coupled_atmos.h, atmos_sim, Val(:height_int))
     u_atmos = Interfacer.get_field(atmos_sim, Val(:u_int), land_space)
     v_atmos = Interfacer.get_field(atmos_sim, Val(:v_int), land_space)
-    Interfacer.get_field!(coupled_atmos.thermal_state, atmos_sim, Val(:thermo_state_int))
-
     @. coupled_atmos.u = StaticArrays.SVector(u_atmos, v_atmos)
+    @. coupled_atmos.thermal_state = TD.PhaseEquil_ρTq(thermo_params, csf.ρ_atmos, csf.T_atmos, csf.q_atmos)
 
     # set the same atmosphere state for all sub-components
     @assert sim.model.soil.boundary_conditions.top.atmos ===
@@ -591,5 +597,22 @@ function FluxCalculator.compute_surface_fluxes!(
     @. csf.temp1 = soil_dest.ρτyz * (1 - p.snow.snow_cover_fraction) + p.snow.snow_cover_fraction * snow_dest.ρτyz
     @. csf.temp1 = ifelse(area_fraction == 0, zero(csf.temp1), csf.temp1)
     @. csf.F_turb_ρτyz += csf.temp1 * area_fraction
+    return nothing
+end
+
+"""
+    Interfacer.set_cache!(sim::ClimaLandSimulation)
+
+Set cache variables that cannot be initialized before the initial exchange.
+This must be called after radiation, so that `p.drivers`
+is filled with the initial radiation fluxes, and these can be propagated
+to the rest of the cache (e.g. in canopy radative transfer).
+
+This function does not set all the cache variables, because many are computed
+as part of the tendendencies.
+"""
+function Interfacer.set_cache!(sim::ClimaLandSimulation)
+    land_set_initial_cache! = CL.make_set_initial_cache(sim.model)
+    land_set_initial_cache!(sim.integrator.p, sim.integrator.u, sim.integrator.t)
     return nothing
 end

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -118,7 +118,6 @@ function PrescribedIceSimulation(
     cache = (;
         F_turb_energy = CC.Fields.zeros(space),
         F_radiative = CC.Fields.zeros(space),
-        q_sfc = CC.Fields.zeros(space),
         ρ_sfc = CC.Fields.zeros(space),
         area_fraction = ice_fraction,
         SIC_timevaryinginput = SIC_timevaryinginput,
@@ -238,8 +237,6 @@ function ice_rhs!(dY, Y, p, t)
     rhs = @. (-p.F_turb_energy - p.F_radiative + F_conductive) / (params.h * params.ρ * params.c)
     # If tendencies lead to temperature above freezing, set temperature to freezing
     @. dY.T_sfc = min(rhs, (params.T_freeze - Y.T_sfc) / float(p.dt))
-
-    @. p.q_sfc = TD.q_vap_saturation_generic.(p.thermo_params, Y.T_sfc, p.ρ_sfc, TD.Ice())
 end
 
 """

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -76,7 +76,6 @@ function SlabOceanSimulation(
         params = params,
         F_turb_energy = CC.Fields.zeros(space),
         F_radiative = CC.Fields.zeros(space),
-        q_sfc = CC.Fields.zeros(space),
         ρ_sfc = CC.Fields.zeros(space),
         area_fraction = area_fraction,
         thermo_params = thermo_params,
@@ -180,7 +179,6 @@ function slab_ocean_rhs!(dY, Y, cache, t)
     # Note that the area fraction has already been applied to the fluxes,
     #  so we don't need to multiply by it here.
     @. dY.T_sfc = rhs * p.evolving_switch
-    @. cache.q_sfc = TD.q_vap_saturation_generic.(cache.thermo_params, Y.T_sfc, cache.ρ_sfc, TD.Liquid())
 end
 
 """

--- a/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
@@ -4,6 +4,8 @@ import ClimaAtmos as CA
 import ClimaCoupler
 import ClimaCoupler: FluxCalculator, Interfacer
 import Dates
+import Thermodynamics.Parameters as TDP
+import ClimaParams # to load TDP extension
 import ClimaComms
 ClimaComms.@import_required_backends
 
@@ -68,14 +70,11 @@ end
     land_sim = ClimaLandSimulation(FT; dt, tspan, start_date, output_dir, boundary_space, area_fraction)
     model_sims = (; land_sim = land_sim, atmos_sim = atmos_sim)
 
-    # Construct a coupler fields object
-    coupler_fluxes_names = [:F_turb_ρτxz, :F_turb_ρτyz, :F_lh, :F_sh, :F_turb_moisture, :temp1, :temp2]
-    coupler_fluxes = Interfacer.init_coupler_fields(FT, coupler_fluxes_names, boundary_space)
-
     # Initialize the coupler fields so we can perform exchange
     coupler_field_names = Interfacer.default_coupler_fields()
     map(sim -> Interfacer.add_coupler_fields!(coupler_field_names, sim), values(model_sims))
     coupler_fields = Interfacer.init_coupler_fields(FT, coupler_field_names, boundary_space)
+    thermo_params = TDP.ThermodynamicsParameters(FT)
 
     cs = Interfacer.CoupledSimulation{FT}(
         nothing, # comms_ctx
@@ -89,7 +88,7 @@ end
         model_sims,
         (;), # callbacks
         (;), # dirs
-        nothing, # thermo_params
+        thermo_params, # thermo_params
         nothing, # diags_handler
     )
 
@@ -108,22 +107,22 @@ end
     update_boundary_fluxes!(land_sim.integrator.p, land_sim.integrator.u, land_sim.integrator.t)
 
     # Compute the surface fluxes
-    FluxCalculator.compute_surface_fluxes!(coupler_fluxes, land_sim, atmos_sim, boundary_space, nothing, nothing)
+    FluxCalculator.compute_surface_fluxes!(coupler_fields, land_sim, atmos_sim, thermo_params)
 
     # Check that the fluxes have been changed
     zero_field = CC.Fields.zeros(boundary_space)
-    @test coupler_fluxes.F_turb_ρτxz != zero_field
-    @test coupler_fluxes.F_turb_ρτyz != zero_field
-    @test coupler_fluxes.F_lh != zero_field
-    @test coupler_fluxes.F_sh != zero_field
-    @test coupler_fluxes.F_turb_moisture != zero_field
+    @test coupler_fields.F_turb_ρτxz != zero_field
+    @test coupler_fields.F_turb_ρτyz != zero_field
+    @test coupler_fields.F_lh != zero_field
+    @test coupler_fields.F_sh != zero_field
+    @test coupler_fields.F_turb_moisture != zero_field
 
     # Check that the fluxes don't contain any NaNs
-    @test !any(isnan, coupler_fluxes.F_turb_ρτxz)
-    @test !any(isnan, coupler_fluxes.F_turb_ρτyz)
-    @test !any(isnan, coupler_fluxes.F_lh)
-    @test !any(isnan, coupler_fluxes.F_sh)
-    @test !any(isnan, coupler_fluxes.F_turb_moisture)
+    @test !any(isnan, coupler_fields.F_turb_ρτxz)
+    @test !any(isnan, coupler_fields.F_turb_ρτyz)
+    @test !any(isnan, coupler_fields.F_lh)
+    @test !any(isnan, coupler_fields.F_sh)
+    @test !any(isnan, coupler_fields.F_turb_moisture)
 
     # Check that drivers in cache got updated
     for driver in propertynames(land_sim.integrator.p.drivers)

--- a/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
@@ -49,7 +49,6 @@ for FT in (Float32, Float64)
                 area_fraction = SIC_init,
                 SIC_timevaryinginput = SIC_timevaryinginput,
                 land_fraction = CC.Fields.zeros(space),
-                q_sfc = CC.Fields.zeros(space),
                 ρ_sfc = CC.Fields.ones(space),
                 thermo_params = thermo_params,
                 dt = dt,

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -12,7 +12,7 @@ import ..Interfacer, ..FluxCalculator, ..Utilities
 import Thermodynamics as TD
 import Thermodynamics.Parameters as TDP
 
-export update_sim!, update_model_sims!, step_model_sims!, exchange!
+export update_sim!, update_model_sims!, step_model_sims!, exchange!, set_caches!
 
 """
     update_surface_fractions!(cs::Interfacer.CoupledSimulation)
@@ -93,8 +93,10 @@ This is the default function to be used for most surface model simulations, as
 and passed to the surfaces.
 """
 function import_atmos_fields!(csf, ::Interfacer.SurfaceModelSimulation, atmos_sim)
-    # surface density - needed for q_sat and requires atmos and sfc states, so it is calculated and saved in the coupler
-    Interfacer.remap!(csf.ρ_sfc, FluxCalculator.calculate_surface_air_density(atmos_sim, csf.T_sfc)) # TODO: generalize to use individual T_sfc, (#445)
+    # get atmosphere properties used for flux calculations
+    Interfacer.get_field!(csf.T_atmos, atmos_sim, Val(:air_temperature))
+    Interfacer.get_field!(csf.q_atmos, atmos_sim, Val(:specific_humidity))
+    Interfacer.get_field!(csf.ρ_atmos, atmos_sim, Val(:air_density))
 
     # radiative fluxes
     Interfacer.get_field!(csf.F_radiative, atmos_sim, Val(:radiative_energy_flux_sfc))
@@ -108,20 +110,59 @@ end
 import_atmos_fields!(csf, ::Interfacer.AtmosModelSimulation, atmos_sim) = nothing
 
 """
-    import_combined_surface_fields!(csf, model_sims)
+    import_combined_surface_fields!(csf, model_sims, thermo_params)
 
 Updates the coupler with the surface properties. The `Interfacer.get_field`
 functions for (`:surface_temperature`, `:surface_direct_albedo`,
 `:surface_diffuse_albedo`) need to be specified for each surface model.
 
+Note: The calculation of surface humidity uses atmospheric properties stored in
+the coupled fields. For these values to be correct, this function should be called
+after `import_atmos_fields!` in a timestep.
+
 # Arguments
 - `csf`: [NamedTuple] containing coupler fields.
 - `model_sims`: [NamedTuple] containing `ComponentModelSimulation`s.
+- `thermo_params`: [TD.Parameters.ThermodynamicsParameters] the thermodynamic parameters.
 """
-function import_combined_surface_fields!(csf, model_sims)
+function import_combined_surface_fields!(csf, model_sims, thermo_params)
     combine_surfaces!(csf.T_sfc, model_sims, Val(:surface_temperature))
     combine_surfaces!(csf.surface_direct_albedo, model_sims, Val(:surface_direct_albedo))
     combine_surfaces!(csf.surface_diffuse_albedo, model_sims, Val(:surface_diffuse_albedo))
+
+    # q_sfc is computed from the atmosphere state and surface temperature, so it's handled differently
+    # This is computed on the exchange grid, so there's no need to remap
+    compute_surface_humidity!(csf.q_sfc, csf.T_atmos, csf.q_atmos, csf.ρ_atmos, csf.T_sfc, thermo_params)
+    return nothing
+end
+
+"""
+    compute_surface_humidity!(q_sfc, T_atmos, q_atmos, ρ_atmos, T_sfc, thermo_params)
+
+Computes the surface specific humidity based on the atmospheric state and surface temperature.
+The phase of the surface is determined by the surface temperature, and the saturation
+specific humidity is computed accordingly.
+
+All fields should be on the exchange grid.
+
+# Arguments
+- `q_sfc`: [CC.Fields.Field] output field for surface specific humidity.
+- `T_atmos`: [CC.Fields.Field] atmospheric temperature.
+- `q_atmos`: [CC.Fields.Field] atmospheric specific humidity.
+- `ρ_atmos`: [CC.Fields.Field] atmospheric air density.
+- `T_sfc`: [CC.Fields.Field] surface temperature.
+- `thermo_params`: [TD.Parameters.ThermodynamicsParameters] the thermodynamic parameters.
+"""
+function compute_surface_humidity!(q_sfc, T_atmos, q_atmos, ρ_atmos, T_sfc, thermo_params)
+    thermo_state_atmos = TD.PhaseEquil_ρTq.(thermo_params, ρ_atmos, T_atmos, q_atmos)
+    ρ_sfc = FluxCalculator.extrapolate_ρ_to_sfc.(thermo_params, thermo_state_atmos, T_sfc)
+
+    T_freeze = TDP.T_freeze(thermo_params)
+    @. q_sfc = ifelse(
+        T_sfc .> T_freeze,
+        TD.q_vap_saturation_generic(thermo_params, T_sfc, ρ_sfc, TD.Liquid()),
+        TD.q_vap_saturation_generic(thermo_params, T_sfc, ρ_sfc, TD.Ice()),
+    )
     return nothing
 end
 
@@ -153,9 +194,6 @@ Updates the surface component model cache with the current coupler fields beside
 """
 function update_sim!(sim::Interfacer.SurfaceModelSimulation, csf, area_fraction)
     FT = eltype(area_fraction)
-
-    # atmospheric surface density
-    Interfacer.update_field!(sim, Val(:air_density), csf.ρ_sfc)
 
     # radiative fluxes
     Interfacer.update_field!(sim, Val(:radiative_energy_flux_sfc), FT.(area_fraction .* csf.F_radiative))
@@ -231,34 +269,6 @@ function combine_surfaces!(combined_field, sims, field_name)
 end
 
 """
-    compute_surface_humidity!(q_sfc, T_atmos, q_atmos, ρ_atmos, T_sfc, thermo_params)
-
-Compute the surface specific humidity based on the atmospheric state and surface temperature.
-The phase of the surface is determined by the surface temperature, and the saturation
-specific humidity is computed accordingly.
-All fields should be on the exchange grid.
-# Arguments
-- `q_sfc`: [CC.Fields.Field] output field for surface specific humidity.
-- `T_atmos`: [CC.Fields.Field] atmospheric temperature.
-- `q_atmos`: [CC.Fields.Field] atmospheric specific humidity.
-- `ρ_atmos`: [CC.Fields.Field] atmospheric air density.
-- `T_sfc`: [CC.Fields.Field] surface temperature.
-- `thermo_params`: [TD.Parameters.ThermodynamicsParameters] the thermodynamic parameters.
-"""
-function compute_surface_humidity!(q_sfc, T_atmos, q_atmos, ρ_atmos, T_sfc, thermo_params)
-    thermo_state_atmos = TD.PhaseEquil_ρTq.(thermo_params, ρ_atmos, T_atmos, q_atmos)
-    ρ_sfc = FluxCalculator.extrapolate_ρ_to_sfc.(thermo_params, thermo_state_atmos, T_sfc)
-
-    T_freeze = TDP.T_freeze(thermo_params)
-    @. q_sfc = ifelse(
-        T_sfc .> T_freeze,
-        TD.q_vap_saturation_generic(thermo_params, T_sfc, ρ_sfc, TD.Liquid()),
-        TD.q_vap_saturation_generic(thermo_params, T_sfc, ρ_sfc, TD.Ice()),
-    )
-    return nothing
-end
-
-"""
     exchange!(cs::Interfacer.CoupledSimulation)
 
 Exchange fields between the surface and atmosphere models.
@@ -272,12 +282,33 @@ the atmosphere fields to be updated so that surface humidity can be computed.
 function exchange!(cs::Interfacer.CoupledSimulation)
     # Import the atmosphere fields and surface fields into the coupler
     import_atmos_fields!(cs.fields, cs.model_sims)
-    import_combined_surface_fields!(cs.fields, cs.model_sims)
+    import_combined_surface_fields!(cs.fields, cs.model_sims, cs.thermo_params)
 
     # Update the component model simulations with the coupler fields
     update_model_sims!(cs.model_sims, cs.fields)
     return nothing
 end
 
+"""
+    set_caches!(cs::Interfacer.CoupledSimulation)
+
+Perform any initialization of the component model caches that cannot be
+done before the initial exchange. This is useful in handling cache interdependencies
+between component models.
+
+For example, the radiation callback in the atmosphere model needs to be
+initialized with the surface temperatures, which are only available after the
+initial exchange. The integrated land, in turn, requires its drivers in the
+cache to be filled with the initial radiation fluxes, so that it can propagate
+these to the rest of its cache (e.g. in canopy radative transfer).
+"""
+function set_caches!(cs::Interfacer.CoupledSimulation)
+    Interfacer.set_cache!(cs.model_sims.atmos_sim)
+    exchange!(cs)
+    for sim in cs.model_sims
+        sim isa Interfacer.SurfaceModelSimulation && Interfacer.set_cache!(sim)
+    end
+    return nothing
+end
 
 end # module

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -12,22 +12,12 @@ import Thermodynamics as TD
 import ClimaCore as CC
 import ..Interfacer, ..Utilities
 
-export calculate_surface_air_density,
-    extrapolate_ρ_to_sfc,
+export extrapolate_ρ_to_sfc,
     turbulent_fluxes!,
     get_surface_params,
     update_turbulent_fluxes!,
     water_albedo_from_atmosphere!,
     compute_surface_fluxes!
-
-"""
-    calculate_surface_air_density(atmos_sim::ClimaAtmosSimulation, T_sfc::CC.Fields.Field)
-
-Extension for this  to to calculate surface density.
-"""
-function calculate_surface_air_density(atmos_sim::Interfacer.AtmosModelSimulation, T_sfc::CC.Fields.Field)
-    error("this function is required to be dispatched on $(nameof(atmos_sim)), but no method defined")
-end
 
 function turbulent_fluxes!(cs::Interfacer.CoupledSimulation)
     return turbulent_fluxes!(cs.fields, cs.model_sims, cs.thermo_params)
@@ -70,7 +60,6 @@ function turbulent_fluxes!(csf, model_sims, thermo_params)
         :z0m_sfc,
         :z0b_sfc,
         :beta,
-        :q_sfc,
         :L_MO,
         :ustar,
         :buoyancy_flux,
@@ -80,21 +69,19 @@ function turbulent_fluxes!(csf, model_sims, thermo_params)
 
     # Compute the surface fluxes for each surface model and add them to `csf`
     for sim in model_sims
-        compute_surface_fluxes!(csf, sim, atmos_sim, boundary_space, thermo_params)
+        compute_surface_fluxes!(csf, sim, atmos_sim, thermo_params)
     end
 
     # Update the atmosphere with the fluxes across all surface models
     # The surface models have already been updated with the fluxes in `compute_surface_fluxes!`
     # TODO this should be `update_turbulent_fluxes` to match the surface models
     Interfacer.update_field!(atmos_sim, Val(:turbulent_fluxes), csf)
-
-    # TODO: add allowable bounds here, check explicitly that all fluxes are equal
     return nothing
 end
 
 
 function surface_inputs(input_args::NamedTuple)
-    (; thermo_state_sfc, thermo_state_int, uₕ_int, z_int, z_sfc, scheme_properties, boundary_space) = input_args
+    (; thermo_state_sfc, thermo_state_atmos, uₕ_int, z_int, z_sfc, scheme_properties, boundary_space) = input_args
     FT = CC.Spaces.undertype(boundary_space)
     (; z0b, z0m, beta, gustiness) = scheme_properties
 
@@ -105,7 +92,7 @@ function surface_inputs(input_args::NamedTuple)
 
     z_int_fv = maybe_fv(z_int)
     uₕ_int_fv = maybe_fv(uₕ_int)
-    thermo_state_int_fv = maybe_fv(thermo_state_int)
+    thermo_state_atmos_fv = maybe_fv(thermo_state_atmos)
     z_sfc_fv = maybe_fv(z_sfc)
     thermo_state_sfc_fv = maybe_fv(thermo_state_sfc)
     beta_fv = maybe_fv(beta)
@@ -115,7 +102,7 @@ function surface_inputs(input_args::NamedTuple)
 
     # Compute state values
     result = @. SF.ValuesOnly(
-        SF.StateValues(z_int_fv, uₕ_int_fv, thermo_state_int_fv), # state_in
+        SF.StateValues(z_int_fv, uₕ_int_fv, thermo_state_atmos_fv), # state_in
         SF.StateValues(                                  # state_sfc
             z_sfc_fv,
             StaticArrays.SVector(FT(0), FT(0)),
@@ -129,44 +116,6 @@ function surface_inputs(input_args::NamedTuple)
 
     # Put the result data layout back onto the surface space
     return CC.Fields.Field(result, boundary_space)
-end
-
-"""
-    surface_thermo_state(sim::Interfacer.SurfaceModelSimulation,
-                         thermo_params::TD.Parameters.ThermodynamicsParameters,
-                         atmos_sim::Interfacer.AtmosModelSimulation)
-
-Return the surface thermo state the surface model simulation `sim`.
-
-This is obtained by using the model surface temperature in `sim`, extrapolating atmospheric
-density adiabatically to the surface, and using the model surface humidity (which, by
-default, is computed assuming a liquid phase).
-"""
-function surface_thermo_state(
-    sim::Interfacer.SurfaceModelSimulation,
-    thermo_params::TD.Parameters.ThermodynamicsParameters,
-    atmos_sim::Interfacer.AtmosModelSimulation,
-)
-    FT = eltype(atmos_sim.integrator.u)
-
-    T_sfc = Interfacer.get_field(sim, Val(:surface_temperature))
-    # Note that the surface air density, ρ_sfc, is computed using the atmospheric state at the first level and making ideal gas
-    # and hydrostatic balance assumptions. The land model does not compute the surface air density so this is
-    # a reasonable stand-in.
-    #
-    # NOTE: This allocates! Fix me!
-    ρ_sfc =
-        FluxCalculator.extrapolate_ρ_to_sfc.(
-            thermo_params,
-            Interfacer.get_field(atmos_sim, Val(:thermo_state_int)),
-            T_sfc,
-        ) # ideally the # calculate elsewhere, here just getter...
-
-    # For SurfaceStabs, this is just liquid phase
-    q_sfc = TD.q_vap_saturation_generic.(thermo_params, T_sfc, ρ_sfc, TD.Liquid()) # default: saturated liquid surface
-
-    # NOTE: This allocates! Fix me!
-    return @. TD.PhaseEquil_ρTq.(thermo_params, ρ_sfc, T_sfc, q_sfc)
 end
 
 # TODO: (an equivalent of) this function also lives in Atmos and Land - should move to general utilities
@@ -264,7 +213,7 @@ function water_albedo_from_atmosphere!(atmos_sim::Interfacer.AtmosModelSimulatio
 end
 
 """
-    compute_surface_fluxes!(csf, sim, atmos_sim, boundary_space, thermo_params)
+    compute_surface_fluxes!(csf, sim, atmos_sim, thermo_params)
 
 This function computes surface fluxes between the input component model
 simulation and the atmosphere.
@@ -280,14 +229,12 @@ function does nothing if called on an atmosphere model simulation.
 - `csf`: [CC.Fields.Field] containing a NamedTuple of turbulent flux fields: `F_turb_ρτxz`, `F_turb_ρτyz`, `F_lh`, `F_sh`, `F_turb_moisture`.
 - `sim`: [Interfacer.ComponentModelSimulation] the surface simulation to compute fluxes for.
 - `atmos_sim`: [Interfacer.AtmosModelSimulation] the atmosphere simulation to compute fluxes with.
-- `boundary_space`: [CC.Spaces.AbstractSpace] the space of the coupler surface.
 - `thermo_params`: [TD.Parameters.ThermodynamicsParameters] the thermodynamic parameters.
 """
 function compute_surface_fluxes!(
     csf,
     sim::Interfacer.AtmosModelSimulation,
     atmos_sim::Interfacer.AtmosModelSimulation,
-    boundary_space,
     thermo_params,
 )
     # do nothing for atmos model
@@ -298,21 +245,29 @@ function compute_surface_fluxes!(
     csf,
     sim::Interfacer.SurfaceModelSimulation,
     atmos_sim::Interfacer.AtmosModelSimulation,
-    boundary_space,
     thermo_params,
 )
+    boundary_space = axes(csf)
+    # TODO lots of allocations here
     # `_int` refers to atmos state of center level 1
     z_int = Interfacer.get_field(atmos_sim, Val(:height_int), boundary_space)
     u_int = Interfacer.get_field(atmos_sim, Val(:u_int), boundary_space)
     v_int = Interfacer.get_field(atmos_sim, Val(:v_int), boundary_space)
     uₕ_int = @. StaticArrays.SVector(u_int, v_int)
-    thermo_state_int = Interfacer.get_field(atmos_sim, Val(:thermo_state_int), boundary_space)
     z_sfc = Interfacer.get_field(atmos_sim, Val(:height_sfc), boundary_space)
+
+    # construct the atmospheric thermo states
+    thermo_state_atmos = TD.PhaseEquil_ρTq.(thermo_params, csf.ρ_atmos, csf.T_atmos, csf.q_atmos)
+
+    # construct the surface thermo state
+    # get surface air density by extrapolating atmospheric density to the surface
+    ρ_sfc = extrapolate_ρ_to_sfc.(thermo_params, thermo_state_atmos, csf.T_sfc)
+
+    # compute surface humidity from the surface temperature, surface density, and phase
+    thermo_state_sfc = TD.PhaseEquil_ρTq.(thermo_params, ρ_sfc, csf.T_sfc, csf.q_sfc)
 
     # get area fraction (min = 0, max = 1)
     area_fraction = Interfacer.get_field(sim, Val(:area_fraction), boundary_space)
-
-    thermo_state_sfc = FluxCalculator.surface_thermo_state(sim, thermo_params, atmos_sim)
 
     surface_params = FluxCalculator.get_surface_params(atmos_sim)
 
@@ -322,8 +277,16 @@ function compute_surface_fluxes!(
     FT = eltype(z0m)
     scheme_properties = (; z0b = z0b, z0m = z0m, Ch = FT(0), Cd = FT(0), beta = beta, gustiness = FT(1))
 
-    input_args =
-        (; thermo_state_sfc, thermo_state_int, uₕ_int, z_int, z_sfc, scheme_properties, boundary_space, surface_params)
+    input_args = (;
+        thermo_state_sfc,
+        thermo_state_atmos,
+        uₕ_int,
+        z_int,
+        z_sfc,
+        scheme_properties,
+        boundary_space,
+        surface_params,
+    )
     inputs = FluxCalculator.surface_inputs(input_args)
 
     # calculate the surface fluxes
@@ -380,10 +343,6 @@ function compute_surface_fluxes!(
     @. csf.z0m_sfc += z0m * area_fraction
     @. csf.z0b_sfc += z0b * area_fraction
     @. csf.beta += beta * area_fraction
-
-    # NOTE: This is essentially setting q_sfc to the Atmos q_sfc (because we compute the
-    # thermo_state_sfc by extrapolating the atmos properties onto the surface)
-    @. csf.q_sfc += TD.total_specific_humidity.(thermo_params, thermo_state_sfc) * area_fraction
     return nothing
 end
 

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -25,6 +25,9 @@ export CoupledSimulation,
     AbstractSurfaceStub,
     SurfaceStub,
     step!,
+    set_cache!,
+    remap,
+    remap!,
     AbstractSlabplanetSimulationMode,
     AMIPMode,
     SlabplanetMode,
@@ -87,13 +90,13 @@ function Base.show(io::IO, sim::CoupledSimulation)
 end
 
 """
-    current_date(cs::Interfacer.CoupledSimulation)
+    current_date(cs::CoupledSimulation)
 
 Return the model date at the current timestep.
 # Arguments
 - `cs`: [CoupledSimulation] containing info about the simulation
 """
-current_date(cs::Interfacer.CoupledSimulation) = cs.t[] isa ITime ? date(cs.t[]) : cs.start_date + Dates.second(cs.t[])
+current_date(cs::CoupledSimulation) = cs.t[] isa ITime ? date(cs.t[]) : cs.start_date + Dates.second(cs.t[])
 
 """
     default_coupler_fields()
@@ -106,12 +109,19 @@ default_coupler_fields() = [
     :z0b_sfc,
     :beta,
     :emissivity,
+    # fields used to compute fluxes
+    :T_atmos,
+    :q_atmos,
+    :ρ_atmos,
+    :T_sfc,
+    :q_sfc,
     # fields used for flux exchange
     :F_lh,
     :F_sh,
     :F_turb_moisture,
     :F_turb_ρτxz,
     :F_turb_ρτyz,
+    :F_radiative,
     # fields used to track water conservation, and for water fluxes
     :P_liq,
     :P_snow,
@@ -429,5 +439,15 @@ function remap!(target_field, source)
     target_field .= remap(source, axes(target_field))
     return nothing
 end
+
+
+"""
+    set_cache!(sim::ComponentModelSimulation)
+
+Perform any initialization of the component model cache that must be done
+after the initial exchange.
+This is not required to be extended, but may be necessary for some models.
+"""
+set_cache!(sim::ComponentModelSimulation) = nothing
 
 end # module

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -3,7 +3,8 @@ import StaticArrays
 import ClimaCore as CC
 import ClimaParams
 import Thermodynamics as TD
-import Thermodynamics.Parameters.ThermodynamicsParameters
+import Thermodynamics.Parameters as TDP
+import SurfaceFluxes as SF
 import SurfaceFluxes.Parameters.SurfaceFluxesParameters
 import SurfaceFluxes.UniversalFunctions as UF
 import ClimaCoupler: FieldExchanger, FluxCalculator, Interfacer
@@ -26,12 +27,22 @@ struct TestAtmos{P, D, I} <: Interfacer.AtmosModelSimulation
 end
 struct TestAtmos2 <: Interfacer.AtmosModelSimulation end
 
+Interfacer.get_field(sim::TestAtmos, ::Val{:air_temperature}) = sim.integrator.T
+Interfacer.get_field(sim::TestAtmos, ::Val{:specific_humidity}) = sim.integrator.q
+Interfacer.get_field(sim::TestAtmos, ::Val{:air_density}) = sim.integrator.ρ
 Interfacer.get_field(sim::TestAtmos, ::Val{:height_int}) = sim.integrator.p.z
 Interfacer.get_field(sim::TestAtmos, ::Val{:height_sfc}) = sim.integrator.p.z_sfc
 Interfacer.get_field(sim::TestAtmos, ::Val{:u_int}) = sim.integrator.p.u
 Interfacer.get_field(sim::TestAtmos, ::Val{:v_int}) = sim.integrator.p.v
 Interfacer.get_field(sim::TestAtmos, ::Val{:thermo_state_int}) =
     TD.PhaseEquil_ρTq.(get_thermo_params(sim), sim.integrator.ρ, sim.integrator.T, sim.integrator.q)
+
+function FieldExchanger.import_atmos_fields!(csf, sim::TestAtmos, atmos_sim)
+    # update atmos properties in coupler fields needed to compute surface fluxes
+    Interfacer.get_field!(csf.T_atmos, atmos_sim, Val(:air_temperature))
+    Interfacer.get_field!(csf.q_atmos, atmos_sim, Val(:specific_humidity))
+    Interfacer.get_field!(csf.ρ_atmos, atmos_sim, Val(:air_density))
+end
 
 function FieldExchanger.update_sim!(sim::TestAtmos, fields, _)
     (; F_turb_ρτxz, F_lh, F_sh, F_turb_moisture) = fields
@@ -43,7 +54,7 @@ end
 
 function get_thermo_params(sim::TestAtmos)
     FT = sim.params.FT
-    thermo_params = ThermodynamicsParameters(FT)
+    thermo_params = TDP.ThermodynamicsParameters(FT)
     return thermo_params
 end
 
@@ -53,7 +64,6 @@ function FluxCalculator.get_surface_params(sim::TestAtmos)
     return sf_params
 end
 
-
 # ocean sim object and extensions
 struct TestOcean{M, I} <: Interfacer.SurfaceModelSimulation
     model::M
@@ -61,31 +71,14 @@ struct TestOcean{M, I} <: Interfacer.SurfaceModelSimulation
 end
 
 Interfacer.get_field(sim::TestOcean, ::Val{:surface_temperature}) = sim.integrator.T
-Interfacer.get_field(sim::TestOcean, ::Val{:air_humidity}) = sim.integrator.p.q
 Interfacer.get_field(sim::TestOcean, ::Val{:roughness_momentum}) = sim.integrator.p.z0m
 Interfacer.get_field(sim::TestOcean, ::Val{:roughness_buoyancy}) = sim.integrator.p.z0b
 Interfacer.get_field(sim::TestOcean, ::Val{:beta}) = sim.integrator.p.beta
 Interfacer.get_field(sim::TestOcean, ::Val{:area_fraction}) = sim.integrator.p.area_fraction
-Interfacer.get_field(sim::TestOcean, ::Val{:heat_transfer_coefficient}) = sim.integrator.p.Ch
-Interfacer.get_field(sim::TestOcean, ::Val{:drag_coefficient}) = sim.integrator.p.Cd
 Interfacer.get_field(sim::TestOcean, ::Union{Val{:surface_direct_albedo}, Val{:surface_diffuse_albedo}}) =
     sim.integrator.p.α
 
-function FluxCalculator.surface_thermo_state(
-    sim::TestOcean,
-    thermo_params::ThermodynamicsParameters,
-    atmos_sim::Interfacer.AtmosModelSimulation,
-)
-    T_sfc = Interfacer.get_field(sim, Val(:surface_temperature))
-    ρ_sfc =
-        FluxCalculator.extrapolate_ρ_to_sfc.(
-            thermo_params,
-            Interfacer.get_field(atmos_sim, Val(:thermo_state_int)),
-            T_sfc,
-        )
-    q_sfc = Interfacer.get_field(sim, Val(:air_humidity)) # read from cache
-    @. TD.PhaseEquil_ρTq.(thermo_params, ρ_sfc, T_sfc, q_sfc)
-end
+FieldExchanger.import_atmos_fields!(csf, sim::TestOcean, atmos_sim) = nothing
 
 function FluxCalculator.update_turbulent_fluxes!(sim::TestOcean, fields::NamedTuple)
     (; F_lh, F_sh) = fields
@@ -100,22 +93,7 @@ end
 
 Interfacer.get_field(sim::DummySurfaceSimulation3, ::Val{:surface_temperature}) = sim.integrator.T
 Interfacer.get_field(sim::DummySurfaceSimulation3, ::Val{:area_fraction}) = sim.integrator.p.area_fraction
-Interfacer.get_field(sim::DummySurfaceSimulation3, ::Val{:heat_transfer_coefficient}) = sim.integrator.p.Ch
-Interfacer.get_field(sim::DummySurfaceSimulation3, ::Val{:drag_coefficient}) = sim.integrator.p.Cd
 Interfacer.get_field(sim::DummySurfaceSimulation3, ::Val{:beta}) = sim.integrator.p.beta
-
-function FluxCalculator.surface_thermo_state(
-    sim::DummySurfaceSimulation3,
-    thermo_params::ThermodynamicsParameters,
-    atmos_sim::Interfacer.AtmosModelSimulation,
-)
-    T_sfc = Interfacer.get_field(sim, Val(:surface_temperature))
-    FT = eltype(T_sfc)
-
-    ρ_sfc = @. T_sfc * FT(0) .+ FT(1.2) # arbitrary
-    q_sfc = @. T_sfc * FT(0) # dry surface
-    @. TD.PhaseEquil_ρTq.(thermo_params, ρ_sfc, T_sfc, q_sfc)
-end
 
 function FluxCalculator.water_albedo_from_atmosphere!(::TestAtmos, temp1::CC.Fields.Field, temp2::CC.Fields.Field)
     temp1 .*= 2
@@ -123,13 +101,6 @@ function FluxCalculator.water_albedo_from_atmosphere!(::TestAtmos, temp1::CC.Fie
 end
 
 for FT in (Float32, Float64)
-    @testset "calculate_surface_air_density for FT=$FT" begin
-        boundary_space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4)
-        coupler_fields = (; T_sfc = 310 .* ones(boundary_space))
-        sim2 = DummySimulation2((; cache = (; flux = zeros(boundary_space))))
-        @test_throws ErrorException FluxCalculator.calculate_surface_air_density(sim2, coupler_fields.T_sfc)
-    end
-
     @testset "calculate correct fluxes: dry for FT=$FT" begin
         boundary_space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4)
 
@@ -157,8 +128,6 @@ for FT in (Float32, Float64)
             beta = ones(boundary_space),
             α = ones(boundary_space) .* FT(0.5),
             q = zeros(boundary_space),
-            Cd = FT(0.01),
-            Ch = FT(0.01),
             area_fraction = ones(boundary_space) .* FT(0.5),
         )
         Y_init = (; T = ones(boundary_space) .* FT(300))
@@ -170,47 +139,83 @@ for FT in (Float32, Float64)
 
         model_sims = (; atmos_sim, ocean_sim, ocean_sim2)
 
-        coupler_cache_names = [
-            :T_sfc,
-            :surface_direct_albedo,
-            :surface_diffuse_albedo,
-            :P_liq,
-            :P_snow,
-            :P_net,
-            :F_lh,
-            :F_sh,
-            :F_turb_ρτxz,
-            :F_turb_ρτyz,
-            :F_turb_moisture,
-            :z0m_sfc,
-            :z0b_sfc,
-            :beta,
-            :q_sfc,
-            :L_MO,
-            :ustar,
-            :buoyancy_flux,
-        ]
+        coupler_cache_additional =
+            [:surface_direct_albedo, :surface_diffuse_albedo, :P_net, :L_MO, :ustar, :buoyancy_flux]
+
+        coupler_cache_names = Interfacer.default_coupler_fields()
+        push!(coupler_cache_names, coupler_cache_additional...)
         fields = Interfacer.init_coupler_fields(FT, coupler_cache_names, boundary_space)
 
-        # calculate turbulent fluxes
+        # import atmosphere properties into coupler fields
+        FieldExchanger.import_atmos_fields!(fields, model_sims)
+
+        # import surface properties into coupler fields
         thermo_params = get_thermo_params(atmos_sim)
+        FieldExchanger.import_combined_surface_fields!(fields, model_sims, thermo_params)
+
+        # calculate turbulent fluxes
         FluxCalculator.turbulent_fluxes!(fields, model_sims, thermo_params)
 
         # calculating the fluxes twice ensures that no accumulation occurred (i.e. fluxes are reset to zero each time)
         # TODO: this will need to be extended once flux accumulation is re-enabled
         FluxCalculator.turbulent_fluxes!(fields, model_sims, thermo_params)
 
-        windspeed = @. hypot(atmos_sim.integrator.p.u, atmos_sim.integrator.p.v)
+        # Compute expected fluxes
+        # Get atmosphere properties
+        z_int = Interfacer.get_field(atmos_sim, Val(:height_int))
+        uₕ_int =
+            StaticArrays.SVector.(
+                Interfacer.get_field(atmos_sim, Val(:u_int)),
+                Interfacer.get_field(atmos_sim, Val(:v_int)),
+            )
+        thermo_state_atmos =
+            TD.PhaseEquil_ρTq.(thermo_params, atmos_sim.integrator.ρ, atmos_sim.integrator.T, atmos_sim.integrator.q)
+        thermo_state_atmos = Interfacer.get_field(atmos_sim, Val(:thermo_state_int))
 
-        thermo_params = get_thermo_params(atmos_sim)
+        # Get surface properties
+        z_sfc = Interfacer.get_field(atmos_sim, Val(:height_sfc))
+        z0m = Interfacer.get_field(ocean_sim, Val(:roughness_momentum))
+        z0b = Interfacer.get_field(ocean_sim, Val(:roughness_buoyancy))
+        gustiness = FT(1)
+        beta = Interfacer.get_field(ocean_sim, Val(:beta))
 
-        surface_thermo_states = FluxCalculator.surface_thermo_state(ocean_sim, thermo_params, atmos_sim)
+        T_sfc = Interfacer.get_field(ocean_sim, Val(:surface_temperature))
+        q_sfc = zeros(boundary_space)
+        FieldExchanger.compute_surface_humidity!(
+            q_sfc,
+            fields.T_atmos,
+            fields.q_atmos,
+            fields.ρ_atmos,
+            T_sfc,
+            thermo_params,
+        )
+        ρ_sfc = FluxCalculator.extrapolate_ρ_to_sfc.(thermo_params, thermo_state_atmos, T_sfc)
+        thermo_state_sfc = TD.PhaseEquil_ρTq.(thermo_params, ρ_sfc, T_sfc, q_sfc)
 
-        # NOTE: This test is very weak! We should add more stringent tests
-        @test Array(parent(fields.F_turb_moisture))[1] ≈ FT(0)
-        for p in coupler_cache_names
-            @test !any(isnan, getproperty(fields, p))
-        end
+        # Use SurfaceFluxes.jl to compute the expected fluxes
+        inputs = @. SF.ValuesOnly(
+            SF.StateValues(z_int, uₕ_int, thermo_state_atmos), # state_in
+            SF.StateValues(                                  # state_sfc
+                z_sfc,
+                StaticArrays.SVector(FT(0), FT(0)),
+                thermo_state_sfc,
+            ),
+            z0m,
+            z0b,
+            gustiness,
+            beta,
+        )
+        surface_params = FluxCalculator.get_surface_params(atmos_sim)
+        fluxes_expected = FluxCalculator.get_surface_fluxes(inputs, surface_params)
+
+        # Compare expected and computed fluxes
+        @test fields.F_turb_ρτxz ≈ fluxes_expected.F_turb_ρτxz
+        @test fields.F_turb_ρτyz ≈ fluxes_expected.F_turb_ρτyz
+        @test fields.F_lh ≈ fluxes_expected.F_lh
+        @test fields.F_sh ≈ fluxes_expected.F_sh
+        # The ClimaCore DataLayout underlying the expected moisture flux uses
+        # Array instead of SubArray, so we can't compare the fields directly.
+        @test all(parent(fields.F_turb_moisture) .≈ parent(fluxes_expected.F_turb_moisture))
     end
 
     @testset "get_surface_params for FT=$FT" begin
@@ -228,18 +233,6 @@ for FT in (Float32, Float64)
         @test_throws ErrorException(
             "update_turbulent_fluxes! is required to be dispatched on $(nameof(sim)), but no method defined",
         ) FluxCalculator.update_turbulent_fluxes!(sim, (;)) == ErrorException
-    end
-
-    @testset "surface_thermo_state for FT=$FT" begin
-        boundary_space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4)
-        _ones = CC.Fields.ones(boundary_space)
-        surface_sim =
-            DummySurfaceSimulation3([], (; T = _ones .* FT(300), ρ = _ones .* FT(1.2), p = (; q = _ones .* FT(0.01))))
-        atmos_sim = TestAtmos((; FT = FT), [], (; T = _ones .* FT(300), ρ = _ones .* FT(1.2), q = _ones .* FT(0.01)))
-        thermo_params = get_thermo_params(atmos_sim)
-        thermo_state_int = Interfacer.get_field(atmos_sim, Val(:thermo_state_int))
-        ρ_expected = FluxCalculator.extrapolate_ρ_to_sfc.(thermo_params, thermo_state_int, surface_sim.integrator.T)
-        @test FluxCalculator.surface_thermo_state(surface_sim, thermo_params, atmos_sim).ρ == ρ_expected
     end
 
     @testset "water_albedo_from_atmosphere!" begin


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #1291

As of #1305, we have a generalized function to compute `q`, choosing phase based on `T_sfc`. This PR uses that function to compute the atmosphere and surface thermo states as needed, rather than exchanging these objects. This will allow us to remap T, q, rho, and construct the thermo states on the exchange grid when computing fluxes.

This unified approach allows us to remove a couple functions, including `surface_thermo_state` and `FluxCalculator.calculate_surface_air_density`.

Previously, we computed radiation before setting the surface ("skin") temperature of the integrated land, which led to immediate instability. Now, the land surface temperature is set at initialization, and we compute radiation + exchange before calling `set_initial_cache` for the land, so the correct radiation drivers have been set when we finish filling the land cache. I expect that this is also a bug on main but wasn't as pronounced since here we use the initial `T_sfc` more extensively to compute `rho_sfc`, `q_sfc`, atmos thermo state, etc.

Visually inspecting the plots from buildkite, they look identical to main.

## Content
- [x] add generalized function to compute q, choosing phase based on T_sfc - done in #1305
- [x] store atmos T, q, rho in coupler fields so we can easily remap them
- [x] store surface T, q in coupler fields; compute rho as needed
- [x] create atmosphere and surface thermo states from the respective T, q, rho on the exchange grid when computing fluxes
- [x] remove `surface_thermo_state` function
- [x] remove FluxCalculator `calculate_surface_air_density`
- [x] [additional] rename integrated land atmosphere properties to unify with the rest of the codebase


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
