### PR TITLE
Reduce size of atmos cache when making checkpoint

### DIFF
--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -137,22 +137,26 @@ function Checkpointer.get_model_cache(sim::ClimaAtmosSimulation)
     return sim.integrator.p
 end
 
-function Checkpointer.restore_cache!(sim::ClimaAtmosSimulation, new_cache)
+"""
+    Checkpointer.restore_cache!(sim::ClimaAtmosSimulation, cache_vec)
+
+Restore the cache in `sim` using `cache_vec` saved from
+`checkpoint_model_cache`.
+
+The atmosphere cache is saved as a vector of objects instead of being saved as
+the entire cache, as is done for the other models. This reduces the file size of
+the saved cache. See `checkpoint_model_cache` and
+`get_model_cache_to_checkpoint` for more information on how the atmosphere cache
+is saved.
+"""
+function Checkpointer.restore_cache!(sim::ClimaAtmosSimulation, cache_vec)
     comms_ctx = ClimaComms.context(sim.integrator.u.c)
-    Checkpointer.restore!(
-        Checkpointer.get_model_cache(sim),
-        new_cache,
-        comms_ctx;
-        ignore = Set([
-            :rc,
-            :params,
-            :ghost_buffer,
-            :hyperdiffusion_ghost_buffer,
-            :data_handler,
-            :graph_context,
-            :dt,
-        ]),
-    )
+    atmos_cache_itr = Checkpointer.CacheIterator(sim)
+    # This assumes that the traversals over the two atmos caches are the same
+    for (i, obj_restored) in enumerate(atmos_cache_itr)
+        obj_saved = cache_vec[i]
+        Checkpointer.restore!(obj_restored, obj_saved, comms_ctx; name = "", ignore = Set())
+    end
     return nothing
 end
 

--- a/src/Checkpointer.jl
+++ b/src/Checkpointer.jl
@@ -98,7 +98,7 @@ function checkpoint_model_cache(
     output_dir = "output",
 )
     # Move p to CPU (because we cannot save CUArrays)
-    p = CC.Adapt.adapt(Array, get_model_cache(sim))
+    p = get_model_cache_to_checkpoint(sim)
     day = floor(Int, t / (60 * 60 * 24))
     sec = floor(Int, t % (60 * 60 * 24))
     @info "Saving checkpoint $(nameof(sim)) model cache to JLD2 on day $day second $sec"
