### PR TITLE
Do not add title again for debug plots

### DIFF
--- a/experiments/ClimaEarth/user_io/debug_plots.jl
+++ b/experiments/ClimaEarth/user_io/debug_plots.jl
@@ -145,10 +145,11 @@ function debug(sim::Interfacer.ComponentModelSimulation, dir)
         if field_index <= length(field_names)
             field_name = field_names[field_index]
             field = Interfacer.get_field(sim, Val(field_name))
-            ax = Makie.Axis(
-                fig[i, j * 2 - 1],
-                title = string(field_name) * print_extrema(field),
-            )
+            # If field is a ClimaCore field, then _heatmap_cc_field! will add a
+            # title to the axis
+            title =
+                field isa CC.Fields.Field ? "" : string(field_name) * print_extrema(field)
+            ax = Makie.Axis(fig[i, j * 2 - 1]; title)
             if field isa OC.Field || field isa OC.AbstractOperations.AbstractOperation
                 if field isa OC.AbstractOperations.AbstractOperation
                     field = OC.Field(field)


### PR DESCRIPTION
closes #1477 - This PR adds an empty title when it is a ClimaCore Field, because `_heatmap_cc_field!` will add the title.

This is an image of the debug plots from Buildkite.
<img width="3000" height="1600" alt="image" src="https://github.com/user-attachments/assets/7f6c0607-58f1-4022-8855-9e85af51ca96" />