### PR TITLE
Remove env update from benchmark pipeline

### DIFF
--- a/.buildkite/benchmarks/pipeline.yml
+++ b/.buildkite/benchmarks/pipeline.yml
@@ -16,7 +16,6 @@ steps:
     command:
       - echo "--- Instantiate experiments/ClimaEarth"
       - julia --project=experiments/ClimaEarth -e 'using Pkg; Pkg.instantiate(;verbose=true)'
-      - julia --project=experiments/ClimaEarth -e 'using Pkg; Pkg.add("MPI"); Pkg.add("CUDA")'
       - julia --project=experiments/ClimaEarth -e 'using Pkg; Pkg.precompile()'
       - julia --project=experiments/ClimaEarth -e 'using Pkg; Pkg.status()'
     agents:


### PR DESCRIPTION
There was a command in the env init step that
added CUDA and MPI to the project. It is already in the project/manifest, and adding either package explicitly can cause unexpected and un-noticed downgrades of packages we care more about (ClimaAtmos, SurfaceFluxes, ClimaLand,...)

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
I noticed that the benchmark buildkite pipeline unexpectedly downgraded ClimaAtmos in the last scheduled run [here](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/290#019b1b3b-e32e-42cb-9d36-974f3da716ec/180-1502)


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
- Remove explicit adding of CUDA.jl and MPI.jl

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
