### PR TITLE
Add `get_field` with `remap`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,14 @@ This allows us to simplify the initial component exchange, since we don't need
 to `step!` component models to get them to compute humidity. Without `step!`,
 we can also remove `reinit!`.
 
+#### Add `get_field` with `remap`. PR[#1314](https://github.com/CliMA/ClimaCoupler.jl/pull/1314)
+
+PR [#1314](https://github.com/CliMA/ClimaCoupler.jl/pull/1314) introduces a new
+method for `get_field`: `get_field(sim, Val(), target_space)`. This new method
+automatically remaps onto `target_space`. Currently, only trivial remapping is
+supported (ie, the same behavior as `dummmy_remap`).
+
+
 #### Turbulent energy flux is split into LHF, SHF. PR[#1309](https://github.com/CliMA/ClimaCoupler.jl/pull/1309)
 Previously, we have exchanged the combined turbulent energy flux `F_turb_energy`;
 This PR splits up the exchanged quantity into `F_lh` and `F_sh`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ method for `get_field`: `get_field(sim, Val(), target_space)`. This new method
 automatically remaps onto `target_space`. Currently, only trivial remapping is
 supported (ie, the same behavior as `dummmy_remap`).
 
+Similarly, `get_field!(target_field, sim, Val())` gets the field in-place.
 
 #### Turbulent energy flux is split into LHF, SHF. PR[#1309](https://github.com/CliMA/ClimaCoupler.jl/pull/1309)
 Previously, we have exchanged the combined turbulent energy flux `F_turb_energy`;

--- a/docs/src/fieldexchanger.md
+++ b/docs/src/fieldexchanger.md
@@ -37,5 +37,4 @@ liquid precipitation, and snow precipitation.
 
 ```@docs
     ClimaCoupler.FieldExchanger.combine_surfaces!
-    ClimaCoupler.FieldExchanger.dummmy_remap!
 ```

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -296,6 +296,8 @@ end
     ClimaCoupler.Interfacer.SlabplanetMode
     ClimaCoupler.Interfacer.SlabplanetAquaMode
     ClimaCoupler.Interfacer.SlabplanetTerraMode
+    ClimaCoupler.Interfacer.remap
+    ClimaCoupler.Interfacer.remap!
 ```
 
 ## Interfacer Internal Functions and Types

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -188,7 +188,7 @@ end
 
 # helpers for get_field extensions, dipatchable on different moisture model options and radiation modes
 
-surface_rain_flux(::CA.DryModel, integrator) = StaticArrays.SVector(eltype(integrator.u)(0))
+surface_rain_flux(::CA.DryModel, integrator) = eltype(integrator.u)(0)
 function surface_rain_flux(::Union{CA.EquilMoistModel, CA.NonEquilMoistModel}, integrator)
     if pkgversion(CA) >= v"0.29.0"
         return integrator.p.precomputed.surface_rain_flux
@@ -197,7 +197,7 @@ function surface_rain_flux(::Union{CA.EquilMoistModel, CA.NonEquilMoistModel}, i
     end
 end
 
-surface_snow_flux(::CA.DryModel, integrator) = StaticArrays.SVector(eltype(integrator.u)(0))
+surface_snow_flux(::CA.DryModel, integrator) = eltype(integrator.u)(0)
 function surface_snow_flux(::Union{CA.EquilMoistModel, CA.NonEquilMoistModel}, integrator)
     if pkgversion(CA) >= v"0.29.0"
         return integrator.p.precomputed.surface_snow_flux
@@ -206,15 +206,15 @@ function surface_snow_flux(::Union{CA.EquilMoistModel, CA.NonEquilMoistModel}, i
     end
 end
 
-surface_radiation_flux(::Nothing, integrator) = StaticArrays.SVector(eltype(integrator.u)(0))
+surface_radiation_flux(::Nothing, integrator) = eltype(integrator.u)(0)
 surface_radiation_flux(::CA.RRTMGPI.AbstractRRTMGPMode, integrator) =
     CC.Fields.level(integrator.p.radiation.ᶠradiation_flux, CC.Utilities.half)
 
-moisture_flux(::CA.DryModel, integrator) = StaticArrays.SVector(eltype(integrator.u)(0))
+moisture_flux(::CA.DryModel, integrator) = eltype(integrator.u)(0)
 moisture_flux(::Union{CA.EquilMoistModel, CA.NonEquilMoistModel}, integrator) =
     CC.Geometry.WVector.(integrator.p.precomputed.sfc_conditions.ρ_flux_q_tot)
 
-ρq_tot(::CA.DryModel, integrator) = zeros(axes(integrator.u.c.uₕ))
+ρq_tot(::CA.DryModel, integrator) = eltype(integrator.u)(0)
 ρq_tot(::Union{CA.EquilMoistModel, CA.NonEquilMoistModel}, integrator) = integrator.u.c.ρq_tot
 
 # extensions required by the Interfacer

--- a/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
@@ -69,15 +69,8 @@ end
     model_sims = (; land_sim = land_sim, atmos_sim = atmos_sim)
 
     # Construct a coupler fields object
-    coupler_fluxes = (;
-        :F_turb_ρτxz => CC.Fields.zeros(boundary_space),
-        :F_turb_ρτyz => CC.Fields.zeros(boundary_space),
-        :F_lh => CC.Fields.zeros(boundary_space),
-        :F_sh => CC.Fields.zeros(boundary_space),
-        :F_turb_moisture => CC.Fields.zeros(boundary_space),
-        :temp1 => CC.Fields.zeros(boundary_space),
-        :temp2 => CC.Fields.zeros(boundary_space),
-    )
+    coupler_fluxes_names = [:F_turb_ρτxz, :F_turb_ρτyz, :F_lh, :F_sh, :F_turb_moisture, :temp1, :temp2]
+    coupler_fluxes = Interfacer.init_coupler_fields(FT, coupler_fluxes_names, boundary_space)
 
     # Initialize the coupler fields so we can perform exchange
     coupler_field_names = Interfacer.default_coupler_fields()

--- a/experiments/ClimaEarth/test/runtests.jl
+++ b/experiments/ClimaEarth/test/runtests.jl
@@ -2,8 +2,6 @@ using SafeTestsets
 import ClimaComms
 ClimaComms.@import_required_backends
 
-gpu_broken = ClimaComms.device() isa ClimaComms.CUDADevice
-
 @safetestset "component model test: ClimaAtmos" begin
     include("component_model_tests/climaatmos_tests.jl")
 end

--- a/experiments/ClimaEarth/user_io/debug_plots.jl
+++ b/experiments/ClimaEarth/user_io/debug_plots.jl
@@ -182,7 +182,7 @@ function debug(sim::Interfacer.ComponentModelSimulation, dir)
             ax = Makie.Axis(fig[i, j * 2 - 1], title = string(field_name) * print_extrema(field))
             if field isa AbstractArray
                 lin = Makie.lines!(ax, Array(field))
-            else
+            elseif field isa CC.Fields.Field
                 # Copy field onto cpu space if necessary
                 cpu_field = CC.to_cpu(field)
                 if cpu_field isa CC.Fields.ExtrudedCubedSphereSpectralElementField3D
@@ -216,6 +216,12 @@ function print_extrema(field::Union{CC.Fields.Field, Vector, StaticArrays.SVecto
     ext_vals = extrema(field)
     min = Printf.@sprintf("%.2E", ext_vals[1])
     max = Printf.@sprintf("%.2E", ext_vals[2])
+    return " [$min, $max]"
+end
+
+function print_extrema(num::Number)
+    min = Printf.@sprintf("%.2E", num)
+    max = Printf.@sprintf("%.2E", num)
     return " [$min, $max]"
 end
 

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -301,23 +301,23 @@ function compute_surface_fluxes!(
     thermo_params,
 )
     # `_int` refers to atmos state of center level 1
-    z_int = Interfacer.get_field(atmos_sim, Val(:height_int))
-    u_int = Interfacer.get_field(atmos_sim, Val(:u_int))
-    v_int = Interfacer.get_field(atmos_sim, Val(:v_int))
+    z_int = Interfacer.get_field(atmos_sim, Val(:height_int), boundary_space)
+    u_int = Interfacer.get_field(atmos_sim, Val(:u_int), boundary_space)
+    v_int = Interfacer.get_field(atmos_sim, Val(:v_int), boundary_space)
     uₕ_int = @. StaticArrays.SVector(u_int, v_int)
-    thermo_state_int = Interfacer.get_field(atmos_sim, Val(:thermo_state_int))
-    z_sfc = Interfacer.get_field(atmos_sim, Val(:height_sfc))
+    thermo_state_int = Interfacer.get_field(atmos_sim, Val(:thermo_state_int), boundary_space)
+    z_sfc = Interfacer.get_field(atmos_sim, Val(:height_sfc), boundary_space)
 
     # get area fraction (min = 0, max = 1)
-    area_fraction = Interfacer.get_field(sim, Val(:area_fraction))
+    area_fraction = Interfacer.get_field(sim, Val(:area_fraction), boundary_space)
 
     thermo_state_sfc = FluxCalculator.surface_thermo_state(sim, thermo_params, atmos_sim)
 
     surface_params = FluxCalculator.get_surface_params(atmos_sim)
 
-    z0m = Interfacer.get_field(sim, Val(:roughness_momentum))
-    z0b = Interfacer.get_field(sim, Val(:roughness_buoyancy))
-    beta = Interfacer.get_field(sim, Val(:beta))
+    z0m = Interfacer.get_field(sim, Val(:roughness_momentum), boundary_space)
+    z0b = Interfacer.get_field(sim, Val(:roughness_buoyancy), boundary_space)
+    beta = Interfacer.get_field(sim, Val(:beta), boundary_space)
     FT = eltype(z0m)
     scheme_properties = (; z0b = z0b, z0m = z0m, Ch = FT(0), Cd = FT(0), beta = beta, gustiness = FT(1))
 
@@ -372,9 +372,9 @@ function compute_surface_fluxes!(
     @. csf.ustar += ustar * area_fraction
     @. csf.buoyancy_flux += buoyancy_flux * area_fraction
 
-    z0m = Interfacer.get_field(sim, Val(:roughness_momentum))
-    z0b = Interfacer.get_field(sim, Val(:roughness_buoyancy))
-    beta = Interfacer.get_field(sim, Val(:beta))
+    z0m = Interfacer.get_field(sim, Val(:roughness_momentum), boundary_space)
+    z0b = Interfacer.get_field(sim, Val(:roughness_buoyancy), boundary_space)
+    beta = Interfacer.get_field(sim, Val(:beta), boundary_space)
 
     @. csf.z0m_sfc += z0m * area_fraction
     @. csf.z0b_sfc += z0b * area_fraction

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -236,14 +236,24 @@ get_field(sim::SurfaceModelSimulation, ::Val{:height_disp}) = convert(eltype(sim
 
 
 """
-    get_field(sim, what, boundary_space)
+    get_field(sim, what, target_space)
 
-Return `what` in `sim` remapped onto the `boundary_space`
+Return `quantity` in `sim` remapped onto the `target_space`
 
 This is equivalent to calling `get_field`, and then `remap`.
 """
-function get_field(sim, what, boundary_space)
-    return remap(get_field(sim, what), boundary_space)
+function get_field(sim, quantity, target_space)
+    return remap(get_field(sim, quantity), target_space)
+end
+
+"""
+    get_field!(target_field, sim, quantity)
+
+Remap `quantity` in `sim` remapped onto the `target_field`.
+"""
+function get_field!(target_field, sim, quantity)
+    remap!(target_field, get_field(sim, quantity))
+    return nothing
 end
 
 """
@@ -396,7 +406,7 @@ Remap the given `field` onto the `target_space`.
 
 Non-ClimaCore fields should provide a method to this function.
 
-TODO: Add in-place option to make this non-allocating.
+TODO: Add support for different source and target fields
 """
 function remap end
 
@@ -418,9 +428,17 @@ function remap(num::Number, target_space::CC.Spaces.AbstractSpace)
     return num
 end
 
-# Used in tests
-function remap(field, ::Nothing)
-    return field
+"""
+    remap!(target_field, source)
+
+Remap the given `source` onto the `target_field`.
+
+Non-ClimaCore fields should provide a method to [`Interfacer.remap`](@ref), or directly to this
+function.
+"""
+function remap!(target_field, source)
+    target_field .= remap(source, axes(target_field))
+    return nothing
 end
 
 end # module

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -108,15 +108,6 @@ Interfacer.update_field!(sim::TestSurfaceSimulationLand, ::Val{:liquid_precipita
 Interfacer.update_field!(sim::TestSurfaceSimulationLand, ::Val{:snow_precipitation}, field) = nothing
 
 for FT in (Float32, Float64)
-    @testset "test dummmy_remap!" begin
-        test_space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4)
-        test_field_ones = CC.Fields.ones(test_space)
-        target_field = CC.Fields.zeros(test_space)
-
-        FieldExchanger.dummmy_remap!(target_field, test_field_ones)
-        @test parent(target_field) == parent(test_field_ones)
-    end
-
     @testset "test update_surface_fractions!" begin
         test_space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4)
         # Construct land fraction of 0s in top half, 1s in bottom half

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -8,6 +8,10 @@ import Thermodynamics as TD
 import Thermodynamics.Parameters as TDP
 import ClimaCoupler: Interfacer
 
+function Interfacer.remap(field, ::Nothing)
+    return field
+end
+
 # test for a simple generic surface model
 struct DummySimulation{S} <: Interfacer.SeaIceModelSimulation
     space::S


### PR DESCRIPTION
This commit adds a method to `Interfacer.get_field`. This method takes in a `target_space` and remaps the field onto the space. This is needed to support Oceananigans fields.

Only the trivial case with `target_space` same as original space is currently supported.

In the future, we need to:
- Carefully handle non-scalars (or just exchange scalars)
- Add support for remapping across different spaces

@coderabbit ignore
