### PR TITLE
fix longrun configs

### DIFF
--- a/config/longrun_configs/amip_decaywithheight.yml
+++ b/config/longrun_configs/amip_decaywithheight.yml
@@ -16,4 +16,5 @@ prescribe_ozone: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "1098days"
+turbconv: ~
 vert_diff: "DecayWithHeightDiffusion"

--- a/config/longrun_configs/amip_decaywithheight_integrated_land.yml
+++ b/config/longrun_configs/amip_decaywithheight_integrated_land.yml
@@ -15,4 +15,5 @@ prescribe_ozone: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "1098days"
+turbconv: ~
 vert_diff: "DecayWithHeightDiffusion"

--- a/experiments/ClimaEarth/cli_options.jl
+++ b/experiments/ClimaEarth/cli_options.jl
@@ -83,6 +83,10 @@ function argparse_settings()
         arg_type = String
         default = "20days"
         # Space information
+        "--h_elem"
+        help = "Number of horizontal elements to use for the boundary space [16 (default)]"
+        arg_type = Int
+        default = 16
         "--share_surface_space"
         help = "Boolean flag indicating whether to share the surface space between the surface models, atmosphere, and boundary [`true` (default), `false`]"
         arg_type = Bool


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
2 fixes to bugs that were recently introduced
1. When using `DecayWithHeight` vertical diffusion, as in the runs added in #1361, we need to also set `turbconv: ~`. This PR sets it for our 2 new DecayWithHeight longruns.
2. In #1292, we use `config_dict["h_elem"]` to construct the boundary space when it isn't being taken from the atmosphere model, but this option isn't always set in our configs. This PR adds a default of `h_elem = 16`.