### PR TITLE
use nonequil moisture with 1M

### DIFF
--- a/config/longrun_configs/amip_edonly_1M.yml
+++ b/config/longrun_configs/amip_edonly_1M.yml
@@ -11,6 +11,7 @@ dt_rad: "1hours"
 energy_check: false
 insolation: "timevarying"
 mode_name: "amip"
+moist: "nonequil"
 precip_model: "1M"
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add `moist: "nonequil"` to the 1M microphysics longrun to make a compatible atmosphere setup. This should fix the error we saw in the [most recent longrun](https://buildkite.com/clima/climacoupler-longruns/builds/904#019796a7-d8df-4a7b-a6f3-73bc921680ed/171-270).