### PR TITLE
remove `netrc_downloader` method

### DIFF
--- a/experiments/ClimaEarth/components/ocean/oceananigans.jl
+++ b/experiments/ClimaEarth/components/ocean/oceananigans.jl
@@ -408,16 +408,3 @@ TODO extend this for non-ClimaCore states.
 function Checkpointer.get_model_prog_state(sim::OceananigansSimulation)
     @warn "get_model_prog_state not implemented for OceananigansSimulation"
 end
-
-import Downloads
-# TODO: Remove this workaround once the change has been made to ClimaOcean
-function CO.DataWrangling.netrc_downloader(username, password, machine, dir)
-    netrc_file = CO.DataWrangling.netrc_permission_file(username, password, machine, dir)
-    downloader = Downloads.Downloader()
-    easy_hook = (easy, *) -> begin
-        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_NETRC_FILE, netrc_file)
-        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_SSL_VERIFYPEER, false)
-    end
-    downloader.easy_hook = easy_hook
-    return downloader
-end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This method was defined in ClimaCoupler.jl as a temporary fix, but was added to ClimaOcean in https://github.com/CliMA/ClimaOcean.jl/pull/557 (included in release v0.7.0)
