### PR TITLE
Fix typo in leaderboard

### DIFF
--- a/experiments/ClimaEarth/leaderboard/data_sources.jl
+++ b/experiments/ClimaEarth/leaderboard/data_sources.jl
@@ -242,7 +242,7 @@ function get_sim_var_in_pfull_dict(diagnostics_folder_path)
                     # pressure and altitude. To avoid that, we exclude everything below 80m.
                     # NOTE: This was empirically found.
                     pfull_var_windowed = ClimaAnalysis.window(pfull_var, "z", left = 80)
-                    sim_var_windowed = ClimaAnalysis.window(pfull_var, "z", left = 80)
+                    sim_var_windowed = ClimaAnalysis.window(sim_var, "z", left = 80)
 
                     sim_in_pfull_var =
                         ClimaAnalysis.Atmos.to_pressure_coordinates(sim_var_windowed, pfull_var_windowed)


### PR DESCRIPTION
It should be `sim_var` and not `pfull_var`.

Here are the plots produced from the leaderboard.
![bias_lat_pfull_heatmaps](https://github.com/user-attachments/assets/41601f2c-cc4a-4848-9a1a-ba04d5ce9ecf)
![bias_vars_in_pfull](https://github.com/user-attachments/assets/9fd66ae1-2d10-4caa-a45c-7873e8a6a256)
