### PR TITLE
Remove test bash script job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -350,16 +350,6 @@ steps:
           slurm_mem: 20GB
           slurm_gpus: 1
 
-  - group: "Test restart run and bash script"
-    steps:
-      - label: "Submit and Monitor sbatch Job on Caltech HPC"
-        # check that (1) the script can be succesfully submitted, (2) it runs successfully
-        command: "test/mpi_tests/test_sbatch_script.sh"
-        agents:
-          slurm_ntasks: 1
-          slurm_time: 30
-        soft_fail: true
-
   - wait
 
   # plot job performance history


### PR DESCRIPTION
The "Submit and Monitor sbatch Job" soft-fails all the time and no one really looks at it. The job also submits its own slurm jobs, which are not tracked by buildkite. This is problem because when a build is canceled, those jobs become stray (and are not cleaned up)

This commit removes the job.
