### PR TITLE
Remove unnecessary update_surface_fractions call

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,8 +3,6 @@ import ClimaComms
 ClimaComms.@import_required_backends
 import Pkg, Artifacts
 
-gpu_broken = ClimaComms.device() isa ClimaComms.CUDADevice
-
 # Download test-only artifacts
 #
 # (Currently not natively supported by Julia)


### PR DESCRIPTION
At the very beginning our a simulation, `update_surface_conditions!` should do nothing, because the surface fractions were already initialized at the correct time. This commir removes that call.

This commit also adds a second atmos callback that modifies the cache.
