### PR TITLE
fix this week's longruns

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -99,6 +99,7 @@ steps:
           queue: clima
           slurm_mem: 32GB
           slurm_gpus: 1
+        timeout_in_minutes: 2160 # 36 hours
 
   - group: "AMIP simulations"
 

--- a/experiments/ClimaEarth/components/land/climaland_integrated.jl
+++ b/experiments/ClimaEarth/components/land/climaland_integrated.jl
@@ -185,7 +185,9 @@ function ClimaLandSimulation(
     #  code itself requires a surface temperature as input.
     @. p.T_sfc = orog_adjusted_T_surface
 
-    updateat = [promote(tspan[1]:dt:(tspan[2] + dt)...)...] # add an extra time at end in case sim steps over end
+    # Update cos(zenith angle) within land model every hour
+    update_dt = dt isa ITime ? ITime(3600) : 3600
+    updateat = [promote(tspan[1]:update_dt:(tspan[2] + dt)...)...] # add an extra time at end in case sim steps over end
     updatefunc = CL.make_update_drivers(CL.get_drivers(model))
     driver_cb = CL.DriverUpdateCallback(updateat, updatefunc)
 

--- a/experiments/ClimaEarth/user_io/diagnostics_plots.jl
+++ b/experiments/ClimaEarth/user_io/diagnostics_plots.jl
@@ -113,6 +113,12 @@ function make_plots_generic(
             vars_left_to_plot -= 1
             continue
         end
+        if minimum(var.data) == maximum(var.data)
+            @warn "$(short_name(var)) diagnostic is spatially constant - skipping plot"
+            vars_left_to_plot -= 1
+            continue
+        end
+
         if grid_pos > MAX_PLOTS_PER_PAGE
             fig = makefig()
             grid = gridlayout()
@@ -132,6 +138,9 @@ function make_plots_generic(
             page += 1
         end
     end
+
+    # Return early if there are no plots to save
+    isempty(summary_files) && return nothing
 
     # Save plots
     output_file = joinpath(plot_path, "$(output_name).pdf")


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Many longruns are now passing, but a few still fail - see [build](https://buildkite.com/clima/climacoupler-longruns/builds/908). This PR fixes the following issues:
- Aquaplanet ED only
  - [Error](https://buildkite.com/clima/climacoupler-longruns/builds/908#0197bab4-5d03-41c2-b6f6-fdae14c08729/170-721): `LoadError: Can't interpolate in a range where cmin == cmax. This can happen, for example, if a colorrange is set automatically but there's only one unique value present.`
  - Fix: Check if an output var contains only spatially constant data, and don't try to plot it in that case
- Aquaplanet diag. EDMF
  - [Error](https://buildkite.com/clima/climacoupler-longruns/builds/908#0197bab4-5d03-4c13-a07e-d970120f374f/170-649): timeout
  - Fix: increase timeout limit so we can see longterm stability of this setup
- AMIP + DecayWithHeight + integrated land
  - [Error](https://buildkite.com/clima/climacoupler-longruns/builds/908#0197bab4-5d05-4ae7-8cf2-0c0501d6e74b/171-297): StackOverflow when constructing array to update radiative fluxes
  - Fix: update radiative fluxes every 1 hour, which is how often the atmosphere computes radiation anyway. Note that a simulation with length < 1 hour will just update at the start of the simulation.

A couple other longruns still fail, but these are because of instabilities in the model and need to be debugged in the component models.