### PR TITLE
use default depot + julia -O0 flag

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,35 +19,29 @@ steps:
   - label: "init environment :computer:"
     key: "init_cpu_env"
     command:
-      - |
-        if [ -n "$$CLEAR_DEPOT" ]; then
-          echo "--- Clearing depot"
-          rm -rf ${JULIA_DEPOT_PATH}
-        fi
-
       - echo "--- Instantiate package env"
-      - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project -e 'using Pkg; Pkg.precompile()'"
-      - "julia --project -e 'using Pkg; Pkg.status()'"
+      - "julia -O0 --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia -O0 --project -e 'using Pkg; Pkg.precompile()'"
+      - "julia -O0 --project -e 'using Pkg; Pkg.status()'"
 
       - echo "--- Instantiate ClimaEarth experiments env"
-      - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(\"MPI\")'"
-      - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.precompile()'"
-      - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.status()'"
+      - "julia -O0 --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia -O0 --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(\"MPI\")'"
+      - "julia -O0 --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia -O0 --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.status()'"
 
       - echo "--- Instantiate ClimaCore experiments env"
-      - "julia --project=experiments/ClimaCore/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project=experiments/ClimaCore/ -e 'using Pkg; Pkg.add(\"MPI\")'"
-      - "julia --project=experiments/ClimaCore/ -e 'using Pkg; Pkg.precompile()'"
-      - "julia --project=experiments/ClimaCore/ -e 'using Pkg; Pkg.status()'"
+      - "julia -O0 --project=experiments/ClimaCore/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia -O0 --project=experiments/ClimaCore/ -e 'using Pkg; Pkg.add(\"MPI\")'"
+      - "julia -O0 --project=experiments/ClimaCore/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia -O0 --project=experiments/ClimaCore/ -e 'using Pkg; Pkg.status()'"
 
       - echo "--- Instantiate test env"
-      - "julia --project=test/ -e 'using Pkg; Pkg.develop(path=\".\")'"
-      - "julia --project=test/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project=test/ -e 'using Pkg; Pkg.add(\"MPI\")'"
-      - "julia --project=test/ -e 'using Pkg; Pkg.precompile()'"
-      - "julia --project=test/ -e 'using Pkg; Pkg.status()'"
+      - "julia -O0 --project=test/ -e 'using Pkg; Pkg.develop(path=\".\")'"
+      - "julia -O0 --project=test/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia -O0 --project=test/ -e 'using Pkg; Pkg.add(\"MPI\")'"
+      - "julia -O0 --project=test/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia -O0 --project=test/ -e 'using Pkg; Pkg.status()'"
 
     concurrency: 1
     concurrency_group: 'depot/climacoupler-ci'
@@ -65,7 +59,7 @@ steps:
 
       - label: "MPI Utilities unit tests"
         key: "utilities_mpi_tests"
-        command: "srun julia --color=yes --project=test/ test/utilities_tests.jl"
+        command: "srun julia -O0 --color=yes --project=test/ test/utilities_tests.jl"
         timeout_in_minutes: 5
         env:
           CLIMACOMMS_CONTEXT: "MPI"
@@ -75,7 +69,7 @@ steps:
 
       - label: "MPI Interfacer unit tests"
         key: "interfacer_mpi_tests"
-        command: "srun julia --color=yes --project=test/ test/interfacer_tests.jl"
+        command: "srun julia -O0 --color=yes --project=test/ test/interfacer_tests.jl"
         timeout_in_minutes: 5
         env:
           CLIMACOMMS_CONTEXT: "MPI"
@@ -86,7 +80,7 @@ steps:
   - group: "GPU: unit tests"
     steps:
       - label: "GPU runtests"
-        command: "julia --color=yes --project=test/ test/runtests.jl"
+        command: "julia -O0 --color=yes --project=test/ test/runtests.jl"
         timeout_in_minutes: 10
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -98,7 +92,7 @@ steps:
   - group: "ClimaEarth tests"
     steps:
       - label: "ClimaEarth runtests"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/runtests.jl"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/runtests.jl"
         agents:
           slurm_mem: 16GB
 
@@ -116,7 +110,7 @@ steps:
           slurm_mem: 32GB
 
       - label: "GPU restarts"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/restart.jl"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/restart.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -125,7 +119,7 @@ steps:
           slurm_mem: 32GB
 
       - label: "GPU restarts"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/restart_state_only.jl"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/restart_state_only.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -184,13 +178,13 @@ steps:
       # Test default behavior with no config file or job ID provided
       - label: "AMIP: default"
         key: "amip_default"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl"
         artifact_paths: "output/amip_default/artifacts/*"
         agents:
           slurm_mem: 20GB
 
       - label: "AMIP: integrated land non-spun up initial condition test"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_land_ic.yml --job_id amip_land_ic"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_land_ic.yml --job_id amip_land_ic"
         artifact_paths: "output/amip_land_ic/artifacts/*"
         agents:
           slurm_ntasks: 1
@@ -198,7 +192,7 @@ steps:
 
       - label: "AMIP - Float64 + hourly checkpoint"
         key: "amip"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_ft64_hourly_checkpoints.yml --job_id amip_coarse_ft64_hourly_checkpoints"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_ft64_hourly_checkpoints.yml --job_id amip_coarse_ft64_hourly_checkpoints"
         artifact_paths: "output/amip_coarse_ft64_hourly_checkpoints/artifacts/*"
         env:
           FLAME_PLOT: ""
@@ -208,14 +202,14 @@ steps:
           slurm_mem: 20GB
 
       - label: "AMIP - Component dts test"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_component_dts.yml --job_id target_amip_component_dts"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_component_dts.yml --job_id target_amip_component_dts"
         artifact_paths: "output/target_amip_component_dts/artifacts/*"
         agents:
           slurm_ntasks: 1
           slurm_mem: 20GB
 
       - label: "MPI AMIP"
-        command: "srun julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_mpi.yml --job_id amip_coarse_mpi"
+        command: "srun julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_mpi.yml --job_id amip_coarse_mpi"
         artifact_paths: "output/amip_coarse_mpi/artifacts/*"
         timeout_in_minutes: 30
         env:
@@ -227,7 +221,7 @@ steps:
       # short high-res performance test
       - label: "Unthreaded AMIP FINE" # also reported by longruns with a flame graph
         key: "unthreaded_amip_fine"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_n1_shortrun.yml --job_id target_amip_n1_shortrun"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_n1_shortrun.yml --job_id target_amip_n1_shortrun"
         artifact_paths: "output/target_amip_n1_shortrun/artifacts/*"
         env:
           BUILD_HISTORY_HANDLE: ""
@@ -264,7 +258,7 @@ steps:
       # GPU RUNS: AMIP
       - label: "GPU AMIP: ED only + integrated land"
         key: "gpu_amip_edonly_integrated_land"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_edonly_integrated_land.yml --job_id gpu_amip_edonly_integrated_land"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_edonly_integrated_land.yml --job_id gpu_amip_edonly_integrated_land"
         artifact_paths: "output/gpu_amip_edonly_integrated_land/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -274,7 +268,7 @@ steps:
 
       - label: "GPU AMIP: ED only + bucket"
         key: "gpu_amip_edonly_bucket"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_edonly_bucket.yml --job_id gpu_amip_edonly_bucket"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_edonly_bucket.yml --job_id gpu_amip_edonly_bucket"
         artifact_paths: "output/gpu_amip_edonly_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -284,7 +278,7 @@ steps:
 
       - label: "GPU AMIP: diag. EDMF + integrated land"
         key: "gpu_amip_diagedmf_integrated_land"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_diagedmf_integrated_land.yml --job_id gpu_amip_diagedmf_integrated_land"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_diagedmf_integrated_land.yml --job_id gpu_amip_diagedmf_integrated_land"
         artifact_paths: "output/gpu_amip_diagedmf_integrated_land/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -294,7 +288,7 @@ steps:
 
       - label: "GPU AMIP: diag. EDMF + bucket"
         key: "gpu_amip_diagedmf_bucket"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_diagedmf_bucket.yml --job_id gpu_amip_diagedmf_bucket"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_diagedmf_bucket.yml --job_id gpu_amip_diagedmf_bucket"
         artifact_paths: "output/gpu_amip_diagedmf_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -304,7 +298,7 @@ steps:
 
       - label: "GPU AMIP: prog. EDMF + bucket"
         key: "gpu_amip_progedmf_bucket"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_progedmf_bucket.yml --job_id gpu_amip_progedmf_bucket"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_progedmf_bucket.yml --job_id gpu_amip_progedmf_bucket"
         artifact_paths: "output/gpu_amip_progedmf_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -315,7 +309,7 @@ steps:
 
       - label: "GPU AMIP test: albedo from function"
         key: "gpu_amip_albedo_function"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_albedo_function.yml --job_id gpu_amip_albedo_function"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_albedo_function.yml --job_id gpu_amip_albedo_function"
         artifact_paths: "output/gpu_amip_albedo_function/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -325,7 +319,7 @@ steps:
 
       - label: "GPU AMIP: albedo from temporal map + 0M"
         key: "gpu_amip_albedo_temporal_map"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_albedo_temporal_map.yml --job_id gpu_amip_albedo_temporal_map"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_albedo_temporal_map.yml --job_id gpu_amip_albedo_temporal_map"
         artifact_paths: "output/gpu_amip_albedo_temporal_map/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -335,7 +329,7 @@ steps:
 
       - label: "GPU AMIP: albedo from temporal map + 1M"
         key: "gpu_amip_albedo_temporal_map_1M"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_albedo_temporal_map_1M.yml --job_id gpu_amip_albedo_temporal_map_1M"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_albedo_temporal_map_1M.yml --job_id gpu_amip_albedo_temporal_map_1M"
         artifact_paths: "output/gpu_amip_albedo_temporal_map_1M/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -348,7 +342,7 @@ steps:
 
       - label: "GPU CMIP: ClimaAtmos + bucket land + Oceananigans + ClimaSeaIce"
         key: "gpu_cmip_oceananigans_climaseaice_bucket"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice_bucket.yml --job_id gpu_cmip_oceananigans_climaseaice_bucket"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice_bucket.yml --job_id gpu_cmip_oceananigans_climaseaice_bucket"
         artifact_paths: "output/gpu_cmip_oceananigans_climaseaice_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -358,7 +352,7 @@ steps:
 
       - label: "GPU CMIP: ClimaAtmos + integrated land + Oceananigans + ClimaSeaIce"
         key: "gpu_cmip_oceananigans_climaseaice"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice.yml --job_id gpu_cmip_oceananigans_climaseaice"
+        command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice.yml --job_id gpu_cmip_oceananigans_climaseaice"
         artifact_paths: "output/gpu_cmip_oceananigans_climaseaice/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -371,7 +365,7 @@ steps:
       - label: "Perfect model calibration test"
         key: "amip_pm_calibration"
         command:
-          - "julia --color=yes --project=experiments/ClimaEarth experiments/calibration/perfect_model/run_calibration.jl"
+          - "julia -O0 --color=yes --project=experiments/ClimaEarth experiments/calibration/perfect_model/run_calibration.jl"
         artifact_paths: "experiments/calibration/output/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           version: '1.11'
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia -O0 --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ docs/make.jl
+        run: julia -O0 --project=docs/ docs/make.jl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
           file: lcov.info
       - run: |
-          julia --color=yes --project=experiments/ClimaEarth -e 'using Pkg; Pkg.instantiate()'
-          julia --color=yes --project=experiments/ClimaEarth -e 'using Pkg; Pkg.develop(; path = ".")'
-          julia --color=yes --project=experiments/ClimaEarth experiments/ClimaEarth/test/runtests.jl
+          julia -O0 --color=yes --project=experiments/ClimaEarth -e 'using Pkg; Pkg.instantiate()'
+          julia -O0 --color=yes --project=experiments/ClimaEarth -e 'using Pkg; Pkg.develop(; path = ".")'
+          julia -O0 --color=yes --project=experiments/ClimaEarth experiments/ClimaEarth/test/runtests.jl
       - run: |
-          julia --color=yes --project=experiments/ClimaCore -e 'using Pkg; Pkg.instantiate()'
-          julia --color=yes --project=experiments/ClimaCore -e 'using Pkg; Pkg.develop(; path = ".")'
-          julia --color=yes --project=experiments/ClimaCore experiments/ClimaCore/test/runtests.jl
+          julia -O0 --color=yes --project=experiments/ClimaCore -e 'using Pkg; Pkg.instantiate()'
+          julia -O0 --color=yes --project=experiments/ClimaCore -e 'using Pkg; Pkg.develop(; path = ".")'
+          julia -O0 --color=yes --project=experiments/ClimaCore experiments/ClimaCore/test/runtests.jl


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
I added `climacoupler-ci` to the [Clear Depot pipeline](https://buildkite.com/clima/clear-depot/settings/steps). Now we can use the generic clear depot instead of the coupler-specific one. The default `clear depot` can be used to clear this pipeline's depot by setting the environment variable `slug=climacoupler-ci`.

Also minimized optimization of everything in the regular CI by passing the -O0 flag (as opposed to the default -O2 optimization level).

For timing examples, see CI runs [with -O0](https://buildkite.com/clima/climacoupler-ci/builds/7163) vs [default](https://buildkite.com/clima/climacoupler-ci/builds/7165). The largest change is in GPU CMIP, which goes from 42 to 28 minutes. Some slabplanet runs and the sea breeze experiment become slower because they're run for 1+days. This option seems to only be useful for tests and experiments that run for "a few" steps (maybe <5, depending on the configuration).

## Update 10 February 2026
Rebased on main
New timing comparison: with -O0 vs default