### PR TITLE
Use bucket cache `e_per_area`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,6 +43,7 @@ steps:
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.develop(path=\".\")'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(\"MPI\"); Pkg.add(\"CUDA\");'"
+      - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaLand\", rev=\"tr/add-energy_per_area-bucket\"))'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.precompile()'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.status()'"
 

--- a/experiments/ClimaEarth/Manifest-v1.11.toml
+++ b/experiments/ClimaEarth/Manifest-v1.11.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.4"
 manifest_format = "2.0"
-project_hash = "b128b4b3c921eda6ebd10795a43db24e86ebb375"
+project_hash = "a6b727ee8a2506c47fabb82909c682490f07c2f7"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "e2478490447631aedba0823d4d7a80b2cc8cdb32"
@@ -348,7 +348,9 @@ version = "0.2.13"
 
 [[deps.ClimaLand]]
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
-git-tree-sha1 = "08d08423e0a955180d3eea39c340b81603a00585"
+git-tree-sha1 = "d5ba1073aa5c015f6d25ee9ace265d63ac421197"
+repo-rev = "tr/add-energy_per_area-bucket"
+repo-url = "https://github.com/CliMA/ClimaLand.jl.git"
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
 version = "0.15.14"
 

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -278,7 +278,6 @@ function CoupledSimulation(config_dict::AbstractDict)
                 use_land_diagnostics,
                 albedo_type = land_albedo_type,
                 land_initial_condition,
-                energy_check,
                 parameter_files,
             )
         elseif land_model == "integrated"
@@ -341,7 +340,6 @@ function CoupledSimulation(config_dict::AbstractDict)
             use_land_diagnostics,
             albedo_type = land_albedo_type,
             land_initial_condition,
-            energy_check,
             parameter_files,
         )
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
https://github.com/CliMA/ClimaLand.jl/pull/1104 adds `e_per_area` to the Bucket cache, independent of whether conservation checks are enabled. This allows us to access that field directly and simplify the coupler code. It's tested out here.

closes https://github.com/CliMA/ClimaCoupler.jl/issues/1261

## To-do
- [x] access `p.e_per_area` directly in `get_field(::BucketSimulation, Val(:energy))`
- [x] remove `get_new_cache` method for Bucket
- [x] don't pass `energy_check` to Bucket constructor
