### PR TITLE
fix CO.ExponentialCoordinate access

### DIFF
--- a/experiments/ClimaEarth/components/ocean/oceananigans.jl
+++ b/experiments/ClimaEarth/components/ocean/oceananigans.jl
@@ -80,7 +80,7 @@ function OceananigansSimulation(area_fraction, start_date, stop_date; output_dir
         # When we use EN4 data, the forcing takes care of everything, including
         # the initial conditions
         restoring_rate = 1 / (3 * 86400)
-        mask = CO.LinearlyTaperedPolarMask(southern = (-80, -70), northern = (70, 90), z = (z[1], 0))
+        mask = CO.LinearlyTaperedPolarMask(southern = (-80, -70), northern = (70, 90), z = (z(1), 0))
 
         forcing_T = CO.DatasetRestoring(en4_temperature, grid; mask, rate = restoring_rate)
         forcing_S = CO.DatasetRestoring(en4_salinity, grid; mask, rate = restoring_rate)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
When I updated to ClimaOcean v0.7 in #1417, I switched to use the new `ExponentialCoordinate`, but I didn't correctly update how it's used. This fixes it, and should make the next nightly CMIP run pass - see previous [failure](https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/427#0197f210-b2d7-475f-813b-03b43d993f6e/174-317).