### PR TITLE
rm GPU ClimaEarth runtests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -105,15 +105,6 @@ steps:
         agents:
           slurm_mem: 16GB
 
-      - label: "GPU ClimaEarth runtests"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/runtests.jl"
-        env:
-          CLIMACOMMS_DEVICE: "CUDA"
-        agents:
-          slurm_ntasks: 1
-          slurm_gres: "gpu:1"
-          slurm_mem: 32GB
-
       - label: "MPI restarts"
         key: "mpi_restarts"
         command: "srun julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/restart.jl"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Removes the "GPU ClimaEarth runtests" from our CI pipeline. This is the slowest part of our CI pipeline (typically by 10-30 minutes), so removing it will speed up development time.

These tests include individual component model tests, and a coarse AMIP test designed to be use in downstream tests of upstream packages. Each of these is already tested as part of GPU simulations in this pipeline, and we keep the
"CPU ClimaEarth runtests" run, so we don't really lose any coverage by removing the GPU version.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
