### PR TITLE
misc cleanup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,14 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Misc. interface cleanup
+
+Including:
+- Remove `ρ_sfc` from surface model caches
+- Remove `F_radiative` from `add_coupler_fields` since it's a default
+- Remove atmosphere `get_field` method for `thermo_state_int`, since it's now constructed on the boundary space
+- Update Interfacer docs
+
 #### Construct thermo states from exchanged T, q, ρ. PR[#1293](https://github.com/CliMA/ClimaCoupler.jl/pull/1293)
 
 Instead of exchanging atmosphere and surface thermo states, exchange T, q, ρ

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -284,8 +284,6 @@ function Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:SW_d})
         CC.Utilities.half,
     )
 end
-Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:thermo_state_int}) =
-    CC.Spaces.level(sim.integrator.p.precomputed.ᶜts, 1)
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:water}) =
     ρq_tot(sim.integrator.p.atmos.moisture_model, sim.integrator)
 function Interfacer.update_field!(sim::ClimaAtmosSimulation, ::Val{:surface_temperature}, csf)

--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -310,10 +310,9 @@ Extend Interfacer.add_coupler_fields! to add the fields required for BucketSimul
 
 The fields added are:
 - `:ρ_sfc`
-- `:F_radiative` (for radiation input)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::BucketSimulation)
-    bucket_coupler_fields = [:ρ_sfc, :F_radiative]
+    bucket_coupler_fields = [:ρ_sfc]
     push!(coupler_field_names, bucket_coupler_fields...)
 end
 

--- a/experiments/ClimaEarth/components/ocean/prescr_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_ocean.jl
@@ -14,7 +14,6 @@ Ocean roughness follows the https://github.com/NOAA-GFDL/ice_param/blob/main/oce
 
 The cache is expected to contain the following variables:
 - `T_sfc` (surface temperature [K])
-- `ρ_sfc` (surface air density [kg / m3])
 - `z0m` (roughness length for momentum [m])
 - `z0b` (roughness length for tracers [m])
 - `beta` (evaporation scaling factor)
