### PR TITLE
remove CPU runs from benchmarks

### DIFF
--- a/.buildkite/benchmarks/pipeline.yml
+++ b/.buildkite/benchmarks/pipeline.yml
@@ -29,60 +29,6 @@ steps:
 
   - wait
 
-  - group: "CPU benchmarks"
-    steps:
-      - label: "CPU ClimaAtmos without diagnostic EDMF"
-        key: "climaatmos"
-        command: "srun julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/component_model_tests/climaatmos_standalone/atmos_driver.jl --config_file $BENCHMARK_CONFIG_PATH/climaatmos.yml --job_id climaatmos"
-        artifact_paths: "experiments/ClimaEarth/output/climaatmos/artifacts/*"
-        env:
-          CLIMACOMMS_CONTEXT: "MPI"
-          BUILD_HISTORY_HANDLE: ""
-          CLIMACOMMS_DEVICE: "CPU"
-        agents:
-          slurm_ntasks_per_node: 64
-          slurm_nodes: 1
-          slurm_mem_per_cpu: 4GB
-
-      - label: "CPU ClimaAtmos with diagnostic EDMF"
-        key: "climaatmos_diagedmf"
-        command: "srun julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/component_model_tests/climaatmos_standalone/atmos_driver.jl --config_file $BENCHMARK_CONFIG_PATH/climaatmos_diagedmf.yml --job_id climaatmos_diagedmf"
-        artifact_paths: "experiments/ClimaEarth/output/climaatmos_diagedmf/artifacts/*"
-        env:
-          CLIMACOMMS_CONTEXT: "MPI"
-          BUILD_HISTORY_HANDLE: ""
-          CLIMACOMMS_DEVICE: "CPU"
-        agents:
-          slurm_ntasks_per_node: 64
-          slurm_nodes: 1
-          slurm_mem_per_cpu: 4GB
-
-      - label: "CPU AMIP with diagnostic EDMF"
-        key: "amip_diagedmf"
-        command: "srun julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $BENCHMARK_CONFIG_PATH/amip_diagedmf.yml --job_id amip_diagedmf"
-        artifact_paths: "experiments/ClimaEarth/output/amip_diagedmf/artifacts/*"
-        env:
-          CLIMACOMMS_CONTEXT: "MPI"
-          BUILD_HISTORY_HANDLE: ""
-          CLIMACOMMS_DEVICE: "CPU"
-        agents:
-          slurm_ntasks_per_node: 64
-          slurm_nodes: 1
-          slurm_mem_per_cpu: 4GB
-
-      - label: "CPU AMIP with diagnostic EDMF and io"
-        key: "amip_diagedmf_io"
-        command: "srun julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $BENCHMARK_CONFIG_PATH/amip_diagedmf_io.yml --job_id amip_diagedmf_io"
-        artifact_paths: "experiments/ClimaEarth/output/amip_diagedmf_io/artifacts/*"
-        env:
-          CLIMACOMMS_CONTEXT: "MPI"
-          BUILD_HISTORY_HANDLE: ""
-          CLIMACOMMS_DEVICE: "CPU"
-        agents:
-          slurm_ntasks_per_node: 64
-          slurm_nodes: 1
-          slurm_mem_per_cpu: 4GB
-
   - group: "GPU benchmarks"
     steps:
       - label: "GPU ClimaAtmos without diagnostic EDMF"
@@ -141,13 +87,9 @@ steps:
     steps:
       - label: "Compare AMIP/Atmos-only with diagnostic EDMF"
         key: "compare_amip_climaatmos_amip_diagedmf"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/user_io/benchmarks.jl --cpu_job_id_coupled amip_diagedmf --cpu_job_id_coupled_io amip_diagedmf_io --cpu_job_id_atmos_diagedmf climaatmos_diagedmf --cpu_job_id_atmos climaatmos --build_id $BUILDKITE_BUILD_NUMBER"
