### PR TITLE
Fix formatting in docs

### DIFF
--- a/docs/src/checkpointer.md
+++ b/docs/src/checkpointer.md
@@ -9,10 +9,11 @@ Checkpoints are a mix of HDF5 and JLD2 files and are typically saved in a
 `checkpoints` folder in the simulation output. See
 [`Utilities.setup_output_dirs`](@ref) for more information.
 
-!!! known limitations
+!!! warning "Known limitations"
 
     - The number of MPI processes has to remain the same across checkpoints
-    - Restart files are generally not portable across machines, julia versions, and package versions
+    - Restart files are generally not portable across machines, julia versions, 
+      and package versions
     - Adding/changing new component models will probably require adding/changing code
 
 ### Saving checkpoints
@@ -31,7 +32,7 @@ assuming you have a `start_date`
 import Dates
 
 import ClimaCoupler: Checkpointer, TimeManager
-import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule 
+import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule
 
 schedule = EveryCalendarDtSchedule(Dates.Hour(1); start_date)
 checkpoint_callback = TimeManager.Callback(schedule_checkpoint, Checkpointer.checkpoint_sims)
@@ -94,15 +95,15 @@ saved to JLD2 files.
 serialization methods for every struct. `JLD2` allows us to take a big step
 forward, but there are still several challenges that need to be solved:
 1. `JLD2` does not support CUDA natively. To go around this, we have to move
-  everything onto the CPU first. Then, when the data is read back, we have to
-  move it back to the GPU.
+   everything onto the CPU first. Then, when the data is read back, we have to
+   move it back to the GPU.
 2. `JLD2` does not support MPI natively. To go around this, each process writes
-  its `jld2` checkpoint and reads it back. This introduces the constraint that
-  the number of MPI processes cannot change across restarts.
+   its `jld2` checkpoint and reads it back. This introduces the constraint that
+   the number of MPI processes cannot change across restarts.
 3. Some quantities are best not saved and read (for example, anything with
-  pointers). For this, we write a recursive function that traverses the cache
-  and only restores quantities of a certain type (typically, `ClimaCore`
-  objects)
+   pointers). For this, we write a recursive function that traverses the cache
+   and only restores quantities of a certain type (typically, `ClimaCore`
+   objects)
 
 Point 3. adds significant amount of code and requires component models to
 specify how their cache has to be restored.
@@ -113,7 +114,7 @@ Checkpointer.get_model_prog_state
 Checkpointer.get_model_cache
 Checkpointer.restore_cache!
 ```
-methods. 
+methods.
 
 `ClimaCoupler` moves objects to the CPU with `Adapt(Array, x)`. `Adapt`
 traverses the object recursively, and proper `Adapt` methods have to be defined

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -232,18 +232,19 @@ for the following properties:
     while all other fields will likely be on the simulation's own space.
 
 !!! note "Sea ice concentration vs. area fraction"
-Sea ice models are expected to provide both `area_fraction` and `ice_concentration`.
-This may seem redundant, but there are subtle differences between the two.
-`ice_concentration` is internal to the ice model and may be determined
-via a prognostic variable, prescribed data, etc. `area_fraction` is defined
-at the coupler level and may follow some constraints that don't apply to `ice_concentration`.
-For example, we require that surface model area fractions sum to 1 at all points;
-this constraint is enforced for `area_fraction`, but not for `ice_concentration`.
-Additionally, since `area_fraction` is a coupler-defined concept, it is defined on
-the coupler boundary space, whereas `ice_concentration` exists on the model's space.
-Generally, `ice_concentration` and `area_fraction` should largely agree,
-with differences only arising from `area_fraction` corrections and
-the fields existing on different spaces.
+    Sea ice models are expected to provide both `area_fraction` and
+    `ice_concentration`. This may seem redundant, but there are subtle
+    differences between the two. `ice_concentration` is internal to the ice
+    model and may be determined via a prognostic variable, prescribed data, etc.
+    `area_fraction` is defined at the coupler level and may follow some
+    constraints that don't apply to `ice_concentration`. For example, we require
+    that surface model area fractions sum to 1 at all points; this constraint is
+    enforced for `area_fraction`, but not for `ice_concentration`. Additionally,
+    since `area_fraction` is a coupler-defined concept, it is defined on the
+    coupler boundary space, whereas `ice_concentration` exists on the model's
+    space. Generally, `ice_concentration` and `area_fraction` should largely
+    agree, with differences only arising from `area_fraction` corrections and
+    the fields existing on different spaces.
 
 - `update_field!(::SurfaceModelSimulation, ::Val{property}, field)`:
 A function to update the value of property in the component model
@@ -291,11 +292,12 @@ coupler.
 
 ### Prescribed surface conditions - SurfaceStub
 - `SurfaceStub` is a `SurfaceModelSimulation`, but it only contains required
-data in `<surface_stub>.cache`, e.g., for the calculation of surface fluxes
-through a prescribed surface state. This model is intended to be used for testing
-or as a simple stand-in model. The above adapter functions are already
-predefined for `AbstractSurfaceStub`, which is extended by `SurfaceStub`
-in the `surface_stub.jl` file, with the cache variables specified as:
+  data in `<surface_stub>.cache`, e.g., for the calculation of surface fluxes
+  through a prescribed surface state. This model is intended to be used for
+  testing or as a simple stand-in model. The above adapter functions are already
+  predefined for `AbstractSurfaceStub`, which is extended by `SurfaceStub` in
+  the `surface_stub.jl` file, with the cache variables specified as:
+
 ```
 get_field(sim::AbstractSurfaceStub, ::Val{:area_fraction}) = sim.cache.area_fraction
 get_field(sim::AbstractSurfaceStub, ::Val{:beta}) = sim.cache.beta

--- a/src/TimeManager.jl
+++ b/src/TimeManager.jl
@@ -69,7 +69,7 @@ end
 """
     maybe_trigger_callback(callback, cs)
 
-Check if it time to call `callback`, if yes, call its function on `cs`.
+Check if it is time to call `callback`, if yes, call its function on `cs`.
 """
 function maybe_trigger_callback(callback, cs)
     t = cs.t[]


### PR DESCRIPTION
There were some documentation that was not rendered correctly, because it didn't match with what Documenter.jl was expecting.