@@ -115,6 +115,63 @@ function checkpoint_model_cache(
     return nothing
 end
 
+"""
+    get_model_cache_to_checkpoint(sim::Interfacer.ComponentModelSimulation)
+
+Prepare the cache for checkpointing by moving the entire cache to CPU.
+"""
+function get_model_cache_to_checkpoint(sim::Interfacer.ComponentModelSimulation)
+    return CC.Adapt.adapt(Array, get_model_cache(sim))
+end
+
+"""
+    get_model_cache_to_checkpoint(sim::Interfacer.AtmosModelSimulation)
+
+Prepare the atmos cache for checkpoint by selectively moving parts of the atmos
+cache to CPU instead of moving the entire atmos cache to CPU, resulting in a
+much smaller saved file.
+
+# Implementation Details
+
+When moving the cache from GPU to CPU, calling `adapt` on the entire cache
+creates unnecessary duplicate objects because `adapt` is not properly defined
+for the entire cache structure. This function addresses three key issues:
+
+1. **Individual adaptation**: On GPU, `adapt` is called on each object
+   separately rather than on the entire cache at once.
+
+2. **Deduplication**: Objects sharing the same object ID are not duplicated.
+   Instead, references to already-processed objects are reused.
+
+3. **Selective saving**: Only the parts of the cache needed for restoration are
+   saved.
+
+# Returns
+A vector of objects from the cache. Elements may reference the same underlying
+data if they share object IDs. The order of the objects in the vector is
+determined by `CacheIterator`.
+"""
+function get_model_cache_to_checkpoint(sim::Interfacer.AtmosModelSimulation)
+    atmos_cache_itr = CacheIterator(sim)
+    cache_vec = [] # Elements of the vector can be any type
+    # Keep track of the object ID and its index in the vector while iterating
+    # through the fields of the cache
+    obj_id_to_idx_map = Dict{UInt64, Int}()
+    for (i, obj_saved) in enumerate(atmos_cache_itr)
+        obj_id = objectid(obj_saved)
+        if obj_id in keys(obj_id_to_idx_map)
+            # Reuse the same object if we encountered the same object ID while
+            # traversing the object
+            push!(cache_vec, cache_vec[obj_id_to_idx_map[obj_id]])
+        else
+            # Call adapt on each individual object
+            data = CC.Adapt.adapt(Array, obj_saved)
+            push!(cache_vec, data)
+            obj_id_to_idx_map[obj_id] = i
+        end
+    end
+    return cache_vec
+end
 
 """
     restore_cache!(sim::Interfacer.ComponentModelSimulation, new_cache)
@@ -466,6 +523,170 @@ function restore!(
         @warn "Time value differs in restart" field = name original = v2 new = v1
     end
     return nothing
+end
+
+# Needed for CacheIterator, because calling adapt on a StaticArray makes it into
+# an array
+function restore!(v1::StaticArrays.StaticArray, v2::Array, comms_ctx; name, ignore)
+    v1 == v2 || error("$name is a immutable but it inconsistent ($(v1) != $(v2))")
+    return nothing
+end
+
+"""
+    CacheIterator{F, G}
+
+An iterator that recursively iterate through the object's field hierarchy.
+"""
+struct CacheIterator
+    """A vector to hold the objects during depth first search of the object's
+    field hierarchy"""
+    stack::Vector
+
+    """A set of field names (as `Symbols`s) to exclude from traversal."""
+    ignore::Set{Symbol}
+end
+
+"""
+    CacheIterator(cache, ignore::Set{Symbol})
+
+A stateful iterator for recursively traversing the fields of `cache` by reverse
+preorder traversal.
+
+# Arguments
+- `cache `: The cache object to traverse.
+- `ignore`: A set of field names (as `Symbol`s) to skip during traversal.
+
+# Returns
+An iterator that yields objects that should be saved.
+
+# Notes
+- Objects returned by the iterator may reference the same memory.
+- Fields listed in `ignore` are not traversed.
+"""
+function CacheIterator(cache, ignore::Set{Symbol})
+    stack = []
+    push!(stack, cache)
+    return CacheIterator(stack, ignore)
+end
+
+"""
+    iterate(itr::CacheIterator)
+
+Advance the iterator to obtain the next field in the field hierarchy of the
+object. If no fields remain, `nothing` is returned. Otherwise, a 2-tuple of the
+next element and the new iteration state is returned.
+"""
+function Base.iterate(itr::CacheIterator)
+    stack = itr.stack
+    ignore = itr.ignore
+    while !isempty(stack)
+        obj = pop!(stack)
+        stop(obj) && continue
+        is_leaf(obj) && return (obj, nothing)
+        T = typeof(obj)
+        fields = filter(x -> !(x in ignore), fieldnames(T))
+        for p in fields
+            push!(stack, getfield(obj, p))
+        end
+    end
+    return nothing
+end
+
+# Functions needed to implement the iterator interface
+# see https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-iteration
+Base.iterate(iter::CacheIterator, _) = iterate(iter)
+Base.IteratorEltype(::CacheIterator) = Base.EltypeUnknown()
+Base.IteratorSize(::CacheIterator) = Base.SizeUnknown()
+Base.isdone(itr::CacheIterator, state...) = isempty(itr.stack)
+
+"""
+    stop(::Type)
+
+Returns `true` to stop recursing at the given object and `false` to continue
+recursing through the fields of the object.
+
+This function is used by `CacheIterator`. This is useful to stop recursing and
+not return the object.
+"""
+function stop(
+    ::Union{
+        AbstractTimeVaryingInput,
+        ClimaComms.AbstractCommsContext,
+        ClimaComms.AbstractDevice,
+        UnionAll,
+        DataType,
+    },
+)
+    return true # Stop recursing here
+end
+
+# Catch all for everything else
+stop(obj) = false
+
+"""
+    is_leaf(::Type)
+
+Returns `true` if the object should be saved and `false` otherwise.
+
+This function is used by `CacheIterator`.
+"""
+is_leaf(::Union{CC.DataLayouts.AbstractData, AbstractArray}) = true # Needed for saving data
+
+# Needed for error handling
+is_leaf(
+    ::Union{
+        StaticArrays.StaticArray,
+        Number,
+        UnitRange,
+        LinRange,
+        Symbol,
+        Dict,
+        Dates.DateTime,
+        Dates.UTInstant,
+        Dates.Millisecond,
+    },
+) = true
+
+# Catch all for everything else
+is_leaf(::Any) = false
+
+"""
+    CacheIterator(sim::Interfacer.ComponentModelSimulation)
+
+Create an iterator over the cache in `sim` of objects that should be
+saved.
+
+To use this constructor, the function `get_cache_ignore` must be implemented
+for `sim` which takes in `sim` and returns a set of symbols to ignore while
+iterating through the fields of the cache.
+"""
+function CacheIterator(sim::Interfacer.ComponentModelSimulation)
+    cache = get_model_cache(sim)
+    return CacheIterator(cache, get_cache_ignore(sim))
+end
+
+"""
+    get_cache_ignore(::Interfacer.AtmosModelSimulation)
+
+Return a set of symbols that should be ignored when iterating the fields of the
+atmos cache. These fields will not be saved when checkpointing.
+"""
+function get_cache_ignore(::Interfacer.AtmosModelSimulation)
+    return Set([
+        :rc,
+        :params,
+        :ghost_buffer,
+        :hyperdiffusion_ghost_buffer,
+        :data_handler,
+        :graph_context,
+        :dt,
+    ])
+end
+
+function get_cache_ignore(::Interfacer.ComponentModelSimulation)
+    return error("List of symbols to ignore when iterating the fields of the
+    cache is not supported for this model. Checkpoint by saving the entire
+    cache instead or define get_cache_ignore to use CacheIterator.")
 end
 
 end # module

--- a/test/checkpointer_tests.jl
+++ b/test/checkpointer_tests.jl
@@ -184,3 +184,46 @@ end
     @test v1.b != v2.b # Int doesn't get restored
     @test v1.c == v2.c
 end
+
+@testset "Field iterator" begin
+    struct A
+        B::Any
+        C::Any
+        D::Any
+        ignore_this::Any
+    end
+    cache = A(A([4], [3], [2], [42]), [1], [0], [42])
+    itr = Checkpointer.FieldIterator(cache, ignore = Set([:ignore_this]))
+    @test !isempty(itr)
+    cache_vec = collect(itr)
+    @test cache_vec == [[0], [1], [2], [3], [4]]
+    @test isempty(itr)
+end
+
+@testset "Atmos cache iterator" begin
+    struct IgnoreFields
+        rc::Any
+        params::Any
+        ghost_buffer::Any
+        hyperdiffusion_ghost_buffer::Any
+        data_handler::Any
+        graph_context::Any
+        dt::Any
+    end
+
+    ignore_cache = IgnoreFields([1], [1], [1], [1], [1], [1], [1])
+    itr = Checkpointer.CacheIterator(
+        cache,
+        ignore = Set([
+            :rc,
+            :params,
+            :ghost_buffer,
+            :hyperdiffusion_ghost_buffer,
+            :data_handler,
+            :graph_context,
+            :dt,
+        ]),
+    )
+    cache_vec = collect(itr)
+    @test isempty(cache_vec)
+end


### PR DESCRIPTION
This PR enables compression, save only parts of the cache, and does not do any unnecessary memory copies to reduce the cache size from `57G` to `1.1G`.

Before this change, the size of the atmos cache from the AMIP simulation is `57G`. With this change and no compression, the size of the atmos cache is now `4.6G`. Then, with compression, the size of the atmos cache is `1.1G`. For compressing the data, it does not seems to take too long, but I am not sure about the decompression.

TODO
- [x] Add tests for iterating over the fields of a struct