+        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/user_io/benchmarks.jl --gpu_job_id_coupled gpu_amip_diagedmf --gpu_job_id_coupled_io gpu_amip_diagedmf_io --gpu_job_id_atmos_diagedmf gpu_climaatmos_diagedmf --gpu_job_id_atmos gpu_climaatmos --build_id $BUILDKITE_BUILD_NUMBER"
         artifact_paths: "experiments/ClimaEarth/output/compare_amip_climaatmos_amip_diagedmf/*"
         depends_on:
-          - "climaatmos"
-          - "climaatmos_diagedmf"
-          - "amip_diagedmf"
-          - "amip_diagedmf_io"
           - "gpu_climaatmos"
           - "gpu_climaatmos_diagedmf"
           - "gpu_amip_diagedmf"

--- a/experiments/ClimaEarth/test/component_model_tests/climaatmos_standalone/atmos_driver.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/climaatmos_standalone/atmos_driver.jl
@@ -67,9 +67,4 @@ if ClimaComms.iamroot(comms_ctx)
     open(joinpath(output_dir, "sypd.txt"), "w") do sypd_filename
         println(sypd_filename, "$sypd")
     end
-
-    open(joinpath(output_dir, "max_rss_cpu.txt"), "w") do cpu_max_rss_filename
-        cpu_max_rss_GB = Utilities.show_memory_usage()
-        println(cpu_max_rss_filename, cpu_max_rss_GB)
-    end
 end

--- a/experiments/ClimaEarth/user_io/benchmarks.jl
+++ b/experiments/ClimaEarth/user_io/benchmarks.jl
@@ -1,23 +1,18 @@
 #=
 Our goal here is to output a table displaying some results from benchmark runs
-in the coupler. We want to be able to compare between CPU and GPU runs, as well
-as between coupled and atmos-only runs. The metrics we want to compare are
-SYPD, memory usage, allocations, and the maximum, median, and mean differences
-between the CPU and GPU states.
+in the coupler. We mainly want to compare SYPD between coupled and atmos-only runs.
 
 The table should look something like this (note that the last 3 columns will be
 added in a future PR):
-------------------------------------------------------------------------------------
-|             | CPU Run      | GPU Run     | Max Diff  |  Median Diff |  Mean Diff |
-------------------------------------------------------------------------------------
-|             |   $job_id    |   $job_id   |           |              |              |
-| Coupled run |    $SYPD     |    $SYPD    | $max_diff | $median_diff |  $mean_diff  |
-|             | $cpu_max_rss | $cpu_max_rss|           |              |              |
-------------------------------------------------------------------------------------
-|             |   $job_id    |   $job_id   |           |              |              |
-| Atmos-only  |    $SYPD     |    $SYPD    | $max_diff | $median_diff |  $mean_diff  |
-|             | $cpu_max_rss | $cpu_max_rss|           |              |              |
-------------------------------------------------------------------------------------
+-----------------------------
+|             | GPU Run     |
+-----------------------------
+|             |   $job_id   |
+| Coupled run |    $SYPD    |
+-----------------------------
+|             |   $job_id   |
+| Atmos-only  |    $SYPD    |
+-----------------------------
 
 =#
 
@@ -28,32 +23,16 @@ import ClimaCoupler
 function argparse_settings()
     s = ArgParse.ArgParseSettings()
     ArgParse.@add_arg_table! s begin
-        "--cpu_job_id_coupled"
-        help = "The name of the CPU coupled run we want to compare. User must specify CPU and/or GPU coupled run name."
-        arg_type = String
-        default = nothing
         "--gpu_job_id_coupled"
         help = "The name of the GPU coupled run we want to compare."
-        arg_type = String
-        default = nothing
-        "--cpu_job_id_coupled_io"
-        help = "The name of the CPU coupled run with IO we want to compare. User must specify CPU and/or GPU coupled run name."
         arg_type = String
         default = nothing
         "--gpu_job_id_coupled_io"
         help = "The name of the GPU coupled with IO run we want to compare."
         arg_type = String
         default = nothing
-        "--cpu_job_id_atmos"
-        help = "The name of the CPU atmos-only run without diagnostic EDMF we want to compare. User must specify CPU and/or GPU atmos-only non-EDMF run name."
-        arg_type = String
-        default = nothing
         "--gpu_job_id_atmos"
         help = "The name of the GPU atmos-only run we want to compare."
