### PR TITLE
Revert SF nightly test branch to main

### DIFF
--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -27,7 +27,7 @@ steps:
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaCore\", rev=\"main\"))'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaTimeSteppers\", rev=\"main\"))'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"Thermodynamics\", rev=\"main\"))'"
-      - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"SurfaceFluxes\", rev=\"4662bf\"))'"
+      - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"SurfaceFluxes\", rev=\"main\"))'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"RRTMGP\", rev=\"main\"))'"
       - "julia --project=experiments/ClimaEarth/ -e 'using Pkg; Pkg.resolve()'"
 

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -291,7 +291,7 @@ function compute_surface_fluxes!(
     beta = csf.scalar_temp4
 
     # Set some scalars that we hardcode for now
-    gustiness = FT(1)
+    gustiness = ones(boundary_space)
 
     # Construct the SurfaceFluxes.jl container of inputs
     if pkgversion(SF) ≥ v"0.14.0"


### PR DESCRIPTION
Compat entries for Atmos / Land to support SurfaceFluxes.jl > 0.14.1 have been added to the corresponding branches. Reverts the commit pin for nightly AMIP runs to use SurfaceFluxes.jl main branch.  

Gustiness is represented as a field for consistency with other scalar fields (e.g. beta) 