### PR TITLE
Use latest Oceananigans in nightly AMIP

### DIFF
--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -29,9 +29,7 @@ steps:
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"Thermodynamics\", rev=\"main\"))'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"SurfaceFluxes\", rev=\"main\"))'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"RRTMGP\", rev=\"main\"))'"
-      # UNCOMMENT when ClimaOcean is updated to use the latest Oceananigans
-      # - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"Oceananigans\", rev=\"main\"))'"
-      # As of 17-Jul-25, ClimaOceans is not yet compatible with the latest Oceananigans
+      - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"Oceananigans\", rev=\"main\"))'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaOcean\", rev=\"main\"))'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.resolve()'"
 


### PR DESCRIPTION
This was previously disabled because ClimaOcean was not compatible with the latest Oceananigans release

I was able to successfully initialize the nightly amip env [here](https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/447#_)

Reverts changes from  #1439 