### PR TITLE
use binary ice fraction and fix the temperature in sea ice radiation

### DIFF
--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -359,6 +359,7 @@ function CoupledSimulation(config_dict::AbstractDict)
 
         ## ocean model using prescribed data
         ice_fraction = Interfacer.get_field(ice_sim, Val(:area_fraction))
+        ice_fraction = ifelse.(ice_fraction .> FT(0.5), FT(1), FT(0))
         ocean_fraction = FT(1) .- ice_fraction .- land_fraction
 
         if sim_mode <: CMIPMode


### PR DESCRIPTION
Uses binary sea ice as it seems to be more stable in amip. Also fixes the surface temperature used in LW radiation of sea ice, and renames T_sfc in sea ice model to T_bulk for clarity.