### PR TITLE
Move some code into functions in setup_run

### DIFF
--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -51,7 +51,7 @@ import Interpolations # triggers InterpolationsExt in ClimaUtilities
 import Random
 
 # TODO: Move to ClimaUtilities once we move the Schedules to ClimaUtilities
-import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule
+import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule, EveryStepSchedule
 
 pkg_dir = pkgdir(ClimaCoupler)
 
@@ -411,13 +411,14 @@ function CoupledSimulation(config_dict::AbstractDict)
     #=
     ## Initialize Callbacks
     Callbacks are used to update at a specified interval. The callbacks are initialized here and
-    saved in a global `Callbacks` struct, `callbacks`. The `trigger_callback!` function is used to call the callback during the simulation below.
+    saved in a global `Callbacks` struct, `callbacks`. The `callbacks!` function is used to call the callback during the simulation below.
 
     The currently implemented callbacks are:
     - `checkpoint_cb`: generates a checkpoint of all model states at a specified interval. This is mainly used for restarting simulations.
     =#
     schedule_checkpoint = EveryCalendarDtSchedule(TimeManager.time_to_period(checkpoint_dt); start_date)
     checkpoint_cb = TimeManager.Callback(schedule_checkpoint, Checkpointer.checkpoint_sims)
+
     callbacks = (checkpoint_cb,)
 
     #= Set up default AMIP diagnostics
