### PR TITLE
use update_turbulent_fluxes; don't area weight rad flux

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,14 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Use `update_turbulent_fluxes!` instead of `update_field!` for atmosphere PR[#1511](https://github.com/CliMA/ClimaCoupler.jl/pull/1511)
+Instead of using an `update_field!` method that dispatches on `::Val{:turbulent_fluxes}`
+to update turbulent fluxes in the atmosphere, we switch to using a function `update_turbulent_fluxes!`.
+This is consistent with what we do for surface models.
+
+This PR also removes area fraction weighting in the default radiative flux update
+in FluxCalculator.jl.
+
 #### Replace `TD.PhaseEquil_ρTq` with `TD.PhaseNonEquil_ρTq` PR[#1506](https://github.com/CliMA/ClimaCoupler.jl/pull/1506)
 This should be more physically correct.
 

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -452,11 +452,7 @@ function Interfacer.update_field!(
         CC.Fields.field2array(temp_field_surface)'
 end
 
-function Interfacer.update_field!(
-    sim::ClimaAtmosSimulation,
-    ::Val{:turbulent_fluxes},
-    fields,
-)
+function FluxCalculator.update_turbulent_fluxes!(sim::ClimaAtmosSimulation, fields)
     (; F_lh, F_sh, F_turb_moisture, F_turb_ρτxz, F_turb_ρτyz) = fields
     atmos_surface_space = get_surface_space(sim)
     temp_field_surface = sim.integrator.p.scratch.ᶠtemp_field_level

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -195,7 +195,6 @@ function update_sim!(atmos_sim::Interfacer.AtmosModelSimulation, csf)
     )
     Interfacer.update_field!(atmos_sim, Val(:emissivity), csf.emissivity)
     Interfacer.update_field!(atmos_sim, Val(:surface_temperature), csf)
-    Interfacer.update_field!(atmos_sim, Val(:turbulent_fluxes), csf)
     return nothing
 end
 
@@ -209,14 +208,8 @@ Updates the surface component model cache with the current coupler fields beside
 - `csf`: [NamedTuple] containing coupler fields.
 """
 function update_sim!(sim::Interfacer.SurfaceModelSimulation, csf, area_fraction)
-    FT = eltype(area_fraction)
-
     # radiative fluxes
-    Interfacer.update_field!(
-        sim,
-        Val(:radiative_energy_flux_sfc),
-        FT.(area_fraction .* csf.F_radiative),
-    )
+    Interfacer.update_field!(sim, Val(:radiative_energy_flux_sfc), csf.F_radiative)
 
     # precipitation
     Interfacer.update_field!(sim, Val(:liquid_precipitation), csf.P_liq)

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -68,8 +68,7 @@ function turbulent_fluxes!(csf, model_sims, thermo_params)
 
     # Update the atmosphere with the fluxes across all surface models
     # The surface models have already been updated with the fluxes in `compute_surface_fluxes!`
-    # TODO this should be `update_turbulent_fluxes` to match the surface models
-    Interfacer.update_field!(atmos_sim, Val(:turbulent_fluxes), csf)
+    FluxCalculator.update_turbulent_fluxes!(atmos_sim, csf)
     return nothing
 end
 
@@ -188,11 +187,14 @@ function get_surface_params(atmos_sim::Interfacer.AtmosModelSimulation)
 end
 
 """
-    update_turbulent_fluxes!(sim::Interfacer.SurfaceModelSimulation, fields::NamedTuple)
+    update_turbulent_fluxes!(sim::Interfacer.ComponentModelSimulation, fields::NamedTuple)
 
-Updates the fluxes in the surface model simulation `sim` with the fluxes in `fields`.
+Updates the fluxes in the simulation `sim` with the fluxes in `fields`.
+
+For surface models, this should be the fluxes computed between the surface model and the atmosphere.
+For atmosphere models, this should be the area-weighted sum of fluxes across all surface models.
 """
-function update_turbulent_fluxes!(sim::Interfacer.SurfaceModelSimulation, fields)
+function update_turbulent_fluxes!(sim::Interfacer.ComponentModelSimulation, fields)
     return error(
         "update_turbulent_fluxes! is required to be dispatched on $(nameof(sim)), but no method defined",
     )

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -275,7 +275,6 @@ update_field!(
         Val{:surface_direct_albedo},
         Val{:surface_diffuse_albedo},
         Val{:surface_temperature},
-        Val{:turbulent_fluxes},
     },
     _,
 ) = update_field_warning(sim, val)

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -121,8 +121,6 @@ Interfacer.update_field!(sim::TestAtmosSimulation, ::Val{:surface_temperature}, 
 Interfacer.update_field!(sim::TestAtmosSimulation, ::Val{:roughness_buoyancy}, field) =
     nothing
 Interfacer.update_field!(sim::TestAtmosSimulation, ::Val{:beta}, field) = nothing
-Interfacer.update_field!(sim::TestAtmosSimulation, ::Val{:turbulent_fluxes}, field) =
-    nothing
 
 #surface sim
 struct TestSurfaceSimulationLand{C} <: Interfacer.SurfaceModelSimulation

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -272,13 +272,8 @@ end
     sim = DummySimulation4(space)
 
     # Test that update_field! gives correct warnings for unextended fields
-    for value in (
-        :emissivity,
-        :surface_direct_albedo,
-        :surface_diffuse_albedo,
-        :surface_temperature,
-        :turbulent_fluxes,
-    )
+    for value in
+        (:emissivity, :surface_direct_albedo, :surface_diffuse_albedo, :surface_temperature)
         val = Val(value)
         @test_logs (
             :warn,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Closes #1494
Closes #1509

## To-do
- [x] Rename the `update_field!` atmosphere method for turbulent fluxes to `update_turbulent_fluxes!`
- [x] Remove the area fraction weighting in FluxCalculator.jl default radiative flux update function