-        arg_type = String
-        default = nothing
-        "--cpu_job_id_atmos_diagedmf"
-        help = "The name of the CPU atmos-only run with diagnostic EDMF we want to compare. User must specify CPU and/or GPU atmos-only EDMF run name."
         arg_type = String
         default = nothing
         "--gpu_job_id_atmos_diagedmf"
@@ -76,26 +55,22 @@ end
     get_run_info(parsed_args, run_type)
 
 Use the input `parsed_args` to get the job ID and artifacts directories for
-both the CPU and GPU runs of the given `run_type`.
+the GPU run of the given `run_type`.
 
 `run_type` must be one of "coupled", "coupled_io", "atmos", or "atmos_diagedmf".
 """
 function get_run_info(parsed_args, run_type)
-    # Read in CPU and GPU job ID info from command line
+    # Read in GPU job ID info from command line
     if run_type == "coupled"
-        cpu_job_id = parsed_args["cpu_job_id_coupled"]
         gpu_job_id = parsed_args["gpu_job_id_coupled"]
         mode_name = "amip"
     elseif run_type == "coupled_io"
-        cpu_job_id = parsed_args["cpu_job_id_coupled_io"]
         gpu_job_id = parsed_args["gpu_job_id_coupled_io"]
         mode_name = "amip"
     elseif run_type == "atmos_diagedmf"
-        cpu_job_id = parsed_args["cpu_job_id_atmos_diagedmf"]
         gpu_job_id = parsed_args["gpu_job_id_atmos_diagedmf"]
         mode_name = "climaatmos"
     elseif run_type == "atmos"
-        cpu_job_id = parsed_args["cpu_job_id_atmos"]
         gpu_job_id = parsed_args["gpu_job_id_atmos"]
         mode_name = "climaatmos"
     else
@@ -103,26 +78,18 @@ function get_run_info(parsed_args, run_type)
     end
 
     # Verify that the user has provided the necessary job IDs
-    # If only one job ID of the CPU/GPU run pair is provided, the other will be inferred
-    if isnothing(cpu_job_id) && isnothing(gpu_job_id)
-        error("Must pass CPU and/or GPU coupled run name to compare them.")
-    elseif isnothing(gpu_job_id)
-        gpu_job_id = "gpu_" * cpu_job_id
-    elseif isnothing(cpu_job_id)
-        cpu_job_id = gpu_job_id[5:end]
-    end
+    isnothing(gpu_job_id) && error("Must pass GPU coupled run name to compare it.")
 
-    # Construct CPU and GPU artifacts directories
-    cpu_artifacts_dir = joinpath(output_dir, cpu_job_id, "artifacts")
+    # Construct GPU artifacts directory
     gpu_artifacts_dir = joinpath(output_dir, gpu_job_id, "artifacts")
 
-    return (cpu_job_id, gpu_job_id, cpu_artifacts_dir, gpu_artifacts_dir)
+    return (gpu_job_id, gpu_artifacts_dir)
 end
 
 """
     get_run_data(artifacts_dir)
 
-Read in run data from artifacts directories, currently SYPD and max RSS on the CPU.
+Read in run data from artifacts directory, currently SYPD.
 """
 function get_run_data(artifacts_dir)
     # Read in SYPD info
@@ -130,36 +97,22 @@ function get_run_data(artifacts_dir)
         round(parse(Float64, read(sypd_file, String)), digits = 4)
     end
 
-    # Read in max RSS info
-    cpu_max_rss = open(joinpath(artifacts_dir, "max_rss_cpu.txt"), "r") do cpu_max_rss_file
-        read(cpu_max_rss_file, String)
-    end
-
-    return (sypd, cpu_max_rss)
+    return sypd
 end
 
 """
