### PR TITLE
Up memory for GCP

### DIFF
--- a/.buildkite/gcp/pipeline.yml
+++ b/.buildkite/gcp/pipeline.yml
@@ -47,7 +47,7 @@ steps:
           slurm_gpus: 1
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
-          slurm_mem: 30GB
+          slurm_mem: 0GB
           slurm_time: "120:00:00"
       
       - label: "Current AMIP: diagedmf + 0M + integrated land"
@@ -67,5 +67,5 @@ steps:
           slurm_gpus: 1
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
-          slurm_mem: 30GB
+          slurm_mem: 0GB
           slurm_time: "120:00:00"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR fixes the failing checkpoint issue on GCP by increasing the job max memory. [Working job](https://buildkite.com/clima/climacoupler-amip-gcp/builds/102#019ae096-04f8-4a12-920b-18571e11e301)

[Previous error](https://buildkite.com/clima/climacoupler-amip-gcp/builds/100#019add71-1e8d-4afb-9ab0-7308d239a85b):
```
[ Info: Saving state to HDF5 file on day 366 second 0
[ Info: Saving checkpoint ClimaAtmosSimulation model state to HDF5 on day 366 second 0
🚨 Error: The command was interrupted by a signal: signal: killed
```

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