@@ -525,29 +526,11 @@ function run!(cs::CoupledSimulation; precompile = (cs.tspan[end] > 2 * cs.Δt_cp
     end
     @info "Simulation took $(walltime) seconds"
 
-    simulated_seconds_per_second = float(cs.tspan[end] - cs.tspan[begin]) / walltime
-    simulated_years_per_day = simulated_seconds_per_second / 365.25
-    sypd = simulated_years_per_day
-    n_coupling_steps = (cs.tspan[end] - cs.tspan[begin]) / cs.Δt_cpl
-    walltime_per_coupling_step = walltime / n_coupling_steps
+    sypd = simulated_years_per_day(cs, walltime)
+    walltime_per_step = walltime_per_coupling_step(cs, walltime)
     @info "SYPD: $sypd"
-    @info "Walltime per coupling step: $(walltime_per_coupling_step)"
-
-    ## Save the SYPD and allocation information
-    if ClimaComms.iamroot(cs.comms_ctx)
-        open(joinpath(cs.dirs.artifacts, "sypd.txt"), "w") do sypd_filename
-            println(sypd_filename, "$sypd")
-        end
-
-        open(joinpath(cs.dirs.artifacts, "walltime_per_step.txt"), "w") do walltime_per_step_filename
-            println(walltime_per_step_filename, "$(walltime_per_coupling_step)")
-        end
-
-        open(joinpath(cs.dirs.artifacts, "max_rss_cpu.txt"), "w") do cpu_max_rss_filename
-            cpu_max_rss_GB = Utilities.show_memory_usage()
-            println(cpu_max_rss_filename, cpu_max_rss_GB)
-        end
-    end
+    @info "Walltime per coupling step: $(walltime_per_step)"
+    save_sypd_walltime_to_disk(cs, walltime)
 
     # Close all diagnostics file writers
     isnothing(cs.diags_handler) || foreach(diag -> close(diag.output_writer), cs.diags_handler.scheduled_diagnostics)
@@ -625,7 +608,7 @@ function step!(cs::CoupledSimulation)
     ConservationChecker.check_conservation!(cs)
 
     ## step component model simulations sequentially for one coupling timestep (Δt_cpl)
-    FieldExchanger.step_model_sims!(cs.model_sims, cs.t[])
+    FieldExchanger.step_model_sims!(cs)
 
     ## update the surface fractions for surface models
     FieldExchanger.update_surface_fractions!(cs)
@@ -637,11 +620,9 @@ function step!(cs::CoupledSimulation)
     FluxCalculator.turbulent_fluxes!(cs)
 
     ## Maybe call the callbacks
-    foreach(c -> TimeManager.maybe_trigger_callback(c, cs), cs.callbacks)
+    TimeManager.callbacks!(cs)
 
-    ## compute/output AMIP diagnostics if scheduled for this timestep
-    ## wrap the current CoupledSimulation fields and time in a NamedTuple to match the ClimaDiagnostics interface
-    cs_nt = (; u = cs.fields, p = nothing, t = cs.t[], step = round(cs.t[] / cs.Δt_cpl))
-    !isnothing(cs.diags_handler) && CD.orchestrate_diagnostics(cs_nt, cs.diags_handler)
+    # Compute coupler diagnostics
+    CD.orchestrate_diagnostics(cs)
     return nothing
 end

--- a/experiments/ClimaEarth/user_io/coupler_diagnostics.jl
+++ b/experiments/ClimaEarth/user_io/coupler_diagnostics.jl
@@ -3,6 +3,18 @@ import ClimaCoupler: Interfacer
 import Dates
 
 """
+    ClimaDiagnostics.orchestrate_diagnostics(cs::CoupledSimulation)
+
+Compute and output coupled diagnostics.
+"""
+function CD.orchestrate_diagnostics(cs::CoupledSimulation)
+    ## wrap the current CoupledSimulation fields and time in a NamedTuple to match the ClimaDiagnostics interface
+    cs_nt = (; u = cs.fields, p = nothing, t = cs.t[], step = round(cs.t[] / cs.Δt_cpl))
+    !isnothing(cs.diags_handler) && CD.orchestrate_diagnostics(cs_nt, cs.diags_handler)
+    return nothing
+end
+
+"""
     coupler_diagnostics_setup(fields, output_dir, start_date, t_start, diagnostics_dt)
 
 Set up the default diagnostics for an AMIP simulation, using ClimaDiagnostics.

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -66,3 +66,52 @@ function postprocess_sim(cs, postprocessing_vars)
     # Close all diagnostics file writers
     !isnothing(cs.diags_handler) && map(diag -> close(diag.output_writer), cs.diags_handler.scheduled_diagnostics)
 end
+
+"""
+    simulated_years_per_day(cs, walltime)
+
+Compute the simulated years per walltime day for the given coupled simulation `cs`, assuming
+that the simulation took `walltime`.
+"""
+function simulated_years_per_day(cs, walltime)
+    simulated_seconds_per_second = float(cs.tspan[end] - cs.tspan[begin]) / walltime
+    return simulated_seconds_per_second / 365.25
+end
+
+"""
+    walltime_per_coupling_step(cs, walltime)
+
+Compute the average walltime needed to take one step for the given coupled simulation `cs`,
+assuming that the simulation took `walltime`. The result is in seconds.
+"""
+function walltime_per_coupling_step(cs, walltime)
+    n_coupling_steps = (cs.tspan[end] - cs.tspan[begin]) / cs.Δt_cpl
+    return walltime / n_coupling_steps
+end
+
+
+"""
+    save_sypd_walltime_to_disk(cs, walltime)
+
+Save the computed `sypd`, `walltime_per_coupling_step`, and memory usage to text files.
+"""
+function save_sypd_walltime_to_disk(cs, walltime)
+    if ClimaComms.iamroot(cs.comms_ctx)
+        sypd = simulated_years_per_day(cs, walltime)
+        walltime_per_step = walltime_per_coupling_step(cs, walltime)
+
+        open(joinpath(cs.dirs.artifacts, "sypd.txt"), "w") do sypd_filename
+            println(sypd_filename, "$sypd")
+        end
+
+        open(joinpath(cs.dirs.artifacts, "walltime_per_step.txt"), "w") do walltime_per_step_filename
+            println(walltime_per_step_filename, "$(walltime_per_step)")
+        end
+
+        open(joinpath(cs.dirs.artifacts, "max_rss_cpu.txt"), "w") do cpu_max_rss_filename
+            cpu_max_rss_GB = Utilities.show_memory_usage()
+            println(cpu_max_rss_filename, cpu_max_rss_GB)
+        end
+    end
+    return nothing
+end

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -226,17 +226,23 @@ end
 
 """
     step_model_sims!(model_sims, t)
+    step_model_sims!(cs::CoupledSimulation)
 
 Iterates `step!` over all component model simulations saved in `cs.model_sims`.
 
 # Arguments
 - `model_sims`: [NamedTuple] containing `ComponentModelSimulation`s.
-- `t`: [AbstractFloat] denoting the simulation time.
+- `t`: [AbstractFloat or ITime] denoting the simulation time.
 """
 function step_model_sims!(model_sims, t)
     for sim in model_sims
         Interfacer.step!(sim, t)
     end
+    return nothing
+end
+
+function step_model_sims!(cs::Interfacer.CoupledSimulation)
+    step_model_sims!(cs.model_sims, cs.t[])
 end
 
 """

--- a/src/TimeManager.jl
+++ b/src/TimeManager.jl
@@ -75,6 +75,19 @@ function maybe_trigger_callback(callback, cs)
     return nothing
 end
 
+"""
+    callback!(cs)
+
+Run the callbacks that need to be run.
+
+This is marked as mutating function because in general callbacks are going to change
+the state of the simulation
+"""
+function callbacks!(cs)
+    foreach(c -> TimeManager.maybe_trigger_callback(c, cs), cs.callbacks)
+    return nothing
+end
+
 
 """
 A schedule that is never true. Useful to disable something.


### PR DESCRIPTION
This commit moves some chunks of code in their own functions, in an effort to make setting up and running a coupled simulation more direct.