-    append_table_data(table_data, setup_id, cpu_job_id, gpu_job_id, cpu_artifacts_dir, gpu_artifacts_dir)
+    append_table_data(table_data, setup_id, gpu_job_id, gpu_artifacts_dir)
 
 Append data for a given setup to the table data.
 """
-function append_table_data(
-    table_data,
-    setup_id,
-    cpu_job_id,
-    gpu_job_id,
-    cpu_artifacts_dir,
-    gpu_artifacts_dir,
-)
-    # Get SYPD and allocation info for both input runs
-    cpu_sypd, cpu_max_rss = get_run_data(cpu_artifacts_dir)
-    gpu_sypd, gpu_cpu_max_rss = get_run_data(gpu_artifacts_dir)
+function append_table_data(table_data, setup_id, gpu_job_id, gpu_artifacts_dir)
+    # Get SYPD info for the GPU run
+    gpu_sypd = get_run_data(gpu_artifacts_dir)
 
     # Create rows containing data for these runs
     new_table_data = [
-        ["" "job ID:" cpu_job_id gpu_job_id]
-        [setup_id "SYPD:" cpu_sypd gpu_sypd]
-        ["" "CPU max RSS:" cpu_max_rss gpu_cpu_max_rss]
+        [setup_id "job ID:" gpu_job_id]
+        ["" "SYPD:" gpu_sypd]
     ]
     return vcat(table_data, new_table_data)
 end
@@ -184,11 +137,10 @@ run_info_atmos_diagedmf = get_run_info(parsed_args, "atmos_diagedmf")
 run_info_atmos = get_run_info(parsed_args, "atmos")
 
 # Set up info for PrettyTables.jl
-headers =
-    [build_id_str, "Horiz. res.: 30 elems", "CPU Run [64 processes]", "GPU Run [2 A100s]"]
+headers = [build_id_str, "Horiz. res.: 30 elems", "GPU Run [2 A100s]"]
 data = [
-    ["" "Vert. res.: 63 levels" "" ""]
-    ["" "dt: 120secs" "" ""]
+    ["" "Vert. res.: 63 levels" ""]
+    ["" "dt: 120secs" ""]
 ]
 
 # Append data to the table for each of the cases we want to compare
@@ -197,12 +149,11 @@ data = append_table_data(data, "Coupled with diag. EDMF", run_info_coupled...)
 data = append_table_data(data, "Atmos with diag. EDMF", run_info_atmos_diagedmf...)
 data = append_table_data(data, "Atmos without diag. EDMF", run_info_atmos...)
 
-# Use the coupled CPU job ID for the output dir
-cpu_job_id_coupled = run_info_coupled[1]
-table_output_dir = joinpath(output_dir, "compare_amip_climaatmos_$(cpu_job_id_coupled)")
-!isdir(table_output_dir) && mkdir(table_output_dir)
+# Output table to file, note that this must match the slack upload command in the pipeline.yml file
+table_output_dir = joinpath(output_dir, "compare_amip_climaatmos_amip_diagedmf")
+mkpath(table_output_dir)
 table_path = joinpath(table_output_dir, "table.txt")
 open(table_path, "w") do f
     # Output the table, including lines before and after the header
-    PrettyTables.pretty_table(f, data, header = headers, hlines = [0, 3, 6, 9, 12, 15])
+    PrettyTables.pretty_table(f, data, header = headers, hlines = [0, 3, 5, 7, 9, 11])
 end

--- a/experiments/ClimaEarth/user_io/postprocessing.jl
+++ b/experiments/ClimaEarth/user_io/postprocessing.jl
@@ -116,14 +116,6 @@ function save_sypd_walltime_to_disk(cs, walltime)
         ) do walltime_per_step_filename
             println(walltime_per_step_filename, "$(walltime_per_step)")
         end
-
-        open(
-            joinpath(cs.dir_paths.artifacts_dir, "max_rss_cpu.txt"),
-            "w",
-        ) do cpu_max_rss_filename
-            cpu_max_rss_GB = Utilities.show_memory_usage()
-            println(cpu_max_rss_filename, cpu_max_rss_GB)
-        end
     end
     return nothing
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We don't care about tracking or comparing performance on CPU, so we can remove the CPU runs from the weekly benchmark runs.

We also don't need to track max RSS. It isn't very informative (especially on GPU) and isn't really a metric we care about.

## Content
- [x] remove CPU runs x4 from benchmark pipeline
- [x] remove max RSS output
- [x] update table generation according to these

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
