### PR TITLE
add flag to check RMSE

### DIFF
--- a/config/longrun_configs/amip_diagedmf_topo.yml
+++ b/config/longrun_configs/amip_diagedmf_topo.yml
@@ -16,6 +16,7 @@ netcdf_output_at_levels: true
 output_default_diagnostics: true
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "300days"

--- a/config/longrun_configs/amip_diagedmf_topo_integrated_land.yml
+++ b/config/longrun_configs/amip_diagedmf_topo_integrated_land.yml
@@ -16,6 +16,7 @@ netcdf_output_at_levels: true
 output_default_diagnostics: true
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "366days"

--- a/config/longrun_configs/amip_edonly.yml
+++ b/config/longrun_configs/amip_edonly.yml
@@ -13,6 +13,7 @@ insolation: "timevarying"
 mode_name: "amip"
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "366days"

--- a/config/longrun_configs/amip_edonly_1M.yml
+++ b/config/longrun_configs/amip_edonly_1M.yml
@@ -15,6 +15,7 @@ moist: "nonequil"
 precip_model: "1M"
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "366days"

--- a/config/longrun_configs/amip_edonly_topo.yml
+++ b/config/longrun_configs/amip_edonly_topo.yml
@@ -15,6 +15,7 @@ mode_name: "amip"
 netcdf_interpolate_z_over_msl: true
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "366days"

--- a/config/longrun_configs/amip_edonly_topo_integrated_land.yml
+++ b/config/longrun_configs/amip_edonly_topo_integrated_land.yml
@@ -15,6 +15,7 @@ mode_name: "amip"
 netcdf_interpolate_z_over_msl: true
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "366days"

--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -13,6 +13,7 @@ insolation: "timevarying"
 mode_name: "cmip"
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "93days"

--- a/config/longrun_configs/cmip_edonly_land.yml
+++ b/config/longrun_configs/cmip_edonly_land.yml
@@ -13,6 +13,7 @@ land_model: "integrated"
 mode_name: "cmip"
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
+rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "93days"

--- a/experiments/ClimaEarth/cli_options.jl
+++ b/experiments/ClimaEarth/cli_options.jl
@@ -106,13 +106,17 @@ function argparse_settings()
         help = "Boolean flag indicating whether to use a dynamic slab ocean model, as opposed to constant surface temperatures [`true` (default), `false`]"
         arg_type = Bool
         default = true
-        # Conservation information
+        # Conservation and RMSE check information
         "--energy_check"
         help = "Boolean flag indicating whether to check energy conservation [`false` (default), `true`]"
         arg_type = Bool
         default = false
         "--conservation_softfail"
         help = "Boolean flag indicating whether to soft fail on conservation errors [`false` (default), `true`]"
+        arg_type = Bool
+        default = false
+        "--rmse_check"
+        help = "Boolean flag indicating whether to check RMSE of some physical fields [`false` (default), `true`]"
         arg_type = Bool
         default = false
         # Output information

--- a/experiments/ClimaEarth/leaderboard/test_rmses.jl
+++ b/experiments/ClimaEarth/leaderboard/test_rmses.jl
@@ -62,8 +62,8 @@ Return a dictionary mapping short names to maximum acceptable RMSE values.
 function get_rmse_thresholds()
     rmse_thresholds = Dict(
         "pr" => 3.0,      # mm/day
-        "rsut" => 20.0,   # W/m²
-        "rsutcs" => 7.0,  # W/m²
+        "rsut" => 24.0,   # W/m²
+        "rsutcs" => 7.4,  # W/m²
     )
     return rmse_thresholds
 end

--- a/experiments/ClimaEarth/run_amip.jl
+++ b/experiments/ClimaEarth/run_amip.jl
@@ -47,6 +47,6 @@ cs = CoupledSimulation(config_file)
 run!(cs)
 
 # Postprocessing
-# TODO: Remove this option?
 conservation_softfail = get_coupler_config_dict(config_file)["conservation_softfail"]
