### PR TITLE
change the logic of detect_restart_file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Change the behavior of `detect_restart_file` PR[#1515](https://github.com/CliMA/ClimaCoupler.jl/pull/1515)
+Users now only need to specify `restart_dir` and `restart_t` to restart a simulation from a specific file, and do
+not need to set `detect_restart_file` to true. `detect_restart_file` is used for detecting restart file automatically.
+
 #### Use `update_turbulent_fluxes!` instead of `update_field!` for atmosphere PR[#1511](https://github.com/CliMA/ClimaCoupler.jl/pull/1511)
 Instead of using an `update_field!` method that dispatches on `::Val{:turbulent_fluxes}`
 to update turbulent fluxes in the atmosphere, we switch to using a function `update_turbulent_fluxes!`.
@@ -50,8 +54,7 @@ in `make_land_domain`. Now we correctly use the provided `dz_tuple` and `n_eleme
 
 #### Add option `detect_restart_files` PR[#1463](https://github.com/CliMA/ClimaCoupler.jl/pull/1463)
 Add a CLI option to signal whether restart files should be automatically used
-to restart a simulation. This is true by default, but can be set to false if a
-user wishes to run a simulation from the beginning, ignoring present restart files.
+to restart a simulation. This is false by default.
 
 #### Remove ED/EDMF aquaplanet longruns PR[#1461](https://github.com/CliMA/ClimaCoupler.jl/pull/1461)
 Removes the ED-only and diag. EDMF aquaplanet longruns.

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -173,11 +173,12 @@ function CoupledSimulation(config_dict::AbstractDict)
     Random.seed!(random_seed)
     @info "Random seed set to $(random_seed)"
 
-    isnothing(restart_t) &&
-        (restart_t = Checkpointer.t_start_from_checkpoint(dir_paths.checkpoints))
-    isnothing(restart_dir) && (restart_dir = dir_paths.checkpoints)
-    should_restart =
-        detect_restart_files && !isnothing(restart_t) && !isnothing(restart_dir)
+    if detect_restart_files
+        isnothing(restart_t) &&
+            (restart_t = Checkpointer.t_start_from_checkpoint(dir_paths.checkpoints))
+        isnothing(restart_dir) && (restart_dir = dir_paths.checkpoints)
+    end
+    should_restart = !isnothing(restart_t) && !isnothing(restart_dir)
     if should_restart
         if t_start isa ITime
             t_start, _ = promote(ITime(restart_t), t_start)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Currently, the simulation will restart only if `detect_restart_file` is true. This requires users to both set `detect_restart_file` to true and provide `restart_dir` and `restart_t` if they want to specify a restart file. This PR changes the logic so that the users only need to provide `restart_dir` and `restart_t`, or set `detect_restart_file` to true to restart a simulation. I think this is more straightforward to most users.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
