### PR TITLE
Remove Interfacer.float_type

### DIFF
--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -283,7 +283,6 @@ end
     ClimaCoupler.Interfacer.ComponentModelSimulation
     ClimaCoupler.Interfacer.AbstractSurfaceStub
     ClimaCoupler.Interfacer.SurfaceStub
-    ClimaCoupler.Interfacer.float_type
     ClimaCoupler.Interfacer.get_field
     ClimaCoupler.Interfacer.update_field!
     ClimaCoupler.Interfacer.AbstractSlabplanetSimulationMode

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -6,6 +6,8 @@ atmospheric and surface component models.
 """
 module FieldExchanger
 
+import ClimaCore as CC
+
 import ..Interfacer, ..FluxCalculator, ..Utilities
 import Thermodynamics as TD
 import Thermodynamics.Parameters as TDP
@@ -22,9 +24,8 @@ Maintains the invariant that the sum of area fractions is 1 at all points.
 - `cs`: [Interfacer.CoupledSimulation] containing area fraction information.
 """
 function update_surface_fractions!(cs::Interfacer.CoupledSimulation)
-    FT = Interfacer.float_type(cs)
-
     boundary_space = cs.boundary_space
+    FT = CC.Spaces.undertype(boundary_space)
 
     # land fraction is static
     land_fraction = Interfacer.get_field(cs.model_sims.land_sim, Val(:area_fraction), boundary_space)

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -14,7 +14,6 @@ import SciMLBase: step!
 import ClimaUtilities.TimeManager: ITime, date
 
 export CoupledSimulation,
-    float_type,
     ComponentModelSimulation,
     AtmosModelSimulation,
     SurfaceModelSimulation,
@@ -95,13 +94,6 @@ Return the model date at the current timestep.
 - `cs`: [CoupledSimulation] containing info about the simulation
 """
 current_date(cs::Interfacer.CoupledSimulation) = cs.t[] isa ITime ? date(cs.t[]) : cs.start_date + Dates.second(cs.t[])
-
-"""
-    float_type(::CoupledSimulation)
-
-Return the floating point type backing `T`: `T` can either be an object or a type.
-"""
-float_type(::CoupledSimulation{FT}) where {FT} = FT
 
 """
     default_coupler_fields()

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -31,10 +31,12 @@ Interfacer.get_field(sim::Interfacer.SurfaceModelSimulation, ::Val{:var_float}) 
 
 for FT in (Float32, Float64)
     @testset "test CoupledSim construction, float_type for FT=$FT" begin
+        boundary_space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4)
+
         cs = Interfacer.CoupledSimulation{FT}(
-            nothing, # comms_ctx
+            ClimaComms.context(boundary_space),
             nothing, # dates
-            nothing, # boundary_space
+            boundary_space,
             nothing, # fields
             nothing, # conservation_checks
             (Int(0), Int(1000)), # tspan
@@ -46,8 +48,8 @@ for FT in (Float32, Float64)
             nothing, # thermo_params
             nothing, # diags_handler
         )
+        @test CC.Spaces.undertype(cs.boundary_space) == FT
 
-        @test Interfacer.float_type(cs) == FT
     end
 
     @testset "get_field indexing for FT=$FT" begin


### PR DESCRIPTION
`Interfacer.float_type` was used only in one place and can be easily replaced with other functions.
