### PR TITLE
Update leaderboard code for use in calibration

### DIFF
--- a/experiments/ClimaEarth/Manifest-v1.11.toml
+++ b/experiments/ClimaEarth/Manifest-v1.11.toml
@@ -285,9 +285,9 @@ weakdeps = ["SparseArrays"]
 
 [[deps.ClimaAnalysis]]
 deps = ["Artifacts", "Dates", "Interpolations", "NCDatasets", "NaNStatistics", "OrderedCollections", "Reexport", "Statistics", "Unitful"]
-git-tree-sha1 = "0a9f4a6de147d0a9dc09f2e8f702f76dd6777e07"
+git-tree-sha1 = "810e7bf67726ab1a3a3d7fc25fc5e07ff35b2f8e"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
-version = "0.5.16"
+version = "0.5.17"
 weakdeps = ["GeoMakie", "Makie"]
 
     [deps.ClimaAnalysis.extensions]

--- a/experiments/ClimaEarth/leaderboard/leaderboard.jl
+++ b/experiments/ClimaEarth/leaderboard/leaderboard.jl
@@ -6,13 +6,14 @@ import Dates
 include("data_sources.jl")
 
 """
-    compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)
+    compute_leaderboard(leaderboard_base_path, diagnostics_folder_path, spinup)
 
 Plot the biases and a leaderboard of various variables defined over longitude, latitude, and
 time.
 
-The parameter `leaderboard_base_path` is the path to save the leaderboards and bias plots,
-and `diagnostics_folder_path` is the path to the simulation data.
+The argument `leaderboard_base_path` is the path to save the leaderboards and bias plots,
+`diagnostics_folder_path` is the path to the simulation data, and `spinup` is the number
+of months to remove from the beginning of the simulation.
 
 Loading and preprocessing simulation data is done by `get_sim_var_dict`. Loading and
 preprocessing observational data is done by `get_obs_var_dict`. The ranges of the bias plots
@@ -20,7 +21,7 @@ are determined by `get_compare_vars_biases_plot_extrema`. The groups of variable
 the bias plots are determined by `get_compare_vars_biases_groups()`. Loading the RMSEs from
 other models is done by `get_rmse_var_dict`. See the functions defined in data_sources.jl.
 """
-function compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)
+function compute_leaderboard(leaderboard_base_path, diagnostics_folder_path, spinup)
     @info "Error against observations"
 
     # Get everything we need from data_sources.jl
@@ -49,8 +50,8 @@ function compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)
         obs_var = obs_var_dict[short_name](sim_var.attributes["start_date"])
 
         # Remove first spin_up_months from simulation
-        spin_up_months = 3
-        spinup_cutoff = spin_up_months * 31 * 86400.0
+        spinup_months = spinup
+        spinup_cutoff = spinup_months * 31 * 86400.0
         ClimaAnalysis.times(sim_var)[end] >= spinup_cutoff &&
             (sim_var = ClimaAnalysis.window(sim_var, "time", left = spinup_cutoff))
 
@@ -179,23 +180,21 @@ function compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)
 end
 
 """
-    compute_pfull_leaderboard(leaderboard_base_path, diagnostics_folder_path)
+    compute_pfull_leaderboard(leaderboard_base_path, diagnostics_folder_path, spinup)
 
 Plot the biases and a leaderboard of various variables defined over longitude, latitude,
 time, and pressure levels.
 
-The parameter `leaderboard_base_path` is the path to save the leaderboards and bias plots,
-and `diagnostics_folder_path` is the path to the simulation data.
-
-The parameter `leaderboard_base_path` is the path to save the leaderboards and bias plots,
-and `diagnostics_folder_path` is the path to the simulation data.
+The argument `leaderboard_base_path` is the path to save the leaderboards and bias plots,
+`diagnostics_folder_path` is the path to the simulation data, and `spinup` is the number
+of months to remove from the beginning of the simulation.
 
 Loading and preprocessing simulation data is done by `get_sim_var_in_pfull_dict`. Loading
 and preprocessing observational data is done by `get_obs_var_in_pfull_dict`. The ranges of
 the bias plots is defined by `get_compare_vars_biases_plot_extrema_pfull`. See the functions
 defined in data_sources.jl for more information.
 """
-function compute_pfull_leaderboard(leaderboard_base_path, diagnostics_folder_path)
+function compute_pfull_leaderboard(leaderboard_base_path, diagnostics_folder_path, spinup)
     @info "Error against observations for variables in pressure coordinates"
 
     sim_var_pfull_dict = get_sim_var_in_pfull_dict(diagnostics_folder_path)
