### PR TITLE
make each dt divisible by the smallest

### DIFF
--- a/config/ci_configs/cmip_oceananigans_climaseaice.yml
+++ b/config/ci_configs/cmip_oceananigans_climaseaice.yml
@@ -5,7 +5,7 @@ bucket_albedo_type: "map_temporal"
 coupler_toml: ["toml/amip.toml"]
 dt_atmos: "120secs" # 2 minutes
 dt_cpl: "1800secs" # 30 minutes
-dt_land: "450secs" # 7.5 minutes
+dt_land: "360secs" # 6 minutes
 dt_ocean: "1800secs" # 30 minutes
 dt_seaice: "1800secs" # 30 minutes
 dz_bottom: 100.0

--- a/config/ci_configs/cmip_oceananigans_prescrseaice.yml
+++ b/config/ci_configs/cmip_oceananigans_prescrseaice.yml
@@ -5,7 +5,7 @@ bucket_albedo_type: "map_temporal"
 coupler_toml: ["toml/amip.toml"]
 dt_atmos: "120secs" # 2 minutes
 dt_cpl: "1800secs" # 30 minutes
-dt_land: "450secs" # 7.5 minutes
+dt_land: "360secs" # 6 minutes
 dt_ocean: "1800secs" # 30 minutes
 dt_seaice: "1800secs" # 30 minutes
 dz_bottom: 100.0

--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -6,11 +6,11 @@ checkpoint_dt: "720hours"
 co2: "maunaloa"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "900secs" # 15 minutes
-dt_land: "450secs" # 7.5 minutes
-dt_ocean: "900secs" # 15 minutes
+dt_cpl: "960secs" # 16 minutes
+dt_land: "480secs" # 8 minutes
+dt_ocean: "960secs" # 16 minutes
 dt_rad: "1hours"
-dt_seaice: "900secs" # 15 minutes
+dt_seaice: "960secs" # 16 minutes
 energy_check: false
 insolation: "timevarying"
 mode_name: "cmip"

--- a/config/longrun_configs/cmip_edonly_land.yml
+++ b/config/longrun_configs/cmip_edonly_land.yml
@@ -5,11 +5,11 @@ checkpoint_dt: "720hours"
 co2: "maunaloa"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "900secs" # 15 minutes
-dt_land: "450secs" # 7.5 minutes
-dt_ocean: "900secs" # 15 minutes
+dt_cpl: "960secs" # 16 minutes
+dt_land: "480secs" # 8 minutes
+dt_ocean: "960secs" # 16 minutes
 dt_rad: "1hours"
-dt_seaice: "900secs" # 15 minutes
+dt_seaice: "960secs" # 16 minutes
 energy_check: false
 insolation: "timevarying"
 land_model: "integrated"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The CMIP longruns failed because the coupler dt was not divisible by the atmosphere dt ([here](https://buildkite.com/clima/climacoupler-longruns/builds/977#019ad3c7-b791-4974-ac9b-c9066e50b594)). This makes all the dts divisible by the smallest one, so they all line up at the end of a coupling step.