-postprocess(cs, conservation_softfail)
+rmse_check = get_coupler_config_dict(config_file)["rmse_check"]
+postprocess(cs; conservation_softfail, rmse_check)

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -552,15 +552,18 @@ function run!(cs::CoupledSimulation; precompile = (cs.tspan[end] > 2 * cs.Δt_cp
 end
 
 """
-    postprocess(cs, conservation_softfail)
+    postprocess(cs; conservation_softfail = false, rmse_check = false)
 
 Process the results after a simulation has completed, including generating
 plots, checking conservation, and other diagnostics.
 
 When `conservation_softfail` is true, throw an error if conservation is not
 respected.
+
+When `rmse_check` is true, compute the RMSE against observations and test
+that it is below a certain threshold.
 """
-function postprocess(cs, conservation_softfail)
+function postprocess(cs; conservation_softfail = false, rmse_check = false)
     #=
     ## Postprocessing
     All postprocessing is performed using the root process only, if applicable.
@@ -576,7 +579,7 @@ function postprocess(cs, conservation_softfail)
     =#
 
     if ClimaComms.iamroot(ClimaComms.context(cs)) && !isnothing(cs.diags_handler)
-        postprocessing_vars = (; conservation_softfail)
+        postprocessing_vars = (; conservation_softfail, rmse_check)
         postprocess_sim(cs, postprocessing_vars)
     end
     return nothing

--- a/experiments/ClimaEarth/user_io/arg_parsing.jl
+++ b/experiments/ClimaEarth/user_io/arg_parsing.jl
@@ -112,6 +112,7 @@ function get_coupler_args(config_dict::Dict)
     # Conservation information
     energy_check = config_dict["energy_check"]
     conservation_softfail = config_dict["conservation_softfail"]
+    rmse_check = config_dict["rmse_check"]
 
     # Output information
     output_dir_root = joinpath(config_dict["coupler_output_dir"], job_id)
@@ -143,6 +144,7 @@ function get_coupler_args(config_dict::Dict)
         evolving_ocean,
         energy_check,
         conservation_softfail,
+        rmse_check,
         output_dir_root,
         land_model,
         bucket_albedo_type,

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -13,7 +13,7 @@ producing the leaderboard if monthly data is available, performing
 conservation checks if enabled, and closing all diagnostics file writers.
 """
 function postprocess_sim(cs, postprocessing_vars)
-    (; conservation_softfail) = postprocessing_vars
+    (; conservation_softfail, rmse_check) = postprocessing_vars
     output_dir = cs.dirs.output
     artifact_dir = cs.dirs.artifacts
     coupler_output_dir = joinpath(output_dir, "coupler")
@@ -41,7 +41,7 @@ function postprocess_sim(cs, postprocessing_vars)
         if t_end > 84600 * 31 * 3 # 3 months for spin up
             leaderboard_base_path = artifact_dir
             compute_leaderboard(leaderboard_base_path, atmos_output_dir, 3)
-            test_rmse_thresholds(atmos_output_dir, 3)
+            rmse_check && test_rmse_thresholds(atmos_output_dir, 3)
             pressure_in_output && compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir, 6)
         end
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds an option to enable checking the RMSE. This is by default off, but is turned on for runs that are physically complex enough to produce small RMSEs. For now, these include: CMIP and AMIP longruns with ED only or diag. EDMF diffusion.

Also makes the conservation_softfail and rmse_check arguments to postprocess optional kwargs so that we can call postprocess(cs).

Increases two of the RMSE thresholds to values that are more reasonable based on the past weekend's [longrun failures](https://buildkite.com/clima/climacoupler-longruns/builds/915#_).

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
- [x] add an option `rmse_check` and use it to conditionally test RMSE
- [x] set `rmse_check: true` for complex AMIP and CMIP runs 
- [x] lower two RMSE thresholds
- [x] make `conservation_softfail` and `rmse_check` optional arguments to `postprocess`


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
