### PR TITLE
decrease dt for cmip longruns

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -1,6 +1,6 @@
 agents:
   queue: central
-  slurm_time: 24:00:00
+  slurm_time: 30:00:00
   modules: climacommon/2025_05_15
 
 env:
@@ -160,7 +160,6 @@ steps:
           queue: clima
           slurm_mem: 32GB
           slurm_gpus: 1
-          slurm_time: 12:00:00
 
       - label: "GPU CMIP: ClimaAtmos + Bucket + ClimaOcean + PrescribedSeaIce"
         key: "cmip_edonly_bucket"
@@ -174,7 +173,6 @@ steps:
           queue: clima
           slurm_mem: 32GB
           slurm_gpus: 1
-          slurm_time: 12:00:00
 
   - group: "Calibration experiments"
 

--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -6,11 +6,11 @@ checkpoint_dt: "720hours"
 co2: "maunaloa"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "960secs" # 16 minutes
-dt_land: "480secs" # 8 minutes
-dt_ocean: "960secs" # 16 minutes
+dt_cpl: "240secs" # 4 minutes
+dt_land: "240secs" # 4 minutes
+dt_ocean: "240secs" # 4 minutes
 dt_rad: "1hours"
-dt_seaice: "960secs" # 16 minutes
+dt_seaice: "240secs" # 4 minutes
 energy_check: false
 insolation: "timevarying"
 mode_name: "cmip"

--- a/config/longrun_configs/cmip_edonly_land.yml
+++ b/config/longrun_configs/cmip_edonly_land.yml
@@ -5,11 +5,11 @@ checkpoint_dt: "720hours"
 co2: "maunaloa"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "960secs" # 16 minutes
-dt_land: "480secs" # 8 minutes
-dt_ocean: "960secs" # 16 minutes
+dt_cpl: "240secs" # 4 minutes
+dt_land: "240secs" # 4 minutes
+dt_ocean: "240secs" # 4 minutes
 dt_rad: "1hours"
-dt_seaice: "960secs" # 16 minutes
+dt_seaice: "240secs" # 4 minutes
 energy_check: false
 insolation: "timevarying"
 land_model: "integrated"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR makes 2 changes: decreasing the component model dts for CMIP longruns, and increasing the overall slurm time limit for the longruns.

1. The most recent CMIP longruns [failed](https://buildkite.com/clima/climacoupler-longruns/builds/985#_), likely because we recently increased the dts for land, ocean, sea ice, and coupling. This PR lowers them all down to 240secs. `dt_atmos` remains at 120secs.

2. The most recent AMIP + integrated land [timed out](https://buildkite.com/clima/climacoupler-longruns/builds/985#019af7d4-3e05-4f01-8f05-c1eec68da390) during postprocessing. I increased the slurm time limit from 24 to 30 hours to avoid failures like this.

After review I'll merge this without running CI since it only changes longrun configs/pipeline