### PR TITLE
Enable restart using a new sim start time

### DIFF
--- a/experiments/ClimaEarth/components/shared/restore.jl
+++ b/experiments/ClimaEarth/components/shared/restore.jl
@@ -10,6 +10,7 @@ import ClimaCore.Spaces: AbstractSpace
 import ClimaUtilities.TimeVaryingInputs: AbstractTimeVaryingInput
 import StaticArrays
 import NCDatasets
+import Dates
 
 """
     restore!(v1, v2, comms_ctx; ignore)
@@ -75,5 +76,26 @@ end
 function restore!(v1::Dict, v2::Dict, comms_ctx; name, ignore)
     # RRTGMP has some internal dictionaries
     v1 == v2 || error("$name is inconsistent")
+    return nothing
+end
+
+"""
+    restore!(v1::T1, v2::T2, comms_ctx; name = "", ignore) where {T1 <: Union{Dates.DateTime, Dates.UTInstant, Dates.Millisecond}, T2 <: Union{Dates.DateTime, Dates.UTInstant, Dates.Millisecond}}
+
+Special case for time-related types to allow different timestamps during restore.
+"""
+function restore!(
+    v1::T1,
+    v2::T2,
+    comms_ctx;
+    name,
+    ignore,
+) where {
+    T1 <: Union{Dates.DateTime, Dates.UTInstant, Dates.Millisecond},
+    T2 <: Union{Dates.DateTime, Dates.UTInstant, Dates.Millisecond},
+}
+    if v1 != v2
+        @warn "Time value differs in restart" field = name original = v2 new = v1
+    end
     return nothing
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR enables us to use restart files with a new simulation start time. This is needed to enable steady initial states for calibration.

Sample output:
```
[ Info: Restarting from time 31536000 and directory experiments/calibration/coarse_amip/output/model_config/checkpoints
┌ Warning: Time value differs in restart
│   field = ".dt.epoch"
│   original = 2001-09-01T00:00:00
│   new = 2002-09-01T00:00:00
└ @ Main ~/clima/ClimaCoupler.jl/experiments/ClimaEarth/components/shared/restore.jl:94
┌ Warning: Time value differs in restart
│   field = ".atmos.insolation.start_date"
│   original = 2001-09-01T00:00:00
│   new = 2002-09-01T00:00:00
└ @ Main ~/clima/ClimaCoupler.jl/experiments/ClimaEarth/components/shared/restore.jl:94
```
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
