### PR TITLE
isolate area fraction logic to update_surface_fractions

### DIFF
--- a/docs/src/fieldexchanger.md
+++ b/docs/src/fieldexchanger.md
@@ -39,6 +39,6 @@ the atmosphere and each surface model.
 
 ```@docs
     ClimaCoupler.FieldExchanger.combine_surfaces!
-    ClimaCoupler.FieldExchanger.resolve_ocean_ice_fractions!
+    ClimaCoupler.FieldExchanger.resolve_area_fractions!
     ClimaCoupler.FieldExchanger.import_atmos_fields!
 ```

--- a/experiments/ClimaEarth/components/ocean/prescr_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_ocean.jl
@@ -42,7 +42,8 @@ end
         ::Type{FT},
         space,
         start_date,
-        area_fraction,
+        t_start,
+        coupled_param_dict,
         thermo_params,
         comms_ctx;
         z0m = FT(5.8e-5),
@@ -65,7 +66,6 @@ function PrescribedOceanSimulation(
     space,
     start_date,
     t_start,
-    area_fraction,
     coupled_param_dict,
     thermo_params,
     comms_ctx;
@@ -115,7 +115,7 @@ function PrescribedOceanSimulation(
         α_diffuse = ones(space) .* α_diffuse_val,
         u_int = zeros(space),
         v_int = zeros(space),
-        area_fraction = area_fraction,
+        area_fraction = ones(space),
         phase = TD.Liquid(),
         thermo_params = thermo_params,
         SST_timevaryinginput = SST_timevaryinginput,

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -172,12 +172,10 @@ function PrescribedIceSimulation(
     )
 
     # Get initial SIC values and use them to calculate ice fraction
-    SIC_init = CC.Fields.zeros(space)
-    evaluate!(SIC_init, SIC_timevaryinginput, tspan[1])
+    ice_fraction = CC.Fields.zeros(space)
+    evaluate!(ice_fraction, SIC_timevaryinginput, tspan[1])
 
-    # Overwrite ice fraction with the static land area fraction anywhere we have nonzero land area
-    #  max needed to avoid Float32 errors (see issue #271; Heisenbug on HPC)
-    ice_fraction = @. max(min(SIC_init, FT(1) - land_fraction), FT(0))
+    # Make ice fraction binary rather than fractional
     ice_fraction = ifelse.(ice_fraction .> FT(0.5), FT(1), FT(0))
 
     params = IceSlabParameters{FT}(coupled_param_dict)

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -105,9 +105,19 @@ function slab_ocean_space_init(space, params)
 end
 
 """
-    SlabOceanSimulation(::Type{FT}; tspan, dt, saveat, space, area_fraction, stepper = CTS.RK4()) where {FT}
+    SlabOceanSimulation(::Type{FT};
+        tspan,
+        dt,
+        saveat,
+        space,
+        coupled_param_dict,
+        thermo_params,
+        stepper = CTS.RK4(),
+        evolving = true,
+    ) where {FT}
 
-Initializes the `DiffEq` problem, and creates a Simulation-type object containing the necessary information for `step!` in the coupling loop.
+Initializes the `DiffEq` problem, and creates a Simulation-type object containing the
+necessary information for `step!` in the coupling loop.
 """
 function SlabOceanSimulation(
     ::Type{FT};
@@ -115,7 +125,6 @@ function SlabOceanSimulation(
     dt,
     saveat,
     space,
-    area_fraction,
     coupled_param_dict,
     thermo_params,
     stepper = CTS.RK4(),
@@ -131,7 +140,7 @@ function SlabOceanSimulation(
         F_turb_energy = CC.Fields.zeros(space),
         SW_d = CC.Fields.zeros(space),
         LW_d = CC.Fields.zeros(space),
-        area_fraction = area_fraction,
+        area_fraction = ones(space),
         thermo_params = thermo_params,
         α_direct = CC.Fields.ones(space) .* params.α,
         α_diffuse = CC.Fields.ones(space) .* params.α,

--- a/experiments/ClimaEarth/test/component_model_tests/prescr_ocean_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/prescr_ocean_tests.jl
@@ -35,7 +35,6 @@ end
         space,
         start_date,
         t_start,
-        area_fraction,
         coupled_param_dict,
         thermo_params,
         comms_ctx,

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -16,7 +16,7 @@ export update_sim!,
     exchange!,
     set_caches!,
     update_surface_fractions!,
-    resolve_ocean_ice_fractions!
+    resolve_area_fractions!
 
 """
     update_surface_fractions!(cs::Interfacer.CoupledSimulation)
@@ -71,7 +71,7 @@ function update_surface_fractions!(cs::Interfacer.CoupledSimulation)
 
         # ensure that ocean and ice fractions are consistent
         if haskey(cs.model_sims, :ice_sim)
-            resolve_ocean_ice_fractions!(ocean_sim, cs.model_sims.ice_sim, land_fraction)
+            resolve_area_fractions!(ocean_sim, cs.model_sims.ice_sim, land_fraction)
         end
     else
         cs.fields.scalar_temp1 .= 0
@@ -84,7 +84,7 @@ function update_surface_fractions!(cs::Interfacer.CoupledSimulation)
 end
 
 """
-    resolve_ocean_ice_fractions!(ocean_sim, ice_sim, land_fraction)
+    resolve_area_fractions!(ocean_sim, ice_sim, land_fraction)
 
 Ensure that the ocean and ice fractions are consistent with each other.
 For most ocean and ice models, this does nothing since the ocean fraction is
@@ -92,7 +92,7 @@ defined as `1 - ice_fraction - land_fraction`. However, some models may have
 additional constraints on the ice and ocean fractions that need to be enforced.
 This function can be extended for such models.
 """
-function resolve_ocean_ice_fractions!(ocean_sim, ice_sim, land_fraction)
+function resolve_area_fractions!(ocean_sim, ice_sim, land_fraction)
     return nothing
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Instead of enforcing the same constraints (`ice_fraction = 1 - land_fraction`, and `ocean_fraction = 1 - ice_fraction`) in multiple places, we do it only in `resolve_area_fractions!`.

This simplifies the component model initialization in `setup_run.jl` and also means that surface model area fractions are incorrect until `update_surface_fractions!` is called. This is done before the initial exchange and during each step, so I think this is fine.


## To-do
- [x] overwrite ocean/ice fractions only in `update_surface_fractions!`
- [x] initialize models with dummy area fractions that get correctly resolved during the initial exchange and at each step via `update_surface_fractions!`
- [x] call `update_surface_fractions!` for both restarted and non-restarted runs. I don't think this will affect reproducibility since area fractions aren't saved/read in during restarts anyway.
- [x] rename `resolve_ocean_ice_fractions` to `resolve_area_fractions` since it now also makes sure land is 1 over the poles when using Oceananigans (because of the LatitudeLongitude grid latitude limits)
- [x] verified buildkite plots are unchanged


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
