### PR TITLE
minor dir_paths cleanup

### DIFF
--- a/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
@@ -97,7 +97,7 @@ end
         Ref(-1), # prev_checkpoint_t
         model_sims,
         (;), # callbacks
-        (;), # dirs
+        (;), # dir_paths
         thermo_params, # thermo_params
         nothing, # diags_handler
     )

--- a/experiments/ClimaEarth/test/debug_plots_tests.jl
+++ b/experiments/ClimaEarth/test/debug_plots_tests.jl
@@ -87,7 +87,7 @@ plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
         Ref(-1), # prev_checkpoint_t
         model_sims, # model_sims
         (;), # callbacks
-        (;), # dirs
+        (;), # dir_paths
         nothing, # thermo_params
         nothing, # diags_handler
     )

--- a/experiments/ClimaEarth/test/restart.jl
+++ b/experiments/ClimaEarth/test/restart.jl
@@ -59,7 +59,7 @@ four_steps_reading = deepcopy(four_steps)
 
 four_steps_reading["t_end"] = "900secs"
 four_steps_reading["detect_restart_files"] = true
-four_steps_reading["restart_dir"] = cs_four_steps.dirs.checkpoints
+four_steps_reading["restart_dir"] = cs_four_steps.dir_paths.checkpoints_dir
 four_steps_reading["restart_t"] = 720
 four_steps_reading["job_id"] = "four_steps_reading"
 

--- a/src/Checkpointer.jl
+++ b/src/Checkpointer.jl
@@ -134,7 +134,7 @@ function checkpoint_sims(cs::Interfacer.CoupledSimulation)
     time = Int(round(float(cs.t[])))
     day = floor(Int, time / (60 * 60 * 24))
     sec = floor(Int, time % (60 * 60 * 24))
-    output_dir = cs.dirs.checkpoints
+    output_dir = cs.dir_paths.checkpoints_dir
     prev_checkpoint_t = cs.prev_checkpoint_t[]
     comms_ctx = ClimaComms.context(cs)
 

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -70,7 +70,7 @@ struct CoupledSimulation{
     prev_checkpoint_t::CTT
     model_sims::NTMS
     callbacks::CALLBACKS
-    dirs::NTP
+    dir_paths::NTP
     thermo_params::TP
     diags_handler::DH
 end
@@ -83,7 +83,7 @@ function Base.show(io::IO, sim::CoupledSimulation)
         io,
         "Coupled Simulation\n",
         "├── Running on: $(device_type)\n",
-        "├── Output folder: $(sim.dirs.output)\n",
+        "├── Output folder: $(sim.dir_paths.output_dir_root)\n",
         "└── Current date: $(current_date(sim))\n",
     )
 end

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -82,7 +82,7 @@ for FT in (Float32, Float64)
             Ref(-1), # prev_checkpoint_t
             model_sims, # model_sims
             (;), # callbacks
-            (;), # dirs
+            (;), # dir_paths
             nothing, # thermo_params
             nothing, # diags_handler
         )
@@ -184,7 +184,7 @@ for FT in (Float32, Float64)
             Ref(-1), # prev_checkpoint_t
             model_sims, # model_sims
             (;), # callbacks
-            (;), # dirs
+            (;), # dir_paths
             nothing, # thermo_params
             nothing, # diags_handler
         )

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -217,7 +217,7 @@ for FT in (Float32, Float64)
                 land_sim = DummyStub((; area_fraction = land_fraction)),
             ), # model_sims
             (;), # callbacks
-            (;), # dirs
+            (;), # dir_paths
             nothing, # thermo_params
             nothing, # diags_handler
         )
@@ -505,7 +505,7 @@ for FT in (Float32, Float64)
             Ref(-1), # prev_checkpoint_t
             model_sims,
             (;), # callbacks
-            (;), # dirs
+            (;), # dir_paths
             thermo_params, # thermo_params
             nothing, # diags_handler
         )

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -55,7 +55,7 @@ for FT in (Float32, Float64)
             Ref(-1), # prev_checkpoint_t
             (;), # model_sims
             (;), # callbacks
-            (;), # dirs
+            (;), # dir_paths
             nothing, # thermo_params
             nothing, # diags_handler
         )


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Clean up dir path setting and postprocess function in driver
This PR doesn't change the structure of output/artifact/checkpoint directories at all.

## Content
- [x] unify `dir_path` naming across repo (replace `dirs`)
- [x] unify `output_dir_root` naming across repo (replace `output_dir`)
- [x] return component model output dirs from `setup_output_dirs` to reduce code in driver
- [x] move `postprocess` comment into docstring


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
