### PR TITLE
Extend diagnostics for Oceananigans sim

### DIFF
--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -25,7 +25,6 @@ function postprocess_sim(cs, postprocessing_vars)
     make_diagnostics_plots(coupler_output_dir, artifact_dir, output_prefix = "coupler_")
     make_diagnostics_plots(atmos_output_dir, artifact_dir, output_prefix = "atmos_")
     make_diagnostics_plots(land_output_dir, artifact_dir, output_prefix = "land_")
-    # TODO: Uniform ocean plotting
     make_ocean_diagnostics_plots(ocean_output_dir, artifact_dir, output_prefix = "ocean_")
 
     # Plot all model states and coupler fields (useful for debugging)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #1368


## To-do
- [x] use ClimaAnalysis in `make_ocean_diagnostics_plots` to unify with the other `make_diagnostics_plots` methods
  - I still kept this as a different function since we need to do some things differently because Oceananigans uses a different output saving infrastructure.
- [x] add new ocean diagnostics: S, u, v

## To Do (later)
- [ ] add animations for the ocean simulation and ideally atmosphere too
  - it wasn't clear to me how to do this in a straightforward way, so I left it for a separate PR

## Content
Example of new diagnostics from a simulation run for 2 timesteps locally:
![Screenshot 2025-05-27 at 3 41 48 PM](https://github.com/user-attachments/assets/6a127a10-cc8f-4ea7-9ae3-164e757f1844)


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