@@ -222,8 +221,7 @@ function compute_pfull_leaderboard(leaderboard_base_path, diagnostics_folder_pat
             error("Units of pressure should be hPa for $short_name simulation data")
 
         # Remove first spin_up_months from simulation
-        spin_up_months = 6
-        spinup_cutoff = spin_up_months * 31 * 86400.0
+        spinup_cutoff = spinup * 31 * 86400.0
         ClimaAnalysis.times(sim_var)[end] >= spinup_cutoff &&
             (sim_var = ClimaAnalysis.window(sim_var, "time", left = spinup_cutoff))
 
@@ -347,6 +345,6 @@ if abspath(PROGRAM_FILE) == @__FILE__
     end
     leaderboard_base_path = ARGS[begin]
     diagnostics_folder_path = ARGS[begin + 1]
-    compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)
-    compute_pfull_leaderboard(leaderboard_base_path, diagnostics_folder_path)
+    compute_leaderboard(leaderboard_base_path, diagnostics_folder_path, 3)
+    compute_pfull_leaderboard(leaderboard_base_path, diagnostics_folder_path, 6)
 end

--- a/experiments/ClimaEarth/leaderboard/leaderboard.jl
+++ b/experiments/ClimaEarth/leaderboard/leaderboard.jl
@@ -85,7 +85,11 @@ function compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)
 
     # Plot annual plots
     for compare_vars_biases in compare_vars_biases_groups
-        fig_bias = CairoMakie.Figure(; size = (600, 300 * length(compare_vars_biases)))
+        # Plot all the variables that we can
+        compare_vars_biases = filter(x -> x in keys(sim_obs_comparsion_dict), compare_vars_biases)
+        length(compare_vars_biases) > 0 || continue
+
+        fig_bias = CairoMakie.Figure(; size = (600, 75.0 + 300 * length(compare_vars_biases)))
         for (row, short_name) in enumerate(compare_vars_biases)
             sim_var = sim_obs_comparsion_dict[short_name]["ANN"][1]
             if !ClimaAnalysis.isempty(sim_var)
@@ -108,7 +112,12 @@ function compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)
     # Plot plots with all the seasons (not annual)
     seasons_no_ann = filter(season -> season != "ANN", seasons)
     for compare_vars_biases in compare_vars_biases_groups
-        fig_all_seasons = CairoMakie.Figure(; size = (600 * length(seasons_no_ann), 300 * length(compare_vars_biases)))
+        # Plot all the variables that we can
+        compare_vars_biases = filter(x -> x in keys(sim_obs_comparsion_dict), compare_vars_biases)
+        length(compare_vars_biases) > 0 || continue
+
+        fig_all_seasons =
+            CairoMakie.Figure(; size = (600 * length(seasons_no_ann), 75.0 + 300 * length(compare_vars_biases)))
         for (col, season) in enumerate(seasons_no_ann)
             # Plot at 2 * col - 1 because a bias plot takes up 1 x 2 space
             CairoMakie.Label(fig_all_seasons[0, 2 * col - 1], season, tellwidth = false, fontsize = 30)
@@ -136,6 +145,8 @@ function compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)
     end
 
     # Add RMSE for the CliMA model and for each season
+    is_in_sim_vars(k) = k in keys(sim_var_dict)
+    rmse_var_dict = Dict(k => v for (k, v) in rmse_var_dict if is_in_sim_vars(k))
     rmse_var_names = keys(rmse_var_dict)
     for short_name in rmse_var_names
         for season in seasons

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -36,8 +36,8 @@ function postprocess_sim(cs, postprocessing_vars)
         t_end = times[end]
         if t_end > 84600 * 31 * 3 # 3 months for spin up
             leaderboard_base_path = artifact_dir
-            compute_leaderboard(leaderboard_base_path, atmos_output_dir)
-            compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir)
+            compute_leaderboard(leaderboard_base_path, atmos_output_dir, 3)
+            compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir, 6)
         end
     end
 


### PR DESCRIPTION
The leaderboard code assumes that all the variables defined in `get_sim_var_dict()` are in the diagnostics, but this isn't always the case, especially with calibration. Hence, this PR only adds the variables if they exist in the diagnostics. Furthermore, this PR clean up the leaderboard code a bit using the new features in ClimaAnalysis.