### PR TITLE
use PrescribedSurface for AMIP benchmarks [skip ci]

### DIFF
--- a/config/benchmark_configs/amip_diagedmf.yml
+++ b/config/benchmark_configs/amip_diagedmf.yml
@@ -10,5 +10,6 @@ monthly_checkpoint: false
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 start_date: "20100101"
+surface_setup: "PrescribedSurface"
 t_end: "12hours"
 use_coupler_diagnostics: false

--- a/config/benchmark_configs/amip_diagedmf_io.yml
+++ b/config/benchmark_configs/amip_diagedmf_io.yml
@@ -10,5 +10,6 @@ monthly_checkpoint: false
 prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 start_date: "20100101"
+surface_setup: "PrescribedSurface"
 t_end: "12hours"
 use_coupler_diagnostics: true


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
so that the surface fluxes are computed correctly

failing benchmarks from this past weekend: https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/257#_
passing benchmarks using this PR: https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/258#_

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
