### PR TITLE
use relative atmos height for land fluxes

### DIFF
--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -88,8 +88,8 @@ The default coupler exchange fields are the following, defined in
 | `T_atmos`         | atmosphere temperature at the bottom layer                  | K          |
 | `q_atmos`         | atmosphere humidity at the bottom layer                     | kg kg⁻¹    |
 | `ρ_atmos`         | atmosphere air density at the bottom layer                  | kg m⁻³     |
-| `z_int`           | height of the first internal atmosphere level (center)      | m          |
-| `z_sfc`           | height of the bottom atmosphere layer (face)                | m          |
+| `height_int`      | height at the bottom cell center of the atmosphere space    | m          |
+| `height_sfc`      | height at the bottom face of the atmosphere space           | m          |
 | `F_lh`            | latent heat flux                                            | W m⁻²      |
 | `F_sh`            | sensible heat flux                                          | W m⁻²      |
 | `F_turb_moisture` | turbulent moisture flux                                     | kg m⁻² s⁻¹ |
@@ -341,6 +341,7 @@ end
     ClimaCoupler.Interfacer.remap
     ClimaCoupler.Interfacer.remap!
     ClimaCoupler.Interfacer.boundary_space
+    ClimaCoupler.Interfacer.get_atmos_height_delta
 ```
 
 ## Interfacer Internal Functions and Types

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -561,7 +561,7 @@ FluxCalculator.get_surface_params(sim::ClimaAtmosSimulation) =
     CAP.surface_fluxes_params(sim.integrator.p.params)
 
 """
-    Interfacer.set_cache!(sim::ClimaAtmosSimulation)
+    Interfacer.set_cache!(sim::ClimaAtmosSimulation, csf)
 
 Set cache variables that cannot be initialized before the initial exchange.
 Radiation must be called here because it requires the surface model initial
@@ -571,7 +571,7 @@ Any other callbacks which modify the cache should be called here as well.
 This function does not set all the cache variables, because many are computed
 as part of the tendendencies.
 """
-function Interfacer.set_cache!(sim::ClimaAtmosSimulation)
+function Interfacer.set_cache!(sim::ClimaAtmosSimulation, csf)
     if hasradiation(sim.integrator)
         CA.rrtmgp_model_callback!(sim.integrator)
         if pkgversion(CA) == v"0.30" &&

--- a/experiments/ClimaEarth/components/land/climaland_integrated.jl
+++ b/experiments/ClimaEarth/components/land/climaland_integrated.jl
@@ -125,8 +125,8 @@ function ClimaLandSimulation(
         atmos = CL.CoupledAtmosphere{FT}(surface_space, atmos_h),
         radiation = CL.CoupledRadiativeFluxes{FT}(
             start_date;
-            latitude = ClimaCore.Fields.coordinate_field(domain.space.surface).lat,
-            longitude = ClimaCore.Fields.coordinate_field(domain.space.surface).long,
+            latitude = CC.Fields.coordinate_field(domain.space.surface).lat,
+            longitude = CC.Fields.coordinate_field(domain.space.surface).long,
             toml_dict,
         ),
     )
@@ -547,12 +547,9 @@ function FluxCalculator.compute_surface_fluxes!(
     Y, p, t, model = sim.integrator.u, sim.integrator.p, sim.integrator.t, sim.model
 
     # We should change this to be on the boundary_space
-    land_space = axes(p.soil.turbulent_fluxes)
     coupled_atmos = sim.model.soil.boundary_conditions.top.atmos
 
     # Update the land simulation's coupled atmosphere state
-    Interfacer.get_field!(coupled_atmos.h, atmos_sim, Val(:height_int))
-
     # Use scratch space for remapped wind vector components to avoid allocations
     Interfacer.get_field!(p.scratch1, atmos_sim, Val(:u_int)) # u_atmos
     Interfacer.get_field!(p.scratch2, atmos_sim, Val(:v_int)) # v_atmos
@@ -684,7 +681,7 @@ function FluxCalculator.compute_surface_fluxes!(
 end
 
 """
-    Interfacer.set_cache!(sim::ClimaLandSimulation)
+    Interfacer.set_cache!(sim::ClimaLandSimulation, csf)
 
 Set cache variables that cannot be initialized before the initial exchange.
 This must be called after radiation, so that `p.drivers`
@@ -694,8 +691,14 @@ to the rest of the cache (e.g. in canopy radative transfer).
 This function does not set all the cache variables, because many are computed
 as part of the tendendencies.
 """
-function Interfacer.set_cache!(sim::ClimaLandSimulation)
+function Interfacer.set_cache!(sim::ClimaLandSimulation, csf)
     land_set_initial_cache! = CL.make_set_initial_cache(sim.model)
     land_set_initial_cache!(sim.integrator.p, sim.integrator.u, sim.integrator.t)
+
+    # Set the land model's coupled atmosphere height to the atmospheric height delta,
+    # which is constant over the simulation.
+    Interfacer.remap!(sim.model.soil.boundary_conditions.top.atmos.h, csf.height_delta)
+    Interfacer.remap!(sim.model.canopy.boundary_conditions.atmos.h, csf.height_delta)
+    Interfacer.remap!(sim.model.snow.boundary_conditions.atmos.h, csf.height_delta)
     return nothing
 end

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -247,19 +247,12 @@ function CoupledSimulation(config_dict::AbstractDict)
     end
 
     # Get surface elevation on the boundary space from `atmos` coordinate field
-    surface_elevation = Interfacer.get_field(atmos_sim, Val(:height_sfc), boundary_space) # on surface space
-
-    # Get atmospheric height on the boundary space
-    # Since the atmospheric height is defined on centers, we need to copy the values onto the boundary space
-    # to be able to subtract the surface elevation
-    # Note: This pattern is not reliable and should not be reused.
-    atmos_h =
-        ClimaCore.Fields.Field(
-            ClimaCore.Fields.field_values(
-                Interfacer.get_field(atmos_sim, Val(:height_int)),
-            ),
-            boundary_space,
-        ) .- surface_elevation # atmos height relative to the surface, on the surface space
+    surface_elevation = Interfacer.get_field(atmos_sim, Val(:height_sfc), boundary_space) # on boundary space
+    # Get atmospheric height relative to the surface directly from the atmosphere
+    atmos_h = Interfacer.get_atmos_height_delta(
+        Interfacer.get_field(atmos_sim, Val(:height_int)),
+        surface_elevation,
+    )
 
     #=
     ### Land-sea Fraction
@@ -558,14 +551,17 @@ function CoupledSimulation(config_dict::AbstractDict)
         The concrete steps for proper initialization are:
         =#
 
-        # 1. Import atmospheric and surface fields into the coupler fields,
+        # 1. Import static fields into the coupler fields
+        FieldExchanger.import_static_fields!(cs.fields, cs.model_sims)
+
+        # 2. Import atmospheric and surface fields into the coupler fields,
         #  then broadcast them back out to all components.
         FieldExchanger.exchange!(cs)
 
-        # 2. Update any fields in the model caches that can only be filled after the initial exchange.
+        # 3. Update any fields in the model caches that can only be filled after the initial exchange.
         FieldExchanger.set_caches!(cs)
 
-        # 3. Calculate and update turbulent fluxes for each surface model,
+        # 4. Calculate and update turbulent fluxes for each surface model,
         #  and save the weighted average in coupler fields
         FluxCalculator.turbulent_fluxes!(cs)
     end

--- a/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
@@ -79,8 +79,8 @@ end
     atmos_config = CA.AtmosConfig(atmos_config_file; job_id = "atmos_land_flux_test")
     atmos_sim = ClimaAtmosSimulation(atmos_config)
 
-    boundary_space = ClimaCore.Spaces.horizontal_space(atmos_sim.domain.face_space)
-    area_fraction = ClimaCore.Fields.ones(boundary_space)
+    boundary_space = CC.Spaces.horizontal_space(atmos_sim.domain.face_space)
+    area_fraction = CC.Fields.ones(boundary_space)
     atmos_h = CC.Fields.zeros(boundary_space) .+ 2
     land_sim =
         ClimaLandSimulation(FT; dt, tspan, start_date, output_dir, area_fraction, atmos_h)
@@ -111,6 +111,7 @@ end
 
     # Exchange the initial conditions between atmosphere and land
     # This also tests the `get_field`, `update_field!` and `update_model_sims!` methods for `ClimaLandSimulation`
+    FieldExchanger.import_static_fields!(coupler_fields, model_sims)
     FieldExchanger.exchange!(cs)
 
     # Update land cache variables with the updated drivers in the cache after the exchange

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -284,9 +284,9 @@ function compute_surface_fluxes!(
     if pkgversion(SF) ≥ v"0.14.0"
         roughness_model = Ref(SF.ScalarRoughness())
         inputs = @. SF.ValuesOnly(
-            SF.StateValues(csf.z_int, uₕ_int, thermo_state_atmos), # state_in
+            SF.StateValues(csf.height_int, uₕ_int, thermo_state_atmos), # state_in
             SF.StateValues(                                  # state_sfc
-                csf.z_sfc,
+                csf.height_sfc,
                 StaticArrays.SVector(FT(0), FT(0)),
                 thermo_state_sfc,
             ),
@@ -298,9 +298,9 @@ function compute_surface_fluxes!(
         )
     else
         inputs = @. SF.ValuesOnly(
-            SF.StateValues(csf.z_int, uₕ_int, thermo_state_atmos), # state_in
+            SF.StateValues(csf.height_int, uₕ_int, thermo_state_atmos), # state_in
             SF.StateValues(                                  # state_sfc
-                csf.z_sfc,
+                csf.height_sfc,
                 StaticArrays.SVector(FT(0), FT(0)),
                 thermo_state_sfc,
             ),

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -323,10 +323,12 @@ for FT in (Float32, Float64)
         coupler_fields = Interfacer.init_coupler_fields(FT, coupler_names, boundary_space)
 
         sims = (;
+            atmos_sim = TestAtmosSimulation((; air_temperature = ones(boundary_space),)),
             a = TestSurfaceSimulation1(ones(boundary_space)),
             b = TestSurfaceSimulation2(ones(boundary_space)),
         )
 
+        FieldExchanger.import_static_fields!(coupler_fields, sims)
         FieldExchanger.import_combined_surface_fields!(coupler_fields, sims)
 
         # Analytically compute expected values and compare


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Previously we incorrectly used `height_int` to compute integrated land fluxes. Now we use `height_int - height_z`. Since these heights don't change over the course of the simulation, I added some functions to handle exchange of static fields only at initialization. This will avoid extra remapping at each timestep.

Note `Interfacer.get_atmos_height_delta` allocates a new field, and the atmosphere heights won't change during a simulation, so it should only be called at initialization.

## Content
- [x] rename `z_int`, `z_sfc` to `height_int`, `height_z` for clarity
- [x] update the land's `coupled_atmos.h` with `height_int - height_z` instead of `height_int`
- [x] add a function `Interfacer.get_atmos_height_delta` to compute `height_int - height_z` on the boundary space
- [x] Add a function `import_static_fields!` to fill coupler fields with static component model fields, to be called only at init
- [x] In `set_cache!` for integrated land and atmosphere, also set relevant static fields (height_int, height_z, coupled_atmos.h) - again only at init to avoid extra remaps. These updates are removed from these models' `update_sim!` methods


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
