### PR TITLE
Add cmip_target/cmip_bucket to longruns

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -48,7 +48,6 @@ steps:
       - "julia --project=experiments/calibration/ -e 'using Pkg; Pkg.instantiate(;verbose=true); Pkg.develop(;path=\".\")'"
     agents:
       queue: clima
-      modules: climacommon/2025_05_15
     env:
       JULIA_NUM_PRECOMPILE_TASKS: 8
       JULIA_MAX_NUM_PRECOMPILE_FILES: 50
@@ -212,7 +211,6 @@ steps:
           slurm_mem: 32GB
           slurm_gpus: 1
           slurm_time: 12:00:00
-          modules: climacommon/2025_05_15
 
       - label: "ClimaAtmos + Bucket + ClimaOcean + PrescribedSeaIce"
         key: "cmip_bucket"
@@ -227,7 +225,6 @@ steps:
           slurm_mem: 32GB
           slurm_gpus: 1
           slurm_time: 12:00:00
-          modules: climacommon/2025_05_15
 
   - group: "Current target tests on GPU: AMIP surface"
 
@@ -246,7 +243,6 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 32GB
-          modules: climacommon/2025_05_15
 
       - label: "GPU AMIP FINE: new target amip: topo"
         key: "amip_target_topo_gpu"
@@ -261,7 +257,6 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 32GB
-          modules: climacommon/2025_05_15
 
       - label: "GPU AMIP FINE: new target amip: topo + diagedmf"
         key: "amip_target_topo_diagedmf_gpu"
@@ -278,7 +273,6 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 32GB
-          modules: climacommon/2025_05_15
 
   # DYAMOND AMIP: 1 day (convection resolving)
   - label: "GPU AMIP SUPERFINE: dyamond_target"
@@ -293,7 +287,6 @@ steps:
       queue: clima
       slurm_mem: 20GB
       slurm_gpus: 1
-      modules: climacommon/2025_05_15
 
   - label: "Perfect model calibration test"
     key: "amip_pm_calibration"
@@ -310,7 +303,6 @@ steps:
       slurm_gpus_per_task: 1
       slurm_cpus_per_task: 4
       slurm_time: 05:00:00
-      modules: climacommon/2025_05_15
 
   - wait
 

--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -196,6 +196,39 @@ steps:
           slurm_mem_per_cpu: 16G
           slurm_reservation: "false"
 
+  - group: "CMIP simulations"
+
+    steps:
+      - label: "ClimaAtmos + ClimaLand + ClimaOcean + PrescribedSeaIce"
+        key: "cmip_land"
+        command:
+            - "julia --color=yes --project=experiments/ClimaEarth experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_land.yml --job_id cmip_target"
+        artifact_paths: "experiments/ClimaEarth/output/cmip_land/artifacts/*"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+          CLIMACOMMS_CONTEXT: "SINGLETON"
+        agents:
+          queue: clima
+          slurm_mem: 32GB
+          slurm_gpus: 1
+          slurm_time: 12:00:00
+          modules: climacommon/2025_05_15
+
+      - label: "ClimaAtmos + Bucket + ClimaOcean + PrescribedSeaIce"
+        key: "cmip_bucket"
+        command:
+            - "julia --color=yes --project=experiments/ClimaEarth experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_bucket.yml --job_id cmip_bucket"
+        artifact_paths: "experiments/ClimaEarth/output/cmip_bucket/artifacts/*"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+          CLIMACOMMS_CONTEXT: "SINGLETON"
+        agents:
+          queue: clima
+          slurm_mem: 32GB
+          slurm_gpus: 1
+          slurm_time: 12:00:00
+          modules: climacommon/2025_05_15
+
   - group: "Current target tests on GPU: AMIP surface"
 
     steps:

--- a/config/longrun_configs/cmip_bucket.yml
+++ b/config/longrun_configs/cmip_bucket.yml
@@ -1,0 +1,21 @@
+FLOAT_TYPE: "Float32"
+aerosol_radiation: true
+atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_0M.yml"
+bucket_albedo_type: "map_temporal"
+checkpoint_dt: "720hours"
+co2: "maunaloa"
+dt: "120secs"
+dt_cloud_fraction: "1hours"
+dt_cpl: "120secs"
+dt_rad: "1hours"
+energy_check: false
+insolation: "timevarying"
+mode_name: "cmip"
+prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+prescribe_ozone: true
+rad: "allskywithclear"
+start_date: "20100101"
+surface_setup: "PrescribedSurface"
+t_end: "366days"
+topography: "Earth"
+topo_smoothing: true

--- a/config/longrun_configs/cmip_land.yml
+++ b/config/longrun_configs/cmip_land.yml
@@ -1,0 +1,21 @@
+FLOAT_TYPE: "Float32"
+aerosol_radiation: true
+atmos_config_file: "config/longrun_configs/longrun_aquaplanet_allsky_0M.yml"
+checkpoint_dt: "720hours"
+co2: "maunaloa"
+dt: "120secs"
+dt_cloud_fraction: "1hours"
+dt_cpl: "120secs"
+dt_rad: "1hours"
+energy_check: false
+land_model: "integrated"
+insolation: "timevarying"
+mode_name: "cmip"
+prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+prescribe_ozone: true
+rad: "allskywithclear"
+start_date: "20100101"
+surface_setup: "PrescribedSurface"
+t_end: "366days"
+topography: "Earth"
+topo_smoothing: true


### PR DESCRIPTION
This commit adds two target experiments, one for CMIP with the bucket, and one with CMIP with the integrated model
