### PR TITLE
use more CPUs for aquaplanet longruns

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -86,7 +86,9 @@ steps:
         agents:
           queue: clima
           slurm_mem: 32GB
-          slurm_gpus: 1
+          slurm_gpus_per_task: 1
+          slurm_cpus_per_task: 4
+          slurm_ntasks: 1
 
       - label: "GPU Aquaplanet: diag. EDMF atmosphere + slab ocean"
         key: "aquaplanet_diagedmf"
@@ -98,8 +100,9 @@ steps:
         agents:
           queue: clima
           slurm_mem: 32GB
-          slurm_gpus: 1
-        timeout_in_minutes: 2160 # 36 hours
+          slurm_gpus_per_task: 1
+          slurm_cpus_per_task: 4
+          slurm_ntasks: 1
 
   - group: "AMIP simulations"
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In the latest longruns, the aquaplanet with diag. EDMF [timed out](https://buildkite.com/clima/climacoupler-longruns/builds/915#0197dec3-ecaa-48c8-981b-c8170a655f7c/170-638). Notably, it had lower SYPD (0.742) than AMIP runs with either the bucket (1.093) or integrated land (1.015) - probably because we allocated different resources for them.

This PR unifies the resources we use for all GPU runs so that (1) aquaplanet won't time out and (2) performance between them will be meaningful and less misleading.