### PR TITLE
add prognostic EDMF benchmarks to output table

### DIFF
--- a/.buildkite/benchmarks/pipeline.yml
+++ b/.buildkite/benchmarks/pipeline.yml
@@ -40,8 +40,8 @@ steps:
           slurm_gpus_per_task: 1
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
-          slurm_mem: 16GB 
-        
+          slurm_mem: 16GB
+
       - label: "GPU AMIP with prognostic EDMF + 1M + integrated land (30 helems)"
         key: "gpu_amip_progedmf_1M_land_he30"
         command: "srun julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $BENCHMARK_CONFIG_PATH/amip_progedmf_1m_land_he30.yml --job_id gpu_amip_progedmf_1M_land_he30"
@@ -52,7 +52,7 @@ steps:
           slurm_gpus_per_task: 1
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
-          slurm_mem: 16GB 
+          slurm_mem: 16GB
 
   - group: "GPU benchmarks"
     steps:
@@ -107,19 +107,29 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 2
           slurm_mem: 16GB
- 
+
 
   - group: "Generate output table"
     steps:
       - label: "Compare AMIP/Atmos-only with diagnostic EDMF"
         key: "compare_amip_climaatmos_amip_diagedmf"
-        command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/user_io/benchmarks.jl --gpu_job_id_coupled gpu_amip_diagedmf --gpu_job_id_coupled_io gpu_amip_diagedmf_io --gpu_job_id_atmos_diagedmf gpu_climaatmos_diagedmf --gpu_job_id_atmos gpu_climaatmos --build_id $BUILDKITE_BUILD_NUMBER"
+        command: |
+          julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/user_io/benchmarks.jl \
+            --gpu_job_id_coupled gpu_amip_diagedmf \
+            --gpu_job_id_coupled_io gpu_amip_diagedmf_io \
+            --gpu_job_id_atmos_diagedmf gpu_climaatmos_diagedmf \
+            --gpu_job_id_atmos gpu_climaatmos \
+            --gpu_job_id_coupled_progedmf_coarse gpu_amip_progedmf_1M_land_he16 \
+            --gpu_job_id_coupled_progedmf_fine gpu_amip_progedmf_1M_land_he30 \
+            --build_id $BUILDKITE_BUILD_NUMBER
         artifact_paths: "experiments/ClimaEarth/output/compare_amip_climaatmos_amip_diagedmf/*"
         depends_on:
           - "gpu_climaatmos"
           - "gpu_climaatmos_diagedmf"
           - "gpu_amip_diagedmf"
           - "gpu_amip_diagedmf_io"
+          - "gpu_amip_progedmf_1M_land_he16"
+          - "gpu_amip_progedmf_1M_land_he30"
 
       - label: ":envelope: Slack report: GPU AMIP/Atmos-only table"
         depends_on:

--- a/experiments/ClimaEarth/user_io/benchmarks.jl
+++ b/experiments/ClimaEarth/user_io/benchmarks.jl
@@ -39,6 +39,14 @@ function argparse_settings()
         help = "The name of the GPU atmos-only run we want to compare."
         arg_type = String
         default = nothing
+        "--gpu_job_id_coupled_progedmf_coarse"
+        help = "The name of the coarser GPU coupled with prognostic EDMF + 1M run we want to compare."
+        arg_type = String
+        default = nothing
+        "--gpu_job_id_coupled_progedmf_fine"
+        help = "The name of the finer GPU coupled with prognostic EDMF + 1M run we want to compare."
+        arg_type = String
+        default = nothing
         "--coupler_output_dir"
         help = "Directory to save output files."
         arg_type = String
@@ -73,6 +81,12 @@ function get_run_info(parsed_args, run_type)
     elseif run_type == "atmos"
         gpu_job_id = parsed_args["gpu_job_id_atmos"]
         mode_name = "climaatmos"
+    elseif run_type == "coupled_progedmf_coarse"
+        gpu_job_id = parsed_args["gpu_job_id_coupled_progedmf_coarse"]
+        mode_name = "amip"
+    elseif run_type == "coupled_progedmf_fine"
+        gpu_job_id = parsed_args["gpu_job_id_coupled_progedmf_fine"]
+        mode_name = "amip"
     else
         error("Invalid run type: $run_type")
     end
@@ -131,8 +145,10 @@ else
 end
 
 # Read in run info for each of the cases we want to compare
-run_info_coupled = get_run_info(parsed_args, "coupled")
+run_info_coupled_progedmf_coarse = get_run_info(parsed_args, "coupled_progedmf_coarse")
+run_info_coupled_progedmf_fine = get_run_info(parsed_args, "coupled_progedmf_fine")
 run_info_coupled_io = get_run_info(parsed_args, "coupled_io")
+run_info_coupled = get_run_info(parsed_args, "coupled")
 run_info_atmos_diagedmf = get_run_info(parsed_args, "atmos_diagedmf")
 run_info_atmos = get_run_info(parsed_args, "atmos")
 
@@ -144,6 +160,16 @@ data = [
 ]
 
 # Append data to the table for each of the cases we want to compare
+data = append_table_data(
+    data,
+    "Coupled with progedmf + 1M (16 helem)",
+    run_info_coupled_progedmf_coarse...,
+)
+data = append_table_data(
+    data,
+    "Coupled with progedmf + 1M (30 helem)",
+    run_info_coupled_progedmf_fine...,
+)
 data = append_table_data(data, "Coupled with diag. EDMF + IO", run_info_coupled_io...)
 data = append_table_data(data, "Coupled with diag. EDMF", run_info_coupled...)
 data = append_table_data(data, "Atmos with diag. EDMF", run_info_atmos_diagedmf...)
@@ -155,5 +181,10 @@ mkpath(table_output_dir)
 table_path = joinpath(table_output_dir, "table.txt")
 open(table_path, "w") do f
     # Output the table, including lines before and after the header
-    PrettyTables.pretty_table(f, data, header = headers, hlines = [0, 3, 5, 7, 9, 11])
+    PrettyTables.pretty_table(
+        f,
+        data,
+        header = headers,
+        hlines = [0, 3, 5, 7, 9, 11, 13, 15],
+    )
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds the 2 new flagship AMIP runs to the benchmark table that gets sent to slack.

## Content
- [x] add 2 new rows to the benchmark table
- [x] parse the run artifact data in the table generation

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
