### PR TITLE
Lower Pr_max

### DIFF
--- a/experiments/ClimaEarth/Manifest-v1.11.toml
+++ b/experiments/ClimaEarth/Manifest-v1.11.toml
@@ -349,9 +349,9 @@ weakdeps = ["GeoMakie", "Makie"]
 
 [[deps.ClimaAtmos]]
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SciMLBase", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
-git-tree-sha1 = "e143c5372f42e921125c64388c7732e42d4b03c0"
+git-tree-sha1 = "f7776c82b6329a3a92bfeea793109c8c0e64fac0"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.30.1"
+version = "0.30.2"
 
 [[deps.ClimaComms]]
 deps = ["Adapt", "Logging", "LoggingExtras"]

--- a/experiments/ClimaEarth/Manifest.toml
+++ b/experiments/ClimaEarth/Manifest.toml
@@ -346,9 +346,9 @@ weakdeps = ["GeoMakie", "Makie"]
 
 [[deps.ClimaAtmos]]
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SciMLBase", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
-git-tree-sha1 = "e143c5372f42e921125c64388c7732e42d4b03c0"
+git-tree-sha1 = "f7776c82b6329a3a92bfeea793109c8c0e64fac0"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.30.1"
+version = "0.30.2"
 
 [[deps.ClimaComms]]
 deps = ["Adapt", "Logging", "LoggingExtras"]

--- a/toml/amip.toml
+++ b/toml/amip.toml
@@ -30,3 +30,6 @@ value = 0
 
 [max_area_limiter_scale]
 value = 0
+
+[mixing_length_Prandtl_maximum]
+value = 4.2


### PR DESCRIPTION
Some of the nightly AMIP runs are not stable. Lowering maximum Prandtl number fixes it. 


