### PR TITLE
remove FluxCalculator.surface_inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Remove `FluxCalculator.surface_inputs` helper function PR[#1543](https://github.com/CliMA/ClimaCoupler.jl/pull/1543)
+We can simplify the flux calculation by calling `SF.ValuesOnly` directly.
+Since we now remap all quantities onto the boundary space when we compute
+fluxes, there's no need to access the underlying data layouts of ClimaCore Fields.
+
 #### Provide `SW_d`, `LW_d` to surface models instead of `F_radiative` PR[#1518](https://github.com/CliMA/ClimaCoupler.jl/pull/1518)
 This allows us to correctly compute radiative flux over surface models by
 computing each contribution individually (`SW_u, SW_d, LW_u, LW_d`).


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Since we now remap all quantities onto the boundary space when we compute fluxes, there's no need to access the underlying data layouts of ClimaCore Fields, which was previously being done via `maybe_fv`.

Once we remove `maybe_fv` from `FluxCalculator.surface_inputs`, that becomes a one line function that we can just call directly rather than wrapping it in a separate function.

Plots in buildkite look visually unchanged.