### PR TITLE
Fix insolation update

### DIFF
--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -398,7 +398,9 @@ function Interfacer.add_coupler_fields!(coupler_field_names, atmos_sim::ClimaAtm
     push!(coupler_field_names, atmos_coupler_fields...)
 end
 
-function FieldExchanger.update_sim!(sim::ClimaAtmosSimulation, csf, turbulent_fluxes)
+function FieldExchanger.update_sim!(sim::ClimaAtmosSimulation, csf)
+    # TODO: This function should be removed once we remove cos_zenith_angle as
+    # one of the exchange fields (and use the default method in FieldExchanger)
 
     u = sim.integrator.u
     p = sim.integrator.p
@@ -406,7 +408,7 @@ function FieldExchanger.update_sim!(sim::ClimaAtmosSimulation, csf, turbulent_fl
 
     # Perform radiation-specific updates
     if hasradiation(sim.integrator)
-        !(p.atmos.insolation isa CA.IdealizedInsolation) && CA.set_insolation_variables!(u, p, t, p.atmos.insolation)
+        CA.set_insolation_variables!(u, p, t, p.atmos.insolation)
         Interfacer.update_field!(sim, Val(:surface_direct_albedo), csf.surface_direct_albedo)
         Interfacer.update_field!(sim, Val(:surface_diffuse_albedo), csf.surface_diffuse_albedo)
         Interfacer.update_field!(sim, Val(:surface_temperature), csf)


### PR DESCRIPTION
Switching to PartitionedStateFluxes introduced a bug where insolation was not updated. This is because the correct `update_sim!` method was not being called.

This commit fixes that. In parallel, I also fixed the update of insolation in ClimaAtmos so that it is automatically updated every time RRTGMP is called.

https://github.com/CliMA/ClimaAtmos.jl/pull/3788

As I discuss in that issue, I think the only reason for updating the insolation tuple in ClimaCoupler is to do it more often that the radiation timestep. I think this is because the `cos_zenith_angle` is one of the exchanged field. So, if we remove `cos_zenith_angle` from the exchange fields, we can remove this specialized method in `climaatmos.jl` and use the default one in `FieldExchanger`.
