### PR TITLE
Use ECCO date for ocean initial conditions

### DIFF
--- a/.buildkite/amip/pipeline.yml
+++ b/.buildkite/amip/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 96:00:00
-  modules: climacommon/2025_03_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100

--- a/.buildkite/benchmarks/pipeline.yml
+++ b/.buildkite/benchmarks/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 24:00:00
-  modules: climacommon/2025_03_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_NVTX_CALLBACKS: gc

--- a/.buildkite/hierarchies/pipeline.yml
+++ b/.buildkite/hierarchies/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_time: 24:00:00
-  modules: climacommon/2025_03_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
@@ -30,7 +30,7 @@ steps:
 
     agents:
       queue: clima
-      modules: climacommon/2025_03_18
+      modules: climacommon/2025_05_15
     env:
       JULIA_NUM_PRECOMPILE_TASKS: 8
       JULIA_MAX_NUM_PRECOMPILE_FILES: 50
@@ -52,7 +52,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2025_03_18
+          modules: climacommon/2025_05_15
 
       - label: "Clima: GPU ClimaCoupler moist HS"
         command:
@@ -64,7 +64,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2025_03_18
+          modules: climacommon/2025_05_15
 
       - label: "Clima: GPU ClimaCoupler Cloudless Aquaplanet"
         command:
@@ -76,7 +76,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2025_03_18
+          modules: climacommon/2025_05_15
 
       - label: "Clima: GPU ClimaCoupler Cloudy Aquaplanet"
         command:
@@ -88,7 +88,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2025_03_18
+          modules: climacommon/2025_05_15
 
       - label: "Clima: GPU ClimaCoupler Cloudy Slabplanet"
         command:
@@ -100,4 +100,4 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2025_03_18
+          modules: climacommon/2025_05_15

--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_time: 24:00:00
-  modules: climacommon/2025_03_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
@@ -48,7 +48,7 @@ steps:
       - "julia --project=experiments/calibration/ -e 'using Pkg; Pkg.instantiate(;verbose=true); Pkg.develop(;path=\".\")'"
     agents:
       queue: clima
-      modules: climacommon/2025_03_18
+      modules: climacommon/2025_05_15
     env:
       JULIA_NUM_PRECOMPILE_TASKS: 8
       JULIA_MAX_NUM_PRECOMPILE_FILES: 50
@@ -213,7 +213,7 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 32GB
-          modules: climacommon/2025_03_18
+          modules: climacommon/2025_05_15
 
       - label: "GPU AMIP FINE: new target amip: topo"
         key: "amip_target_topo_gpu"
@@ -228,7 +228,7 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 32GB
-          modules: climacommon/2025_03_18
+          modules: climacommon/2025_05_15
 
       - label: "GPU AMIP FINE: new target amip: topo + diagedmf"
         key: "amip_target_topo_diagedmf_gpu"
@@ -245,7 +245,7 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 32GB
-          modules: climacommon/2025_03_18
+          modules: climacommon/2025_05_15
 
   # DYAMOND AMIP: 1 day (convection resolving)
   - label: "GPU AMIP SUPERFINE: dyamond_target"
@@ -260,7 +260,7 @@ steps:
       queue: clima
       slurm_mem: 20GB
       slurm_gpus: 1
-      modules: climacommon/2025_03_18
+      modules: climacommon/2025_05_15
 
   - label: "Perfect model calibration test"
     key: "amip_pm_calibration"
@@ -277,7 +277,7 @@ steps:
       slurm_gpus_per_task: 1
       slurm_cpus_per_task: 4
       slurm_time: 05:00:00
-      modules: climacommon/2025_03_18
+      modules: climacommon/2025_05_15
 
   - wait
 

--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 14:00:00
-  modules: climacommon/2025_03_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_time: 4:00:00
-  modules: climacommon/2025_03_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -45,7 +45,7 @@ import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput, evaluate!
 import ClimaUtilities.Utils: period_to_seconds_float
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
-import ClimaUtilities.TimeManager: ITime
+import ClimaUtilities.TimeManager: ITime, date
 import Interpolations # triggers InterpolationsExt in ClimaUtilities
 # Random is used by RRMTGP for some cloud properties
 import Random
@@ -327,7 +327,9 @@ function CoupledSimulation(config_dict::AbstractDict)
         ocean_fraction = FT(1) .- ice_fraction .- land_fraction
 
         if sim_mode <: CMIPMode
-            ocean_sim = OceananigansSimulation(ocean_fraction; output_dir = ocean_output_dir, comms_ctx)
+            stop_date = date(tspan[end] - tspan[begin])
+            ocean_sim =
+                OceananigansSimulation(ocean_fraction, start_date, stop_date; output_dir = ocean_output_dir, comms_ctx)
         else
             ocean_sim = PrescribedOceanSimulation(
                 FT,

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -259,7 +259,10 @@ for FT in (Float32, Float64)
     @testset "update_model_sims! for FT=$FT" begin
         # coupler cache setup
         boundary_space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4)
-        coupler_field_names = [Interfacer.default_coupler_fields(); [:surface_direct_albedo, :surface_diffuse_albedo]]
+        coupler_field_names = [
+            Interfacer.default_coupler_fields()
+            [:surface_direct_albedo, :surface_diffuse_albedo]
+        ]
         coupler_fields = Interfacer.init_coupler_fields(FT, coupler_field_names, boundary_space)
         # Initialize with ones
         for p in propertynames(coupler_fields)
@@ -334,7 +337,10 @@ for FT in (Float32, Float64)
         #  and two precipitation fields from the atmos to the surface.
         # coupler cache setup
         boundary_space = CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4)
-        coupler_field_names = [Interfacer.default_coupler_fields(); [:surface_direct_albedo, :surface_diffuse_albedo]]
+        coupler_field_names = [
+            Interfacer.default_coupler_fields()
+            [:surface_direct_albedo, :surface_diffuse_albedo]
+        ]
         # Initialize coupler fields with 0.5
         key_types = (coupler_field_names...,)
         val_types = Tuple{(FT for _ in 1:length(coupler_field_names))...}


### PR DESCRIPTION
This commit changes the initial conditions for the ocean when the simulation is non-trivial (in terms of duration).

ECCO data requires authentication to log in. This is automatic when using ClimaModules.
