### PR TITLE
copy AMIP diagnostics to Azure VM for visualization

### DIFF
--- a/.buildkite/amip/pipeline.yml
+++ b/.buildkite/amip/pipeline.yml
@@ -58,6 +58,11 @@ steps:
 
     steps:
 
+      - label: "Send simulation output to Azure VM for visualization"
+        command:
+          - rsync -avz experiments/ClimaEarth/output/amip/output_active/* azure-arenchon:/home/arenchon/GitHub/ClimaViz.jl/data/climacoupler-amip/
+          - sudo systemctl restart climaviz.service
+
       - label: ":envelope: Slack report: current AMIP"
         command:
           - |


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add a line to the weekly AMIP buildkite pipeline to send diagnostics to the Azure VM for visualization. Note that this only sends diagnostics, not checkpoints or artifacts (plots).

Next, we will find a way to automate setting up the dashboard and output the link to the user, so we can easily see a dashboard for each weekly AMIP run.

I'm skipping CI since this only modifies the AMIP pipeline, which isn't run as part of CI.