### PR TITLE
Fix AtmosModel property access due to breaking interface change

### DIFF
--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -70,7 +70,7 @@ function ClimaAtmosSimulation(atmos_config)
         surface_rain_flux .= FT(0)
         surface_snow_flux .= FT(0)
     end
-    if integrator.p.atmos.precip_model isa CA.Microphysics0Moment
+    if integrator.p.atmos.microphysics_model isa CA.Microphysics0Moment
         if pkgversion(CA) >= v"0.29.0"
             ᶜS_ρq_tot = integrator.p.precomputed.ᶜS_ρq_tot
             ᶜS_ρq_tot .= FT(0)
@@ -177,7 +177,7 @@ function Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:energy})
 
 
     # return total energy and (if Microphysics0Moment) the energy lost due to precipitation removal
-    if p.atmos.precip_model isa CA.Microphysics0Moment
+    if p.atmos.microphysics_model isa CA.Microphysics0Moment
         ᶜts = p.precomputed.ᶜts
         ᶜΦ = p.core.ᶜΦ
         if pkgversion(CA) >= v"0.29.0"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Fix downstream test after https://github.com/CliMA/ClimaAtmos.jl/pull/3886 renames `ClimaAtmos.AtmosModel` field names. This should only be merged after the next ClimaAtmos release, and is needed for the nightly AMIP to pass.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
