### PR TITLE
Bypass certificate verification for ECCO download

### DIFF
--- a/experiments/ClimaEarth/components/ocean/oceananigans.jl
+++ b/experiments/ClimaEarth/components/ocean/oceananigans.jl
@@ -392,3 +392,16 @@ TODO extend this for non-ClimaCore states.
 function Checkpointer.get_model_prog_state(sim::OceananigansSimulation)
     @warn "get_model_prog_state not implemented for OceananigansSimulation"
 end
+
+import Downloads
+# TODO: Remove this workaround once the change has been made to ClimaOcean
+function CO.DataWrangling.netrc_downloader(username, password, machine, dir)
+    netrc_file = CO.DataWrangling.netrc_permission_file(username, password, machine, dir)
+    downloader = Downloads.Downloader()
+    easy_hook = (easy, *) -> begin
+        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_NETRC_FILE, netrc_file)
+        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_SSL_VERIFYPEER, false)
+    end
+    downloader.easy_hook = easy_hook
+    return downloader
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR re-enables downloads from the ECCO server by overriding the downloader configuration in ClimaOcean. This workaround should be removed once this has been [fixed](https://github.com/CliMA/ClimaOcean.jl/pull/557) in ClimaOcean and a new version has been released.

[sample error build](https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/381#01973dd2-1b34-45f6-8f14-73b62e7214d9), [working build](https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/382#01974115-119c-4683-978e-61449ffe94fe)

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
