### PR TITLE
use ClimaParams for shared parameters in coupled sims

### DIFF
--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -5,6 +5,7 @@ import LinearAlgebra
 import ClimaAtmos as CA
 import ClimaAtmos: set_surface_albedo!
 import ClimaAtmos.Parameters as CAP
+import ClimaParams as CP
 import ClimaCore as CC
 import ClimaCore.Geometry: ⊗
 import SurfaceFluxes as SF
@@ -612,13 +613,16 @@ The TOML parameter file to use is chosen using the following priority:
 If a coupler TOML file is provided, it is used.
 Otherwise we use an atmos TOML file if it's provided.
 If neither file is provided, the default ClimaAtmos parameters are used.
+This is analogous to the logic in `get_coupler_config_dict` for selecting
+the coupler configuration TOML file.
 """
-function get_atmos_config_dict(coupler_config::Dict, atmos_output_dir)
+function get_atmos_config_dict(
+    coupler_config::Dict,
+    atmos_output_dir,
+    coupled_param_dict::CP.ParamDict,
+    comms_ctx,
+)
     atmos_config = deepcopy(coupler_config)
-
-    # Rename parameters for consistency with ClimaAtmos.jl
-    # Rename atmosphere config file from ClimaCoupler convention to ClimaAtmos convention
-    atmos_config["config_file"] = coupler_config["atmos_config_file"]
 
     # Ensure Atmos's own checkpoints are synced up with ClimaCoupler, so that we
     # can pick up from where we have left. NOTE: This should not be needed, but
@@ -632,17 +636,24 @@ function get_atmos_config_dict(coupler_config::Dict, atmos_output_dir)
         coupler_config["dt"]
     atmos_config["dt"] = dt_atmos
 
-    # Use atmos toml if coupler toml is not defined
-    # If we can't find the file at the relative path, prepend pkgdir(ClimaAtmos)
+    # Set up the atmosphere parameter dictionary (`toml_dict`)
+    # If we can't find the atmos TOML file at the relative path, prepend pkgdir(ClimaAtmos)
     atmos_toml = map(atmos_config["toml"]) do file
         isfile(file) ? file : joinpath(pkgdir(CA), file)
     end
+    # Use atmos toml only if coupler toml is not defined
     coupler_toml = atmos_config["coupler_toml"]
     toml = isempty(coupler_toml) ? atmos_toml : coupler_toml
     if !isempty(toml)
         @info "Overwriting Atmos parameters from input TOML file(s): $toml"
         atmos_config["toml"] = toml
     end
+
+    # Override atmos parameters with coupled parameters
+    FT = atmos_config["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
+    override_file = CP.merge_toml_files(atmos_config["toml"], override = true)
+    atmos_toml = CP.create_toml_dict(FT; override_file)
+    toml_dict = CP.merge_override_default_values(coupled_param_dict, atmos_toml)
 
     # Specify atmos output directory to be inside the coupler output directory
     atmos_config["output_dir_style"] = "RemovePreexisting"
@@ -660,7 +671,23 @@ function get_atmos_config_dict(coupler_config::Dict, atmos_output_dir)
         atmos_config["restart_file"] =
             replace(atmos_config["restart_file"], "active" => "0000")
     end
-    return CA.AtmosConfig(atmos_config)
+
+    # Construct the AtmosConfig object
+    config_files = atmos_config["toml"]
+    job_id = atmos_config["job_id"]
+    config = CA.override_default_config(atmos_config)
+
+    TD = typeof(toml_dict)
+    PA = typeof(config)
+    C = typeof(comms_ctx)
+    CF = typeof(config_files)
+    return CA.AtmosConfig{FT, TD, PA, C, CF}(
+        toml_dict,
+        config,
+        comms_ctx,
+        config_files,
+        job_id,
+    )
 end
 
 """

