### PR TITLE
add integrated land nightly run

### DIFF
--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -62,9 +62,24 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 30GB
+      
+      - label: "Coarse current AMIP: diagedmf + 0M + integrated land"
+        key: "amip_land"
+        command:
+          - echo "--- Run simulation"
+          - "julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_land.yml --job_id amip_coarse_land"
+        artifact_paths: "experiments/ClimaEarth/output/amip_coarse_land/artifacts/*"
+        timeout_in_minutes: 840
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus_per_task: 1
+          slurm_cpus_per_task: 4
+          slurm_ntasks: 1
+          slurm_mem: 30GB
 
       - label: "Coarse current AMIP: progedmf + 0M + bucket land"
-        key: "amip_random1"
+        key: "amip_progedmf"
         command:
           - echo "--- Run simulation"
           - "julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_progedmf.yml --job_id amip_coarse_progedmf"

--- a/config/nightly_configs/amip_coarse.yml
+++ b/config/nightly_configs/amip_coarse.yml
@@ -20,7 +20,3 @@ t_end: "465days"
 topo_smoothing: true
 topography: "Earth"
 z_elem: 39
-extra_atmos_diagnostics:
-  - short_name: [od550aer, odsc550aer]
-    period: "1months"
-    reduction_time: average

--- a/config/nightly_configs/amip_coarse_land.yml
+++ b/config/nightly_configs/amip_coarse_land.yml
@@ -1,7 +1,6 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
-atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
-bucket_albedo_type: "map_temporal"
+atmos_config_file: "config/atmos_configs/climaatmos_diagedmf.yml"
 checkpoint_dt: "366days"
 coupler_toml: ["toml/amip.toml"]
 dt: "240secs"
@@ -9,6 +8,7 @@ dt_cpl: "240secs"
 dz_bottom: 100.0
 energy_check: false
 h_elem: 8
+land_model: "integrated"
 mode_name: "amip"
 netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
@@ -16,7 +16,7 @@ output_default_diagnostics: true
 radiation_reset_rng_seed: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "825days"
+t_end: "465days"
 topo_smoothing: true
 topography: "Earth"
 z_elem: 39


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds a nightly run for integrated land. I didn't change the weekly amip (which has a higher resolution atmos) because it breaks at ~20 weeks now. Once the amip with integrated land is more stable and faster we can remove the bucket from nightly amip and change the weekly amip.

Also removes some extra diagnostics we don't need.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
