### PR TITLE
Change signature for `turbulent_fluxes!`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,23 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Change signature for `turbulent_fluxes!`. PR[#1327](https://github.com/CliMA/ClimaCoupler.jl/pull/1327)
+
+`FluxCalculator.turbulent_fluxes!` can now be called in two ways:
+```julia
+turbulent_fluxes!(coupled_simulation::CoupledSimulation)
+turbulent_fluxes!(coupler_fields, model_sims, thermo_params)
+```
+The previous signature was
+```julia
+turbulent_fluxes!(model_sims, coupler_fields, boundary_space, thermo_params)
+```
+The new signature simplifies calling the function, ensures that the mutating
+convention is respected (`turbulent_fluxes!` mutates `coupler_fields`), and
+removes unnecessary arguments and type restrictions.
+
+Similarly, `get_surface_fluxes!` was renamed to `get_surface_fluxes`. 
+
 #### Simplify initial component model exchange. PR[#1305](https://github.com/CliMA/ClimaCoupler.jl/pull/1305)
 
 Surface humidity is now computed from the atmosphere state and surface temperature,

--- a/docs/src/fluxcalculator.md
+++ b/docs/src/fluxcalculator.md
@@ -19,7 +19,7 @@ The final result of `turbulent_fluxes!` is an area-weighted sum of
 all the contributions of the various surfaces.
 
 The default method of [`FluxCalculator.compute_surface_fluxes!`](@ref), in turn,
-calls [`FluxCalculator.get_surface_fluxes!`](@ref). This function uses a thermal
+calls [`FluxCalculator.get_surface_fluxes`](@ref). This function uses a thermal
 state obtained by using the model surface temperature, extrapolates atmospheric
 density adiabatically to the surface, and with the surface humidity (if
 available, if not, assuming a saturation specific humidity for liquid phase).
@@ -54,6 +54,6 @@ within the atmospheric model.
 ```@docs
     ClimaCoupler.FluxCalculator.turbulent_fluxes!
     ClimaCoupler.FluxCalculator.compute_surface_fluxes!
-    ClimaCoupler.FluxCalculator.get_surface_fluxes!
+    ClimaCoupler.FluxCalculator.get_surface_fluxes
     ClimaCoupler.FluxCalculator.update_turbulent_fluxes!
 ```

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -518,7 +518,7 @@ function CoupledSimulation(config_dict::AbstractDict)
         # 5. Now we have all information needed for calculating the initial
         # turbulent surface fluxes. Calculate and update turbulent fluxes for each surface model,
         # and save the weighted average in coupler fields
-        FluxCalculator.turbulent_fluxes!(cs.model_sims, cs.fields, cs.boundary_space, cs.thermo_params)
+        FluxCalculator.turbulent_fluxes!(cs)
     end
     return cs
 end
@@ -674,7 +674,7 @@ function step!(cs::CoupledSimulation)
     FieldExchanger.exchange!(cs)
 
     ## calculate turbulent fluxes in the coupler and update the model simulations with them
-    FluxCalculator.turbulent_fluxes!(cs.model_sims, cs.fields, cs.boundary_space, cs.thermo_params)
+    FluxCalculator.turbulent_fluxes!(cs)
 
     ## update water albedo from wind at dt_water_albedo
     ## (this will be extended to a radiation callback from the coupler)

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -194,11 +194,11 @@ for FT in (Float32, Float64)
 
         # calculate turbulent fluxes
         thermo_params = get_thermo_params(atmos_sim)
-        FluxCalculator.turbulent_fluxes!(model_sims, fields, boundary_space, thermo_params)
+        FluxCalculator.turbulent_fluxes!(fields, model_sims, thermo_params)
 
         # calculating the fluxes twice ensures that no accumulation occurred (i.e. fluxes are reset to zero each time)
         # TODO: this will need to be extended once flux accumulation is re-enabled
-        FluxCalculator.turbulent_fluxes!(model_sims, fields, boundary_space, thermo_params)
+        FluxCalculator.turbulent_fluxes!(fields, model_sims, thermo_params)
 
         windspeed = @. hypot(atmos_sim.integrator.p.u, atmos_sim.integrator.p.v)
 


### PR DESCRIPTION
`FluxCalculator.turbulent_fluxes!` can now be called in two ways:
```julia
turbulent_fluxes!(coupled_simulation::CoupledSimulation)
turbulent_fluxes!(coupler_fields, model_sims, thermo_params)
```
The previous signature was
```julia
turbulent_fluxes!(model_sims, coupler_fields, boundary_space, thermo_params)
```
The new signature simplifies calling the function, ensures that the mutating convention is respected (`turbulent_fluxes!` mutates `coupler_fields`), and removes unnecessary arguments and type restrictions.

Closes #1295
