### PR TITLE
make the spinup for pfull leaderboard the same as others

### DIFF
--- a/experiments/ClimaEarth/leaderboard/leaderboard.jl
+++ b/experiments/ClimaEarth/leaderboard/leaderboard.jl
@@ -391,5 +391,5 @@ if abspath(PROGRAM_FILE) == @__FILE__
     leaderboard_base_path = ARGS[begin]
     diagnostics_folder_path = ARGS[begin + 1]
     compute_leaderboard(leaderboard_base_path, diagnostics_folder_path, 3)
-    compute_pfull_leaderboard(leaderboard_base_path, diagnostics_folder_path, 6)
+    compute_pfull_leaderboard(leaderboard_base_path, diagnostics_folder_path, 3)
 end

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -43,7 +43,7 @@ function postprocess_sim(cs, postprocessing_vars)
             compute_leaderboard(leaderboard_base_path, atmos_output_dir, 3)
             rmse_check && test_rmse_thresholds(atmos_output_dir, 3)
             pressure_in_output &&
-                compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir, 6)
+                compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir, 3)
         end
     end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Right now, it makes plots for simulations shorter than 6 months, but the spinup for the pfull leaderboard is 6 months, so it's a bit confusing. This PR changes it.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
