### PR TITLE
increase vertical resolution of land domain

### DIFF
--- a/experiments/ClimaEarth/components/land/climaland_helpers.jl
+++ b/experiments/ClimaEarth/components/land/climaland_helpers.jl
@@ -39,7 +39,7 @@ end
      make_land_domain(
          shared_surface_space::CC.Spaces.SpectralElementSpace2D,
          depth::FT;
-         nelements_vert::Int = 7,
+         nelements_vert::Int = 15,
          ) where {FT}
 
  Creates the land model domain from the input shared surface space and information
@@ -48,7 +48,8 @@ end
 function make_land_domain(
     shared_surface_space::CC.Spaces.SpectralElementSpace2D,
     depth::FT;
-    nelements_vert::Int = 7,
+    nelements_vert::Int = 15,
+    dz_tuple::Tuple{FT, FT} = FT.((10.0, 0.05)),
 ) where {FT}
     mesh = CC.Spaces.topology(shared_surface_space).mesh
 
@@ -72,12 +73,12 @@ function make_land_domain(
     fields = CL.Domains.get_additional_coordinate_field_data(subsurface_space)
 
     if pkgversion(CL) < v"0.16.0"
-        return CL.Domains.SphericalShell{FT}(radius, depth, nothing, nelements, npolynomial, space, fields)
+        return CL.Domains.SphericalShell{FT}(radius, depth, dz_tuple, nelements, npolynomial, space, fields)
     else
         return CL.Domains.SphericalShell{FT, typeof(space), typeof(fields)}(
             radius,
             depth,
-            nothing,
+            dz_tuple,
             nelements,
             npolynomial,
             space,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Increase the vertical resolution of the land domain from 7 to 15 vertical elements. Also specify  `dz_tuple` so we have non-uniform spacing of the vertical levels. The spacing at the top of the domain is now 5cm, and at the bottom it is 10m.

This domain was shown to improve stability of the runs we're currently trying to stabilize in [this longruns build](https://buildkite.com/clima/climacoupler-longruns/builds/880). See the [description of this PR](https://github.com/CliMA/ClimaCoupler.jl/pull/1366) for more details.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
