### PR TITLE
exchange u and v separately

### DIFF
--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -135,7 +135,8 @@ for the following properties:
 | `turbulent_energy_flux`     | aerodynamic turbulent surface fluxes of energy (sensible and latent heat) | W m⁻²      |
 | `turbulent_moisture_flux`   | aerodynamic turbulent surface fluxes of energy (evaporation)              | kg m⁻² s⁻¹ |
 | `thermo_state_int`          | thermodynamic state at the first internal model level                     |            |
-| `uv_int`                    | horizontal wind velocity vector at the first internal model level         | m s⁻¹      |
+| `u_int`                     | zonal wind velocity vector at the first internal model level              | m s⁻¹      |
+| `v_int`                     | meridional wind velocity vector at the first internal model level         | m s⁻¹      |
 
 - `update_field!(::AtmosModelSimulation. ::Val{property}, field)`:
 A function to update the value of property in the component model

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -307,13 +307,17 @@ Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:height_int}) =
     CC.Spaces.level(CC.Fields.coordinate_field(sim.integrator.u.c).z, 1)
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:height_sfc}) =
     CC.Spaces.level(CC.Fields.coordinate_field(sim.integrator.u.f).z, CC.Utilities.half)
-function Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:uv_int})
+function Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:u_int})
     # NOTE: This calculation is copied from ClimaAtmos (and is allocating! Fix me if you can!)
     int_local_geometry_values = Fields.level(Fields.local_geometry_field(sim.integrator.u.c), 1)
     int_u_values = CC.Spaces.level(sim.integrator.p.precomputed.ᶜu, 1)
-    u = CA.projected_vector_data.(CA.CT1, int_u_values, int_local_geometry_values)
-    v = CA.projected_vector_data.(CA.CT2, int_u_values, int_local_geometry_values)
-    return @. StaticArrays.SVector(u, v)
+    return CA.projected_vector_data.(CA.CT1, int_u_values, int_local_geometry_values)
+end
+function Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:v_int})
+    # NOTE: This calculation is copied from ClimaAtmos (and is allocating! Fix me if you can!)
+    int_local_geometry_values = Fields.level(Fields.local_geometry_field(sim.integrator.u.c), 1)
+    int_u_values = CC.Spaces.level(sim.integrator.p.precomputed.ᶜu, 1)
+    return CA.projected_vector_data.(CA.CT2, int_u_values, int_local_geometry_values)
 end
 
 # extensions required by the Interfacer

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -295,7 +295,9 @@ function compute_surface_fluxes!(
 )
     # `_int` refers to atmos state of center level 1
     z_int = Interfacer.get_field(atmos_sim, Val(:height_int))
-    uₕ_int = Interfacer.get_field(atmos_sim, Val(:uv_int))
+    u_int = Interfacer.get_field(atmos_sim, Val(:u_int))
+    v_int = Interfacer.get_field(atmos_sim, Val(:v_int))
+    uₕ_int = @. StaticArrays.SVector(u_int, v_int)
     thermo_state_int = Interfacer.get_field(atmos_sim, Val(:thermo_state_int))
     z_sfc = Interfacer.get_field(atmos_sim, Val(:height_sfc))
 

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -194,7 +194,8 @@ get_field(
         Val{:turblent_energy_flux},
         Val{:turbulent_moisture_flux},
         Val{:thermo_state_int},
-        Val{:uv_int},
+        Val{:u_int},
+        Val{:v_int},
     },
 ) = get_field_error(sim, val)
 

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -30,7 +30,8 @@ Interfacer.name(sim::TestAtmos2) = "TestAtmos2"
 
 Interfacer.get_field(sim::TestAtmos, ::Val{:height_int}) = sim.integrator.p.z
 Interfacer.get_field(sim::TestAtmos, ::Val{:height_sfc}) = sim.integrator.p.z_sfc
-Interfacer.get_field(sim::TestAtmos, ::Val{:uv_int}) = @. StaticArrays.SVector(sim.integrator.p.u, sim.integrator.p.v)
+Interfacer.get_field(sim::TestAtmos, ::Val{:u_int}) = sim.integrator.p.u
+Interfacer.get_field(sim::TestAtmos, ::Val{:v_int}) = sim.integrator.p.v
 Interfacer.get_field(sim::TestAtmos, ::Val{:thermo_state_int}) =
     TD.PhaseEquil_ρTq.(get_thermo_params(sim), sim.integrator.ρ, sim.integrator.T, sim.integrator.q)
 

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -161,7 +161,8 @@ end
         :turbulent_energy_flux,
         :turbulent_moisture_flux,
         :thermo_state_int,
-        :uv_int,
+        :u_int,
+        :v_int,
     )
         val = Val(value)
         @test_throws ErrorException("undefined field `$value` for " * Interfacer.name(sim)) Interfacer.get_field(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Until now, we've been exchanging `uv_int` from the atmosphere to the coupler. This property is an `SVector`, which can't easily be remapped between spaces. As a step to enable remapping, this PR instead exchanges `u` and `v` individually.

closes #1297

## Content
- [x] replace `get_field(atmos_sim, ::Val{uv_int})` with `get_field(atmos_sim, ::Val{u_int})` and `get_field(atmos_sim, ::Val{v_int})`
- [x] integrated land flux calculation: construct an SVector from u and v
- [x] integrated land flux calculation: use `dummmy_remap!` instead of `field_values` to make it more clear where we should use our upcoming remapping function
- [x] update Interfacer docs


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
