### PR TITLE
Add `subsurface_face` to `ClimaLandSimulation` domain

### DIFF
--- a/experiments/ClimaEarth/components/land/climaland_helpers.jl
+++ b/experiments/ClimaEarth/components/land/climaland_helpers.jl
@@ -51,7 +51,8 @@ function make_land_domain(
     verttopology = CC.Topologies.IntervalTopology(vertmesh)
     vert_center_space = CC.Spaces.CenterFiniteDifferenceSpace(verttopology)
     subsurface_space = CC.Spaces.ExtrudedFiniteDifferenceSpace(atmos_boundary_space, vert_center_space)
-    space = (; surface = atmos_boundary_space, subsurface = subsurface_space)
+    subsurface_face_space = CC.Spaces.face_space(subsurface_space)
+    space = (; surface = atmos_boundary_space, subsurface = subsurface_space, subsurface_face = subsurface_face_space)
 
     fields = ClimaLand.Domains.get_additional_coordinate_field_data(subsurface_space)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This [PR](https://github.com/CliMA/ClimaLand.jl/pull/1121#issuecomment-2831436988) in ClimaLand introduces
a new domain, which needs to be added to the ClimaLandSimulation.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
- adds `subsurface_face` to `ClimaLandSimulation` domains


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
