### PR TITLE
re-enable non-binary area fractions

### DIFF
--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -125,7 +125,6 @@ function PrescribedIceSimulation(
     # Overwrite ice fraction with the static land area fraction anywhere we have nonzero land area
     #  max needed to avoid Float32 errors (see issue #271; Heisenbug on HPC)
     ice_fraction = @. max(min(SIC_init, FT(1) - land_fraction), FT(0))
-    ice_fraction = ifelse.(ice_fraction .> FT(0.5), FT(1), FT(0))
 
     params = IceSlabParameters{FT}()
 
@@ -269,7 +268,6 @@ function ice_rhs!(dY, Y, p, t)
 
     # Update the cached area fraction with the current SIC
     evaluate!(p.area_fraction, p.SIC_timevaryinginput, t)
-    @. p.area_fraction = ifelse(p.area_fraction > FT(0.5), FT(1), FT(0))
 
     # Overwrite ice fraction with the static land area fraction anywhere we have nonzero land area
     #  max needed to avoid Float32 errors (see issue #271; Heisenbug on HPC)

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -374,7 +374,6 @@ function CoupledSimulation(config_dict::AbstractDict)
 
         ## ocean model using prescribed data
         ice_fraction = Interfacer.get_field(ice_sim, Val(:area_fraction))
-        ice_fraction = ifelse.(ice_fraction .> FT(0.5), FT(1), FT(0))
         ocean_fraction = FT(1) .- ice_fraction .- land_fraction
 
         if sim_mode <: CMIPMode


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Reverts [this commit](https://github.com/CliMA/ClimaCoupler.jl/pull/1519/commits/16ea3343bc798bc172e2f9d06cc802537e81829b), so that area fractions for ice and ocean will be on [0, 1] again, instead of strictly 0 or 1.