@@ -86,7 +85,6 @@ function PrescribedOceanSimulation(
     # Create the cache
     cache = (;
         T_sfc = SST_init,
-        ρ_sfc = zeros(space),
         z0m = z0m,
         z0b = z0b,
         beta = beta,

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -175,17 +175,6 @@ Interfacer.update_field!(sim::PrescribedIceSimulation, ::Val{:turbulent_moisture
 # extensions required by FieldExchanger
 Interfacer.step!(sim::PrescribedIceSimulation, t) = Interfacer.step!(sim.integrator, t - sim.integrator.t, true)
 
-"""
-Extend Interfacer.add_coupler_fields! to add the fields required for PrescribedIceSimulation.
-
-The fields added are:
-- `:F_radiative` (for radiation input)
-"""
-function Interfacer.add_coupler_fields!(coupler_field_names, ::PrescribedIceSimulation)
-    ice_coupler_fields = [:F_radiative]
-    push!(coupler_field_names, ice_coupler_fields...)
-end
-
 function FluxCalculator.update_turbulent_fluxes!(sim::PrescribedIceSimulation, fields::NamedTuple)
     (; F_lh, F_sh) = fields
     @. sim.integrator.p.F_turb_energy = F_lh + F_sh

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -118,7 +118,6 @@ function PrescribedIceSimulation(
     cache = (;
         F_turb_energy = CC.Fields.zeros(space),
         F_radiative = CC.Fields.zeros(space),
-        ρ_sfc = CC.Fields.zeros(space),
         area_fraction = ice_fraction,
         SIC_timevaryinginput = SIC_timevaryinginput,
         land_fraction = land_fraction,
@@ -162,9 +161,6 @@ It multiplies the the slab temperature by the heat capacity, density, and depth.
 Interfacer.get_field(sim::PrescribedIceSimulation, ::Val{:energy}) =
     sim.integrator.p.params.ρ .* sim.integrator.p.params.c .* sim.integrator.u.T_sfc .* sim.integrator.p.params.h
 
-function Interfacer.update_field!(sim::PrescribedIceSimulation, ::Val{:air_density}, field)
-    parent(sim.integrator.p.ρ_sfc) .= parent(field)
-end
 function Interfacer.update_field!(sim::PrescribedIceSimulation, ::Val{:area_fraction}, field::CC.Fields.Field)
     sim.integrator.p.area_fraction .= field
 end
@@ -183,11 +179,10 @@ Interfacer.step!(sim::PrescribedIceSimulation, t) = Interfacer.step!(sim.integra
 Extend Interfacer.add_coupler_fields! to add the fields required for PrescribedIceSimulation.
 
 The fields added are:
-- `:ρ_sfc` (for humidity calculation)
 - `:F_radiative` (for radiation input)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::PrescribedIceSimulation)
-    ice_coupler_fields = [:ρ_sfc, :F_radiative]
+    ice_coupler_fields = [:F_radiative]
     push!(coupler_field_names, ice_coupler_fields...)
 end
 

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -138,17 +138,6 @@ end
 # extensions required by FieldExchanger
 Interfacer.step!(sim::SlabOceanSimulation, t) = Interfacer.step!(sim.integrator, t - sim.integrator.t, true)
 
-"""
-Extend Interfacer.add_coupler_fields! to add the fields required for SlabOceanSimulation.
-
-The fields added are:
-- `:F_radiative` (for radiation input)
-"""
-function Interfacer.add_coupler_fields!(coupler_field_names, ::SlabOceanSimulation)
-    ocean_coupler_fields = [:F_radiative]
-    push!(coupler_field_names, ocean_coupler_fields...)
-end
-
 function FluxCalculator.update_turbulent_fluxes!(sim::SlabOceanSimulation, fields::NamedTuple)
     (; F_lh, F_sh) = fields
     @. sim.integrator.p.F_turb_energy = F_lh + F_sh

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -76,7 +76,6 @@ function SlabOceanSimulation(
         params = params,
         F_turb_energy = CC.Fields.zeros(space),
         F_radiative = CC.Fields.zeros(space),
-        ρ_sfc = CC.Fields.zeros(space),
         area_fraction = area_fraction,
         thermo_params = thermo_params,
         # add dss_buffer to cache to avoid runtime dss allocation
@@ -123,9 +122,6 @@ Interfacer.get_field(sim::SlabOceanSimulation, ::Val{:energy}) =
 function Interfacer.update_field!(sim::SlabOceanSimulation, ::Val{:area_fraction}, field::CC.Fields.Field)
     sim.integrator.p.area_fraction .= field
 end
-function Interfacer.update_field!(sim::SlabOceanSimulation, ::Val{:air_density}, field)
-    parent(sim.integrator.p.ρ_sfc) .= parent(field)
-end
 function Interfacer.update_field!(sim::SlabOceanSimulation, ::Val{:radiative_energy_flux_sfc}, field)
     parent(sim.integrator.p.F_radiative) .= parent(field)
 end
@@ -146,11 +142,10 @@ Interfacer.step!(sim::SlabOceanSimulation, t) = Interfacer.step!(sim.integrator,
 Extend Interfacer.add_coupler_fields! to add the fields required for SlabOceanSimulation.
 
 The fields added are:
-- `:ρ_sfc` (for humidity calculation)
 - `:F_radiative` (for radiation input)
 """
 function Interfacer.add_coupler_fields!(coupler_field_names, ::SlabOceanSimulation)
-    ocean_coupler_fields = [:ρ_sfc, :F_radiative]
+    ocean_coupler_fields = [:F_radiative]
     push!(coupler_field_names, ocean_coupler_fields...)
 end
 

--- a/experiments/ClimaEarth/test/component_model_tests/prescr_ocean_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/prescr_ocean_tests.jl
@@ -49,7 +49,6 @@ end
     @test sim isa Interfacer.AbstractSurfaceStub
     # Check that the cache is correctly initialized
     @test sim.cache.T_sfc == SST_expected
-    @test sim.cache.ρ_sfc == zeros(space)
     @test sim.cache.z0m == FT(5.8e-5)
     @test sim.cache.z0b == FT(5.8e-5)
     @test sim.cache.beta == FT(1)

--- a/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
@@ -49,7 +49,6 @@ for FT in (Float32, Float64)
                 area_fraction = SIC_init,
                 SIC_timevaryinginput = SIC_timevaryinginput,
                 land_fraction = CC.Fields.zeros(space),
-                ρ_sfc = CC.Fields.ones(space),
                 thermo_params = thermo_params,
                 dt = dt,
             )

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -194,7 +194,6 @@ get_field(
         Val{:snow_precipitation},
         Val{:turblent_energy_flux},
         Val{:turbulent_moisture_flux},
-        Val{:thermo_state_int},
         Val{:u_int},
         Val{:v_int},
     },

--- a/src/surface_stub.jl
+++ b/src/surface_stub.jl
@@ -5,7 +5,6 @@ An abstract type representing a simple stand-in surface model.
 Any concrete type extending this abstract type should have a `cache` field that
 contains the necessary fields for the simulation, at minimum the following:
     - `T_sfc` (surface temperature [K])
-    - `ρ_sfc` (surface air density [kg / m3])
     - `z0m` (roughness length for momentum [m])
     - `z0b` (roughness length for tracers [m])
     - `beta` (evaporation scaling factor)
@@ -53,9 +52,6 @@ end
 function update_field!(sim::AbstractSurfaceStub, ::Val{:surface_temperature}, field::CC.Fields.Field)
     sim.cache.T_sfc .= field
 end
-function update_field!(sim::AbstractSurfaceStub, ::Val{:air_density}, field)
-    parent(sim.cache.ρ_sfc) .= parent(field)
-end
 function update_field!(sim::AbstractSurfaceStub, ::Val{:surface_direct_albedo}, field::CC.Fields.Field)
     sim.cache.α_direct .= field
 end
@@ -69,26 +65,6 @@ update_field!(::AbstractSurfaceStub, ::Val{:turbulent_energy_flux}, field) = not
 update_field!(::AbstractSurfaceStub, ::Val{:turbulent_moisture_flux}, field) = nothing
 
 ## Extensions of FieldExchanger.jl functions
-
-"""
-    update_sim!(::AbstractSurfaceStub, csf, area_fraction)
-
-The stub surface simulation only updates the air density (needed for the turbulent flux calculation).
-"""
-function update_sim!(sim::AbstractSurfaceStub, csf, area_fraction)
-    update_field!(sim, Val(:air_density), csf.ρ_sfc)
-end
-
-"""
-Extend Interfacer.add_coupler_fields! to add the fields required for AbstractSurfaceStub.
-
-The fields added are:
-- `:ρ_sfc` (for humidity calculation)
-"""
-function Interfacer.add_coupler_fields!(coupler_field_names, ::AbstractSurfaceStub)
-    surface_coupler_fields = [:ρ_sfc]
-    push!(coupler_field_names, surface_coupler_fields...)
-end
 
 """
     step!(::AbstractSurfaceStub, t)

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -285,7 +285,6 @@ for FT in (Float32, Float64)
             land_sim = TestSurfaceSimulationLand(land_fields),
             stub_sim = Interfacer.SurfaceStub((;
                 area_fraction = CC.Fields.ones(boundary_space),
-                ρ_sfc = CC.Fields.ones(boundary_space),
                 albedo_direct = CC.Fields.ones(boundary_space),
                 albedo_diffuse = CC.Fields.ones(boundary_space),
             )),

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -34,8 +34,6 @@ Interfacer.get_field(sim::TestAtmos, ::Val{:height_int}) = sim.integrator.p.z
 Interfacer.get_field(sim::TestAtmos, ::Val{:height_sfc}) = sim.integrator.p.z_sfc
 Interfacer.get_field(sim::TestAtmos, ::Val{:u_int}) = sim.integrator.p.u
 Interfacer.get_field(sim::TestAtmos, ::Val{:v_int}) = sim.integrator.p.v
-Interfacer.get_field(sim::TestAtmos, ::Val{:thermo_state_int}) =
-    TD.PhaseEquil_ρTq.(get_thermo_params(sim), sim.integrator.ρ, sim.integrator.T, sim.integrator.q)
 
 function FieldExchanger.import_atmos_fields!(csf, sim::TestAtmos, atmos_sim)
     # update atmos properties in coupler fields needed to compute surface fluxes
@@ -170,7 +168,6 @@ for FT in (Float32, Float64)
             )
         thermo_state_atmos =
             TD.PhaseEquil_ρTq.(thermo_params, atmos_sim.integrator.ρ, atmos_sim.integrator.T, atmos_sim.integrator.q)
-        thermo_state_atmos = Interfacer.get_field(atmos_sim, Val(:thermo_state_int))
 
         # Get surface properties
         z_sfc = Interfacer.get_field(atmos_sim, Val(:height_sfc))

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -74,7 +74,6 @@ for FT in (Float32, Float64)
             z0m = 4,
             z0b = 5,
             beta = 6,
-            ρ_sfc = FT(1),
             phase = TD.Liquid(),
             thermo_params = thermo_params,
         ))
@@ -157,7 +156,6 @@ end
         :radiative_energy_flux_sfc,
         :radiative_energy_flux_toa,
         :snow_precipitation,
-        :thermo_state_int,
         :u_int,
         :v_int,
     )


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #1337

## Content
- [x] Remove `ρ_sfc` from simple surface models (prescribed ocean, prescribed sea ice, slab ocean, surface stub)
- [x] Remove `F_radiative` from `add_coupler_fields` since it's already a default
- [x] Remove atmosphere `get_field` method for `thermo_state_int`, since it's now constructed on the boundary space
- [x] Update Interfacer docs

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
