### PR TITLE
Remove uneeded usage of parent in tests

### DIFF
--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -206,8 +206,8 @@ for FT in (Float32, Float64)
         @test fields.F_lh ≈ fluxes_expected.F_lh
         @test fields.F_sh ≈ fluxes_expected.F_sh
         # The ClimaCore DataLayout underlying the expected moisture flux uses
-        # Array instead of SubArray, so we can't compare the fields directly.
-        @test all(parent(fields.F_turb_moisture) .≈ parent(fluxes_expected.F_turb_moisture))
+        # Array instead of SubArray, so we can't compare the fields directly without copy.
+        @test copy(fields.F_turb_moisture) ≈ fluxes_expected.F_turb_moisture
     end
 
     @testset "get_surface_params for FT=$FT" begin

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -58,9 +58,10 @@ for FT in (Float32, Float64)
 
     @testset "get_field indexing for FT=$FT" begin
         space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4, context)
+        field_of_ones = ones(space)
         for sim in (DummySimulation(space), DummySimulation2(space), DummySimulation3(space))
             # field
-            @test Array(parent(Interfacer.get_field(sim, Val(:var))))[1] == FT(1)
+            @test Interfacer.get_field(sim, Val(:var)) == field_of_ones
             # float
             @test Interfacer.get_field(sim, Val(:var_float)) == FT(2)
         end
@@ -109,10 +110,10 @@ for FT in (Float32, Float64)
         Interfacer.update_field!(stub, Val(:surface_direct_albedo), ones(boundary_space) .* 3)
         Interfacer.update_field!(stub, Val(:surface_diffuse_albedo), ones(boundary_space) .* 4)
 
-        @test Array(parent(Interfacer.get_field(stub, Val(:area_fraction))))[1] == FT(1)
-        @test Array(parent(Interfacer.get_field(stub, Val(:surface_temperature))))[1] == FT(2)
-        @test Array(parent(Interfacer.get_field(stub, Val(:surface_direct_albedo))))[1] == FT(3)
-        @test Array(parent(Interfacer.get_field(stub, Val(:surface_diffuse_albedo))))[1] == FT(4)
+        @test Interfacer.get_field(stub, Val(:area_fraction)) == fill(FT(1), boundary_space)
+        @test Interfacer.get_field(stub, Val(:surface_temperature)) == fill(FT(2), boundary_space)
+        @test Interfacer.get_field(stub, Val(:surface_direct_albedo)) == fill(FT(3), boundary_space)
+        @test Interfacer.get_field(stub, Val(:surface_diffuse_albedo)) == fill(FT(4), boundary_space)
     end
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #1322 


## To-do
`parent` is still used in the following test:

```
        land_fraction = CC.Fields.ones(test_space)
        dims = size(parent(land_fraction))
        m = dims[1]
        n = dims[2]
        parent(land_fraction)[1:(m ÷ 2), :, :, :] .= FT(0)

        # Construct ice fraction of 0s on left, 0.5s on right
        ice_d = CC.Fields.zeros(test_space)
        parent(ice_d)[:, (n ÷ 2 + 1):n, :, :] .= FT(0.5)
```

It could probably be replaced with `CC.Fields.field2array`, but I was not sure
if the top half/ bottom half and left/right relationships are important for the test. 

## Content
Replace `parent` usage with field comparisons in tests.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