--- a/experiments/ClimaEarth/components/land/climaland_helpers.jl
+++ b/experiments/ClimaEarth/components/land/climaland_helpers.jl
@@ -1,5 +1,7 @@
 import ClimaCore as CC
 import ClimaLand as CL
+import ClimaParams as CP
+
 """
     temp_anomaly_aquaplanet(coord)
 
@@ -19,17 +21,22 @@ and result in stable simulations.
 temp_anomaly_amip(coord) = 40 * cosd(coord.lat)^4
 
 """
-    make_land_domain(nelements::Tuple{Int, Int}, depth::FT) where {FT}
-
+    make_land_domain(
+        depth::FT,
+        toml_dict::CP.ParamDict;
+        nelements::Tuple{Int, Int} = (101, 15),
+        dz_tuple::Tuple{FT, FT} = FT.((10.0, 0.05)),
+    ) where {FT}
 Creates a land model domain with the given number of vertical elements
 and vertical depth.
 """
 function make_land_domain(
-    depth::FT;
+    depth::FT,
+    toml_dict::CP.ParamDict;
     nelements::Tuple{Int, Int} = (101, 15),
     dz_tuple::Tuple{FT, FT} = FT.((10.0, 0.05)),
 ) where {FT}
-    radius = FT(6378.1e3)
+    radius = toml_dict["planet_radius"] # in meters
     npolynomial = 0
     domain = CL.Domains.SphericalShell(; radius, depth, nelements, npolynomial, dz_tuple)
     return domain

--- a/experiments/ClimaEarth/components/ocean/prescr_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_ocean.jl
@@ -66,6 +66,7 @@ function PrescribedOceanSimulation(
     start_date,
     t_start,
     area_fraction,
+    coupled_param_dict,
     thermo_params,
     comms_ctx;
     z0m = FT(5.8e-5),
@@ -92,12 +93,13 @@ function PrescribedOceanSimulation(
         end : sst_path
     @info "PrescribedOcean: using SST file" sst_data
 
+    C_to_K = coupled_param_dict["temperature_water_freeze"]
     SST_timevaryinginput = TimeVaryingInput(
         sst_data,
         "SST",
         space,
         reference_date = start_date,
-        file_reader_kwargs = (; preprocess_func = (data) -> data + FT(273.15),), ## convert to Kelvin
+        file_reader_kwargs = (; preprocess_func = (data) -> data + C_to_K,), ## convert Celsius to Kelvin
     )
 
     SST_init = zeros(space)

--- a/experiments/ClimaEarth/test/component_model_tests/climaatmos_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/climaatmos_tests.jl
@@ -6,9 +6,11 @@ include(joinpath("..", "..", "components", "atmosphere", "climaatmos.jl"))
 
 for FT in (Float32, Float64)
     @testset "dss_state! ClimaAtmosSimulation for FT=$FT" begin
+        coupled_param_dict = CP.create_toml_dict(FT)
+
         boundary_space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = coupled_param_dict["planet_radius"], # in meters
             n_quad_points = 4,
             h_elem = 4,
         )

--- a/experiments/ClimaEarth/test/component_model_tests/slab_ocean_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/slab_ocean_tests.jl
@@ -1,14 +1,17 @@
 import Test: @test, @testset
 import ClimaCore as CC
+import ClimaParams as CP
 import ClimaCoupler
 
 include(joinpath("..", "..", "components", "ocean", "slab_ocean.jl"))
 
 for FT in (Float32, Float64)
     @testset "dss_state! SlabOceanSimulation for FT=$FT" begin
+        coupled_param_dict = CP.create_toml_dict(FT)
+
         boundary_space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = coupled_param_dict["planet_radius"], # in meters
             n_quad_points = 4,
             h_elem = 4,
         )

--- a/experiments/ClimaEarth/test/debug_plots_tests.jl
+++ b/experiments/ClimaEarth/test/debug_plots_tests.jl
@@ -1,6 +1,7 @@
 # testing functions used to produce user-defined debugging plots for AMIP experiments
 import Test: @test, @testset, @test_logs
 import ClimaCore as CC
+import ClimaParams as CP
 import ClimaCoupler: Interfacer
 import ClimaComms
 ClimaComms.@import_required_backends
@@ -35,10 +36,11 @@ plot_field_names(sim::ClimaLandSimulation) = (:surface_field,)
 plot_field_names(sim::Interfacer.SurfaceStub) = (:stub_field,)
 
 @testset "import_atmos_fields!" begin
+    coupled_param_dict = CP.create_toml_dict(FT)
 
     boundary_space = CC.CommonSpaces.CubedSphereSpace(
         FT;
-        radius = FT(6371e3),
+        radius = coupled_param_dict["planet_radius"], # in meters
         n_quad_points = 4,
         h_elem = 4,
     )

--- a/experiments/ClimaEarth/test/runtests.jl
+++ b/experiments/ClimaEarth/test/runtests.jl
@@ -11,7 +11,7 @@ end
 @safetestset "component model test: prescr. sea ice" begin
     include("component_model_tests/prescr_seaice_tests.jl")
 end
-@safetestset "component model test: prescr. sea ice" begin
+@safetestset "component model test: prescr. ocean" begin
     include("component_model_tests/prescr_ocean_tests.jl")
 end
 @safetestset "component model test: slab ocean" begin

--- a/test/checkpointer_tests.jl
+++ b/test/checkpointer_tests.jl
@@ -14,7 +14,7 @@ Checkpointer.get_model_prog_state(sim::DummySimulation) = sim.state
 @testset "get_model_prog_state" begin
     boundary_space = CC.CommonSpaces.CubedSphereSpace(
         FT;
-        radius = FT(6371e3),
+        radius = FT(6.371e6), # in meters
         n_quad_points = 4,
         h_elem = 4,
     )
@@ -30,7 +30,7 @@ end
     boundary_space = CC.CommonSpaces.CubedSphereSpace(
         FT;
         comms_ctx,
-        radius = FT(6371e3),
+        radius = FT(6.371e6), # in meters
         n_quad_points = 4,
         h_elem = 4,
     )

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -41,7 +41,7 @@ for FT in (Float32, Float64)
     @testset "test check_conservation for conservation for FT=$FT" begin
         space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
         )
@@ -143,7 +143,7 @@ for FT in (Float32, Float64)
     @testset "test plot_global_conservation with dummy models for FT=$FT" begin
         space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
         )

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -180,7 +180,7 @@ for FT in (Float32, Float64)
     @testset "test update_surface_fractions!" begin
         test_space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
         )
@@ -236,7 +236,7 @@ for FT in (Float32, Float64)
     @testset "test combine_surfaces" begin
         test_space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
         )
@@ -271,7 +271,7 @@ for FT in (Float32, Float64)
     @testset "import_atmos_fields! for FT=$FT" begin
         boundary_space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
         )
@@ -313,7 +313,7 @@ for FT in (Float32, Float64)
         # coupler cache setup
         boundary_space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
         )
@@ -352,7 +352,7 @@ for FT in (Float32, Float64)
         # coupler cache setup
         boundary_space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
         )
@@ -447,7 +447,7 @@ for FT in (Float32, Float64)
         # coupler cache setup
         boundary_space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
         )

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -103,7 +103,7 @@ for FT in (Float32, Float64)
     @testset "calculate correct fluxes: dry for FT=$FT" begin
         boundary_space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
         )

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -37,7 +37,7 @@ for FT in (Float32, Float64)
     @testset "test CoupledSim construction, float_type for FT=$FT" begin
         boundary_space_ = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
             context,
@@ -65,7 +65,7 @@ for FT in (Float32, Float64)
     @testset "get_field indexing for FT=$FT" begin
         space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
             context,
@@ -107,7 +107,7 @@ for FT in (Float32, Float64)
     @testset "update_field! the SurfaceStub area_fraction for FT=$FT" begin
         boundary_space = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
             context,
@@ -155,7 +155,7 @@ end
     FT = Float32
     space = CC.CommonSpaces.CubedSphereSpace(
         FT;
-        radius = FT(6371e3),
+        radius = FT(6.371e6), # in meters
         n_quad_points = 4,
         h_elem = 4,
         context,
@@ -172,7 +172,7 @@ end
     FT = Float32
     space = CC.CommonSpaces.CubedSphereSpace(
         FT;
-        radius = FT(6371e3),
+        radius = FT(6.371e6), # in meters
         n_quad_points = 4,
         h_elem = 4,
         context,
@@ -200,7 +200,7 @@ end
     FT = Float32
     space = CC.CommonSpaces.CubedSphereSpace(
         FT;
-        radius = FT(6371e3),
+        radius = FT(6.371e6), # in meters
         n_quad_points = 4,
         h_elem = 4,
         context,
@@ -231,7 +231,7 @@ end
     FT = Float32
     space = CC.CommonSpaces.CubedSphereSpace(
         FT;
-        radius = FT(6371e3),
+        radius = FT(6.371e6), # in meters
         n_quad_points = 4,
         h_elem = 4,
         context,
@@ -265,7 +265,7 @@ end
     FT = Float32
     space = CC.CommonSpaces.CubedSphereSpace(
         FT;
-        radius = FT(6371e3),
+        radius = FT(6.371e6), # in meters
         n_quad_points = 4,
         h_elem = 4,
         context,
@@ -306,7 +306,7 @@ end
     FT = Float32
     source_space = CC.CommonSpaces.CubedSphereSpace(
         FT;
-        radius = FT(6371e3),
+        radius = FT(6.371e6), # in meters
         n_quad_points = 4,
         h_elem = 4,
         context,
@@ -316,7 +316,7 @@ end
     # Remap field to target space
     target_space = CC.CommonSpaces.CubedSphereSpace(
         FT;
-        radius = FT(6371e3),
+        radius = FT(6.371e6), # in meters
         n_quad_points = 4,
         h_elem = 6,
         context,

--- a/test/utilities_tests.jl
+++ b/test/utilities_tests.jl
@@ -46,7 +46,7 @@ for FT in (Float32, Float64)
     @testset "integral" begin
         space2d = CC.CommonSpaces.CubedSphereSpace(
             FT;
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             n_quad_points = 4,
             h_elem = 4,
         )
@@ -57,7 +57,7 @@ for FT in (Float32, Float64)
             z_elem = 10,
             z_min = 0,
             z_max = 1,
-            radius = FT(6371e3),
+            radius = FT(6.371e6), # in meters
             h_elem = 10,
             n_quad_points = 4,
             staggering = CC.CommonSpaces.CellCenter(),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Get parameters from ClimaParams instead of hardcoding them in ClimaCoupler.

Note that any parameter overrides specified in `parameter_files` are now applied at the coupler level (in the driver), then passed to component models as a TOML dict. This might change interfaces for calibration and/or weather quest.

closes https://github.com/CliMA/ClimaCoupler.jl/issues/1520
closes https://github.com/CliMA/ClimaCoupler.jl/issues/1372

A step towards https://github.com/CliMA/ClimaCoupler.jl/issues/342 - see that issue for next steps

## Content
- parameters to get from CP
  - sigma (Stefan Boltzmann constant)
  - C_to_K
  - thermo_params
  - planet radius (note this was previously wrong when we constructed a boundary space independent of the atmosphere space, i.e. share_surface_space = false)
- add constructors for prescribed ice and slab ocean parameters that take in a toml dict
- for bucket and land constructors, take in a toml dict instead of a list of parameter files (parameters from these files are overriden at the coupler level now)
- confirmed that buildkite plots are unchanged as compared to main

## To Do
remaining:
atmos accepting a toml dict (maybe can just call AtmosConfig directly)
oceananigans/climaseaice accepting a toml dict of parameters
add tests to verify that components are using the same values
