### PR TITLE
use integrated land for benchmark AMIPs [skip ci]

### DIFF
--- a/.buildkite/amip/pipeline.yml
+++ b/.buildkite/amip/pipeline.yml
@@ -41,7 +41,7 @@ steps:
         key: "amip"
         command:
           - echo "--- Run simulation"
-          - "srun --cpu-bind=threads --cpus-per-task=4 julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip.yml --job_id amip"
+          - "srun --cpu-bind=threads --cpus-per-task=4 julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_land.yml --job_id amip"
         artifact_paths: "experiments/ClimaEarth/output/amip/artifacts/*"
         timeout_in_minutes: 5760
         env:

--- a/config/benchmark_configs/amip_diagedmf.yml
+++ b/config/benchmark_configs/amip_diagedmf.yml
@@ -1,10 +1,10 @@
 FLOAT_TYPE: "Float32"
 aerosol_radiation: true
 atmos_config_file: "config/benchmark_configs/climaatmos_diagedmf.yml"
-bucket_albedo_type: "map_temporal"
 dt: "120secs"
 dt_cpl: "120secs"
 energy_check: false
+land_model: "integrated"
 mode_name: "amip"
 monthly_checkpoint: false
 prescribe_ozone: true

--- a/config/benchmark_configs/amip_diagedmf_io.yml
+++ b/config/benchmark_configs/amip_diagedmf_io.yml
@@ -1,10 +1,10 @@
 FLOAT_TYPE: "Float32"
 aerosol_radiation: true
 atmos_config_file: "config/benchmark_configs/climaatmos_diagedmf_io.yml"
-bucket_albedo_type: "map_temporal"
 dt: "120secs"
 dt_cpl: "120secs"
 energy_check: false
+land_model: "integrated"
 mode_name: "amip"
 monthly_checkpoint: false
 prescribe_ozone: true


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We should be able to close O11.5 for coupler performance (see text below), since the latest [benchmark runs](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/269#_) show AMIP with diagnostic EDMF is less than 8% slower than the comparable atmos-only run, and [longruns](https://buildkite.com/clima/climacoupler-longruns/builds/977#_) show AMIP with integrated land is less than 5% slower than AMIP with the bucket.

However I'd prefer to switch the benchmark runs over to use the integrated land before we fully resolve the OKR so we can precisely quantify the difference between atmos-only vs AMIP + integrated land.

> O11.5: Identify and eliminate any remaining bottlenecks to achieve AMIP throughput (with land) within factor 1.5 of atmosphere-only model

After review, I'll merge this PR without running CI since it only changes config files that aren't run during regular CI.

See some discussion of recent improvements to coupled integrated land performance in #1525 