### PR TITLE
use central queue for change to Vast

### DIFF
--- a/.buildkite/hierarchies/pipeline.yml
+++ b/.buildkite/hierarchies/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: new-central
+  queue: central
   slurm_time: 24:00:00
   modules: climacommon/2025_05_15
 

--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: new-central
+  queue: central
   slurm_time: 24:00:00
   modules: climacommon/2025_05_15
 
@@ -86,7 +86,7 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 32GB
-      
+
       - label: "GPU AMIP + ED only + 1M microphysics"
         key: "amip_edonly_1M_gpu"
         command: "srun julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_edonly_1M.yml --job_id amip_edonly_1M_gpu"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: new-central
+  queue: central
   slurm_time: 4:00:00
   modules: climacommon/2025_05_15
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ needed to run CliMA code on Caltech's clusters.
 
 On Central, you can load the appropriate module package by running the following in the terminal:
 ```
-export MODULEPATH="/groups/esm/modules:$MODULEPATH"
+export MODULEPATH="/resnick/groups/esm/modules:$MODULEPATH"
 module load climacommon
 ```
 

--- a/test/mpi_tests/local_checks.sh
+++ b/test/mpi_tests/local_checks.sh
@@ -5,7 +5,7 @@
 #SBATCH --mem-per-cpu=16G
 #SBATCH --partition=expansion
 
-export MODULEPATH="/groups/esm/modules:$MODULEPATH"
+export MODULEPATH="/resnick/groups/esm/modules:$MODULEPATH"
 module purge
 module load climacommon/2024_10_09
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Changes for switch to Vast filesystem

PR for the same change in ClimaLand: https://github.com/CliMA/ClimaLand.jl/pull/1511

## Content
- [x] use the queue `central` instead of `new-central` for CI
- [x] rename any paths that use `central/` or `groups/` to `resnick/`
- [x] change the queue in the [buildkite pipeline](https://buildkite.com/clima/climacoupler-ci/settings/steps)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
