### PR TITLE
Remove redundant fields in CoupledSimulation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ Including:
 - Remove `F_radiative` from `add_coupler_fields` since it's a default
 - Remove atmosphere `get_field` method for `thermo_state_int`, since it's now constructed on the boundary space
 - Update Interfacer docs
+- `comms_ctx` and `boundary_space` are no longer in the `CoupledSimulation` object. Use accessor functions instead.
 
 #### Construct thermo states from exchanged T, q, ρ. PR[#1293](https://github.com/CliMA/ClimaCoupler.jl/pull/1293)
 

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -303,6 +303,7 @@ end
     ClimaCoupler.Interfacer.set_cache!
     ClimaCoupler.Interfacer.remap
     ClimaCoupler.Interfacer.remap!
+    ClimaCoupler.Interfacer.boundary_space
 ```
 
 ## Interfacer Internal Functions and Types

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -457,9 +457,7 @@ function CoupledSimulation(config_dict::AbstractDict)
     =#
 
     cs = CoupledSimulation{FT}(
-        comms_ctx,
         Ref(start_date),
-        boundary_space,
         coupler_fields,
         conservation_checks,
         [tspan[1], tspan[2]],
@@ -530,7 +528,7 @@ function run!(cs::CoupledSimulation; precompile = (cs.tspan[end] > 2 * cs.Δt_cp
     value to calculate the simulated years per day (SYPD) of the simulation.
     =#
     @info "Starting coupling loop"
-    walltime = ClimaComms.@elapsed cs.comms_ctx.device begin
+    walltime = ClimaComms.@elapsed ClimaComms.device(cs) begin
         s = CA.@timed_str begin
             while cs.t[] <= cs.tspan[end]
                 step!(cs)
@@ -576,7 +574,7 @@ function postprocess(cs, conservation_softfail)
     - Plots of useful coupler and component model fields for debugging
     =#
 
-    if ClimaComms.iamroot(cs.comms_ctx) && !isnothing(cs.diags_handler)
+    if ClimaComms.iamroot(ClimaComms.context(cs)) && !isnothing(cs.diags_handler)
         postprocessing_vars = (; conservation_softfail)
         postprocess_sim(cs, postprocessing_vars)
     end

--- a/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
@@ -77,9 +77,7 @@ end
     thermo_params = TDP.ThermodynamicsParameters(FT)
 
     cs = Interfacer.CoupledSimulation{FT}(
-        nothing, # comms_ctx
         nothing, # start_date
-        boundary_space,
         coupler_fields,
         nothing, # conservation_checks
         tspan,

--- a/experiments/ClimaEarth/test/debug_plots_tests.jl
+++ b/experiments/ClimaEarth/test/debug_plots_tests.jl
@@ -70,9 +70,7 @@ plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
         ice_sim = Interfacer.SurfaceStub(stub_fields),
     )
     cs = Interfacer.CoupledSimulation{FT}(
-        nothing, # comms_ctx
         nothing, # dates
-        nothing, # boundary_space
         coupler_fields, # fields
         nothing, # conservation_checks
         (Int(0), Int(1)), # tspan

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -29,7 +29,7 @@ function postprocess_sim(cs, postprocessing_vars)
     make_ocean_diagnostics_plots(ocean_output_dir, artifact_dir, output_prefix = "ocean_")
 
     # Plot all model states and coupler fields (useful for debugging)
-    !CA.is_distributed(cs.comms_ctx) && debug(cs, artifact_dir)
+    ClimaComms.context(cs) isa ClimaComms.SingletonCommsContext && debug(cs, artifact_dir)
 
     # If we have enough data (in time, but also enough variables), plot the leaderboard.
     # We need pressure to compute the leaderboard.
@@ -96,7 +96,7 @@ end
 Save the computed `sypd`, `walltime_per_coupling_step`, and memory usage to text files.
 """
 function save_sypd_walltime_to_disk(cs, walltime)
-    if ClimaComms.iamroot(cs.comms_ctx)
+    if ClimaComms.iamroot(ClimaComms.context(cs))
         sypd = simulated_years_per_day(cs, walltime)
         walltime_per_step = walltime_per_coupling_step(cs, walltime)
 

--- a/src/ConservationChecker.jl
+++ b/src/ConservationChecker.jl
@@ -79,7 +79,7 @@ function check_conservation!(
     ccs = cc.sums
     (; model_sims) = coupler_sim
 
-    FT = CC.Spaces.undertype(coupler_sim.boundary_space)
+    FT = CC.Spaces.undertype(Interfacer.boundary_space(coupler_sim))
     total = FT(0)
 
     # save surfaces
@@ -115,7 +115,9 @@ function check_conservation!(
             else
                 previous = getproperty(ccs, sim_name)
                 # regrid each field onto the boundary space
-                current = integral(Interfacer.get_field(sim, Val(:energy), coupler_sim.boundary_space) .* area_fraction) # # ∫ J / m^3 dV
+                current = integral(
+                    Interfacer.get_field(sim, Val(:energy), Interfacer.boundary_space(coupler_sim)) .* area_fraction,
+                ) # # ∫ J / m^3 dV
             end
             push!(previous, current)
             total += current
@@ -152,12 +154,14 @@ function check_conservation!(
     ccs = cc.sums
     (; model_sims) = coupler_sim
 
-    boundary_space = coupler_sim.boundary_space # thin shell approx (boundary_space[z=0] = boundary_space[z_top])
+    # thin shell approx (boundary_space[z=0] = boundary_space[z_top])
 
     total = 0
 
     # net precipitation (for surfaces that don't collect water)
-    PE_net = coupler_sim.fields.P_net .+= Interfacer.remap(surface_water_gain_from_rates(coupler_sim), boundary_space)
+    PE_net =
+        coupler_sim.fields.P_net .+=
+            Interfacer.remap(surface_water_gain_from_rates(coupler_sim), Interfacer.boundary_space(coupler_sim))
 
     # save surfaces
     for sim in model_sims
@@ -183,7 +187,9 @@ function check_conservation!(
                 push!(previous, current)
             else
                 previous = getproperty(ccs, sim_name)
-                current = integral(Interfacer.get_field(sim, Val(:water), coupler_sim.boundary_space) .* area_fraction) # kg (∫kg of water / m^3 dV)
+                current = integral(
+                    Interfacer.get_field(sim, Val(:water), Interfacer.boundary_space(coupler_sim)) .* area_fraction,
+                ) # kg (∫kg of water / m^3 dV)
                 push!(previous, current)
             end
         end

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -28,8 +28,7 @@ If a surface model is not present, the area fraction is set to 0.
 - `cs`: [Interfacer.CoupledSimulation] containing area fraction information.
 """
 function update_surface_fractions!(cs::Interfacer.CoupledSimulation)
-    boundary_space = cs.boundary_space
-    FT = CC.Spaces.undertype(boundary_space)
+    FT = CC.Spaces.undertype(Interfacer.boundary_space(cs))
 
     # land fraction is static
     if haskey(cs.model_sims, :land_sim)

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -46,25 +46,8 @@ abstract type AbstractSimulation{FT} end
     CoupledSimulation
 Stores information needed to run a simulation with the coupler.
 """
-struct CoupledSimulation{
-    FT <: Real,
-    X,
-    D,
-    B,
-    FV,
-    E,
-    TS,
-    DTI,
-    TT,
-    NTMS <: NamedTuple,
-    CALLBACKS,
-    NTP <: NamedTuple,
-    TP,
-    DH,
-}
-    comms_ctx::X
+struct CoupledSimulation{FT <: Real, D, FV, E, TS, DTI, TT, NTMS <: NamedTuple, CALLBACKS, NTP <: NamedTuple, TP, DH}
     start_date::D
-    boundary_space::B
     fields::FV
     conservation_checks::E
     tspan::TS
@@ -496,5 +479,33 @@ after the initial exchange.
 This is not required to be extended, but may be necessary for some models.
 """
 set_cache!(sim::ComponentModelSimulation) = nothing
+
+"""
+    boundary_space(sim::CoupledSimulation)
+
+Return the `ClimaCore.Field` over which the exchange fields are defined.
+"""
+function boundary_space(sim::CoupledSimulation)
+    return axes(sim.fields)
+end
+
+"""
+    ClimaComms.context(sim::CoupledSimulation)
+
+Return the `ClimaComms.context` associated to the simulation.
+"""
+function ClimaComms.context(sim::CoupledSimulation)
+    return ClimaComms.context(sim.fields)
+end
+
+"""
+    ClimaComms.device(sim::CoupledSimulation)
+
+Return the `ClimaComms.device` associated to the simulation.
+"""
+function ClimaComms.device(sim::CoupledSimulation)
+    return ClimaComms.device(sim.fields)
+end
+
 
 end # module

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -53,19 +53,12 @@ for FT in (Float32, Float64)
         )
 
         # coupler fields
-        cf = (;
-            P_net = CC.Fields.zeros(space),
-            P_liq = CC.Fields.zeros(space),
-            P_snow = CC.Fields.zeros(space),
-            F_turb_moisture = CC.Fields.zeros(space),
-        )
+        cf = Interfacer.init_coupler_fields(FT, [:P_net, :P_liq, :P_snow, :F_turb_moisture], space)
         @. cf.P_liq = -100
 
         # init
         cs = Interfacer.CoupledSimulation{FT}(
-            nothing, # comms_ctx
             nothing, # dates
-            space, # boundary_space
             cf, # fields
             cc, # conservation_checks
             (Int(0), Int(1000)), # tspan
@@ -148,19 +141,12 @@ for FT in (Float32, Float64)
         )
 
         # coupler fields
-        cf = (;
-            P_net = CC.Fields.zeros(space),
-            P_liq = CC.Fields.zeros(space),
-            P_snow = CC.Fields.zeros(space),
-            F_turb_moisture = CC.Fields.zeros(space),
-        )
+        cf = Interfacer.init_coupler_fields(FT, [:P_net, :P_liq, :P_snow, :F_turb_moisture], space)
         @. cf.P_liq = -100
 
         # init
         cs = Interfacer.CoupledSimulation{FT}(
-            nothing, # comms_ctx
             nothing, # dates
-            space, # boundary_space
             cf, # fields
             cc, # conservation_checks
             (Int(0), Int(1000)), # tspan

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -135,10 +135,8 @@ for FT in (Float32, Float64)
 
         # Fill in only the necessary parts of the simulation
         cs = Interfacer.CoupledSimulation{FT}(
-            nothing, # comms_ctx
             nothing, # dates
-            test_space, # boundary_space
-            nothing, # fields
+            ones(test_space), # fields
             nothing, # conservation_checks
             (Int(0), Int(1000)), # tspan
             Int(200), # Δt_cpl
@@ -373,9 +371,7 @@ for FT in (Float32, Float64)
 
         # construct the CoupledSimulation object
         cs = Interfacer.CoupledSimulation{FT}(
-            nothing, # comms_ctx
             nothing, # start_date
-            boundary_space,
             coupler_fields,
             nothing, # conservation_checks
             nothing, # tspan

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -34,14 +34,14 @@ ClimaComms.init(context)
 
 for FT in (Float32, Float64)
     @testset "test CoupledSim construction, float_type for FT=$FT" begin
-        boundary_space =
+        boundary_space_ =
             CC.CommonSpaces.CubedSphereSpace(FT; radius = FT(6371e3), n_quad_points = 4, h_elem = 4, context)
 
+        fields = ones(boundary_space_)
+
         cs = Interfacer.CoupledSimulation{FT}(
-            context,
             nothing, # dates
-            boundary_space,
-            nothing, # fields
+            fields,
             nothing, # conservation_checks
             (Int(0), Int(1000)), # tspan
             Int(200), # Δt_cpl
@@ -52,8 +52,7 @@ for FT in (Float32, Float64)
             nothing, # thermo_params
             nothing, # diags_handler
         )
-        @test CC.Spaces.undertype(cs.boundary_space) == FT
-
+        @test CC.Spaces.undertype(Interfacer.boundary_space(cs)) == FT
     end
 
     @testset "get_field indexing for FT=$FT" begin


### PR DESCRIPTION
Both the `boundary_space` and `comms_ctx` can be obtained from other fields in the `CoupledSimulation` objects.

Closes #1329
