### PR TITLE
Update to handle atmos release refactoring trace gases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 ArgParse = "1"
-ClimaAtmos = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32"
+ClimaAtmos = "0.33"
 ClimaComms = "0.6.2"
 ClimaCore = "0.14.25"
 ClimaDiagnostics = "0.2.6"

--- a/config/atmos_configs/climaatmos_diagedmf.yml
+++ b/config/atmos_configs/climaatmos_diagedmf.yml
@@ -2,7 +2,7 @@
 aerosol_radiation: true
 approximate_linear_solve_iters: 2
 cloud_model: "quadrature"
-co2_model: maunaloa
+time_varying_trace_gases: ["CO2", "O3"]
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
@@ -20,7 +20,6 @@ insolation: "timevarying"
 moist: "equil"
 netcdf_output_at_levels: true
 precip_model: "0M"
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 prognostic_tke: true
 rad: "allskywithclear"

--- a/config/atmos_configs/climaatmos_edonly.yml
+++ b/config/atmos_configs/climaatmos_edonly.yml
@@ -1,7 +1,6 @@
 # This inherits from config/common_configs/numerics_sphere_he16ze63.yml and config/longrun_configs/amip_target_edonly.yml in ClimaAtmos.jl
 aerosol_radiation: true
 approximate_linear_solve_iters: 2
-co2_model: maunaloa
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
@@ -14,12 +13,12 @@ insolation: "timevarying"
 moist: "equil"
 netcdf_output_at_levels: true
 precip_model: "0M"
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 rad: "allskywithclear"
 rayleigh_sponge: true
 surface_setup: "DefaultMoninObukhov"
 t_end: "120days"
+time_varying_trace_gases: ["CO2", "O3"]
 toml: [toml/longrun_aquaplanet.toml]
 turbconv: "edonly_edmfx"
 viscous_sponge: true

--- a/config/atmos_configs/climaatmos_progedmf.yml
+++ b/config/atmos_configs/climaatmos_progedmf.yml
@@ -1,7 +1,6 @@
 aerosol_radiation: true
 approximate_linear_solve_iters: 2
 cloud_model: "quadrature"
-co2_model: maunaloa
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
@@ -27,13 +26,13 @@ max_newton_iters_ode: 3
 moist: "equil"
 netcdf_output_at_levels: true
 precip_model: "0M"
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 prognostic_tke: true
 rad: "allskywithclear"
 rayleigh_sponge: true
 surface_setup: "DefaultMoninObukhov"
 t_end: "120days"
+time_varying_trace_gases: ["CO2", "O3"]
 toml: [toml/longrun_aquaplanet_diagedmf.toml]
 turbconv: "prognostic_edmfx"
 viscous_sponge: true

--- a/config/atmos_configs/climaatmos_progedmf_1m.yml
+++ b/config/atmos_configs/climaatmos_progedmf_1m.yml
@@ -1,7 +1,6 @@
 aerosol_radiation: true
 approximate_linear_solve_iters: 2
 cloud_model: "quadrature"
-co2_model: maunaloa
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
@@ -27,13 +26,13 @@ max_newton_iters_ode: 3
 moist: "nonequil"
 netcdf_output_at_levels: true
 precip_model: "1M"
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 prognostic_tke: true
 rad: "allskywithclear"
 rayleigh_sponge: true
 surface_setup: "DefaultMoninObukhov"
 t_end: "120days"
+time_varying_trace_gases: ["CO2", "O3"]
 toml: [toml/longrun_aquaplanet_diagedmf.toml]
 turbconv: "prognostic_edmfx"
 viscous_sponge: true

--- a/config/atmos_configs/climaatmos_wx_diagedmf.yml
+++ b/config/atmos_configs/climaatmos_wx_diagedmf.yml
@@ -15,8 +15,7 @@ insolation: "timevarying"
 rad: allskywithclear
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
-co2_model: fixed
-# prescribe_ozone: true
+# time_varying_trace_gases: ["O3"]
 # prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 turbconv: diagnostic_edmfx
 implicit_diffusion: true

--- a/config/atmos_configs/climaatmos_wx_progedmf.yml
+++ b/config/atmos_configs/climaatmos_wx_progedmf.yml
@@ -15,8 +15,7 @@ insolation: "timevarying"
 rad: allskywithclear
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
-co2_model: fixed
-# prescribe_ozone: true
+# time_varying_trace_gases: ["O3"]
 # prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true

--- a/config/benchmark_configs/amip_diagedmf.yml
+++ b/config/benchmark_configs/amip_diagedmf.yml
@@ -7,7 +7,6 @@ energy_check: false
 land_model: "integrated"
 mode_name: "amip"
 monthly_checkpoint: false
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 start_date: "20100101"
 surface_setup: "PrescribedSurface"

--- a/config/benchmark_configs/amip_diagedmf_io.yml
+++ b/config/benchmark_configs/amip_diagedmf_io.yml
@@ -7,7 +7,6 @@ energy_check: false
 land_model: "integrated"
 mode_name: "amip"
 monthly_checkpoint: false
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 start_date: "20100101"
 surface_setup: "PrescribedSurface"

--- a/config/benchmark_configs/climaatmos.yml
+++ b/config/benchmark_configs/climaatmos.yml
@@ -1,7 +1,6 @@
 FLOAT_TYPE: "Float32"
 aerosol_radiation: true
 approximate_linear_solve_iters: 2
-co2_model: "maunaloa"
 dt: 120secs
 dt_cloud_fraction: 1hours
 dt_rad: 1hours
@@ -13,11 +12,11 @@ insolation: "timevarying"
 moist: equil
 output_default_diagnostics: false
 precip_model: 0M
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 rad: allskywithclear
 surface_setup: DefaultMoninObukhov
 t_end: 12hours
+time_varying_trace_gases: ["CO2", "O3"]
 vert_diff: "DecayWithHeightDiffusion"
 z_elem: 63
 z_max: 55000.0

--- a/config/benchmark_configs/climaatmos_diagedmf.yml
+++ b/config/benchmark_configs/climaatmos_diagedmf.yml
@@ -1,7 +1,6 @@
 FLOAT_TYPE: "Float32"
 aerosol_radiation: true
 approximate_linear_solve_iters: 2
-co2_model: "maunaloa"
 dt: 120secs
 dt_cloud_fraction: 1hours
 dt_rad: 1hours
@@ -20,12 +19,12 @@ moist: equil
 ode_algo: ARS343
 output_default_diagnostics: false
 precip_model: 0M
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 prognostic_tke: true
 rad: allskywithclear
 surface_setup: DefaultMoninObukhov
 t_end: 12hours
+time_varying_trace_gases: ["CO2", "O3"]
 toml: [toml/amip.toml]
 turbconv: diagnostic_edmfx
 z_elem: 63

--- a/config/benchmark_configs/climaatmos_diagedmf_io.yml
+++ b/config/benchmark_configs/climaatmos_diagedmf_io.yml
@@ -2,7 +2,6 @@
 FLOAT_TYPE: "Float32"
 aerosol_radiation: true
 approximate_linear_solve_iters: 2
-co2_model: "maunaloa"
 dt: 120secs
 dt_cloud_fraction: 1hours
 dt_rad: 1hours
@@ -21,12 +20,12 @@ moist: equil
 ode_algo: ARS343
 output_default_diagnostics: false
 precip_model: 0M
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 prognostic_tke: true
 rad: allskywithclear
 surface_setup: DefaultMoninObukhov
 t_end: 12hours
+time_varying_trace_gases: ["CO2", "O3"]
 toml: [toml/amip.toml]
 turbconv: diagnostic_edmfx
 z_elem: 63

--- a/config/ci_configs/amip_albedo_temporal_map.yml
+++ b/config/ci_configs/amip_albedo_temporal_map.yml
@@ -1,6 +1,5 @@
 apply_limiter: false
 bucket_albedo_type: "map_temporal"
-co2_model: "maunaloa"
 dt: "150secs"
 dt_cpl: "150secs"
 dt_rad: "1hours"
@@ -13,6 +12,7 @@ rad: "gray"
 rayleigh_sponge: true
 start_date: "20100101"
 t_end: "300secs"
+time_varying_trace_gases: ["CO2"]
 vert_diff: "true"
 z_elem: 50
 z_stretch: false

--- a/config/ci_configs/amip_albedo_temporal_map_1M.yml
+++ b/config/ci_configs/amip_albedo_temporal_map_1M.yml
@@ -1,6 +1,5 @@
 apply_limiter: false
 bucket_albedo_type: "map_temporal"
-co2_model: "maunaloa"
 dt: "150secs"
 dt_cpl: "150secs"
 dt_rad: "1hours"
@@ -13,6 +12,7 @@ rad: "gray"
 rayleigh_sponge: true
 start_date: "20100101"
 t_end: "300secs"
+time_varying_trace_gases: ["CO2"]
 vert_diff: "true"
 z_elem: 50
 z_stretch: false

--- a/config/ci_configs/amip_coarse_ft64_hourly_checkpoints.yml
+++ b/config/ci_configs/amip_coarse_ft64_hourly_checkpoints.yml
@@ -1,5 +1,4 @@
 apply_limiter: false
-co2_model: "maunaloa"
 energy_check: false
 h_elem: 6
 mode_name: "amip"
@@ -7,4 +6,5 @@ moist: "equil"
 precip_model: "0M"
 rad: "allskywithclear"
 t_end: "1days"
+time_varying_trace_gases: ["CO2"]
 vert_diff: "true"

--- a/config/ci_configs/amip_coarse_ft64_hourly_checkpoints_restart.yml
+++ b/config/ci_configs/amip_coarse_ft64_hourly_checkpoints_restart.yml
@@ -1,6 +1,5 @@
 apply_limiter: false
 checkpoint_dt: "400secs"
-co2_model: "maunaloa"
 detect_restart_files: true
 energy_check: false
 h_elem: 6
@@ -9,4 +8,5 @@ moist: "equil"
 precip_model: "0M"
 rad: "allskywithclear"
 t_end: "800secs"
+time_varying_trace_gases: ["CO2"]
 vert_diff: "true"

--- a/config/ci_configs/amip_coarse_mpi.yml
+++ b/config/ci_configs/amip_coarse_mpi.yml
@@ -1,5 +1,4 @@
 apply_limiter: false
-co2_model: "maunaloa"
 energy_check: false
 h_elem: 4
 mode_name: "amip"
@@ -8,4 +7,5 @@ precip_model: "0M"
 rad: "allskywithclear"
 share_surface_space: false
 t_end: "1days"
+time_varying_trace_gases: ["CO2"]
 vert_diff: "true"

--- a/config/ci_configs/amip_component_dts.yml
+++ b/config/ci_configs/amip_component_dts.yml
@@ -1,5 +1,4 @@
 apply_limiter: false
-co2_model: "maunaloa"
 dt_atmos: "150secs"
 dt_cpl: "150secs"
 dt_land: "50secs"
@@ -15,6 +14,7 @@ precip_model: "0M"
 rad: "gray"
 rayleigh_sponge: true
 t_end: "600secs"
+time_varying_trace_gases: ["CO2"]
 vert_diff: "true"
 z_elem: 50
 z_stretch: false

--- a/config/ci_configs/amip_default.yml
+++ b/config/ci_configs/amip_default.yml
@@ -1,5 +1,4 @@
 apply_limiter: false
-co2_model: "maunaloa"
 dt: "150secs"
 dt_cpl: "150secs"
 dt_rad: "1hours"
@@ -11,6 +10,7 @@ precip_model: "0M"
 rad: "gray"
 rayleigh_sponge: true
 t_end: "300secs"
+time_varying_trace_gases: ["CO2"]
 use_itime: true
 vert_diff: "true"
 z_elem: 50

--- a/config/ci_configs/amip_diagedmf_bucket.yml
+++ b/config/ci_configs/amip_diagedmf_bucket.yml
@@ -2,7 +2,6 @@ FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_diagedmf.yml"
 bucket_albedo_type: "map_temporal"
-co2: "maunaloa"
 coupler_toml: ["toml/amip.toml"]
 dt: "120secs"
 dt_cpl: "120secs"

--- a/config/ci_configs/amip_diagedmf_integrated_land.yml
+++ b/config/ci_configs/amip_diagedmf_integrated_land.yml
@@ -1,7 +1,6 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_diagedmf.yml"
-co2: "maunaloa"
 coupler_toml: ["toml/amip.toml"]
 dt: "120secs"
 dt_cpl: "120secs"

--- a/config/ci_configs/amip_land_ic.yml
+++ b/config/ci_configs/amip_land_ic.yml
@@ -1,5 +1,4 @@
 apply_limiter: false
-co2_model: "maunaloa"
 dt: "150secs"
 dt_cpl: "150secs"
 dt_rad: "1hours"
@@ -13,6 +12,7 @@ precip_model: "0M"
 rad: "allskywithclear"
 rayleigh_sponge: true
 t_end: "300secs"
+time_varying_trace_gases: ["CO2"]
 vert_diff: "true"
 z_elem: 50
 z_stretch: false

--- a/config/ci_configs/amip_n1_shortrun.yml
+++ b/config/ci_configs/amip_n1_shortrun.yml
@@ -1,5 +1,4 @@
 apply_limiter: false
-co2_model: "maunaloa"
 dt: "150secs"
 dt_cpl: "150secs"
 dt_rad: "1hours"
@@ -12,6 +11,7 @@ precip_model: "0M"
 rad: "gray"
 rayleigh_sponge: true
 t_end: "300secs"
+time_varying_trace_gases: ["CO2"]
 vert_diff: "true"
 z_elem: 50
 z_stretch: false

--- a/config/ci_configs/amip_progedmf_bucket.yml
+++ b/config/ci_configs/amip_progedmf_bucket.yml
@@ -2,7 +2,6 @@ FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_progedmf.yml"
 bucket_albedo_type: "map_temporal"
-co2: "maunaloa"
 coupler_toml: ["toml/amip_progedmf.toml"]
 dt: "30secs"
 dt_cpl: "30secs"

--- a/config/longrun_configs/amip_diagedmf.yml
+++ b/config/longrun_configs/amip_diagedmf.yml
@@ -14,7 +14,6 @@ insolation: "timevarying"
 mode_name: "amip"
 netcdf_output_at_levels: true
 output_default_diagnostics: true
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 rmse_check: true
 start_date: "20100101"

--- a/config/longrun_configs/amip_diagedmf_integrated_land.yml
+++ b/config/longrun_configs/amip_diagedmf_integrated_land.yml
@@ -14,7 +14,6 @@ land_model: "integrated"
 mode_name: "amip"
 netcdf_output_at_levels: true
 output_default_diagnostics: true
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 rmse_check: true
 start_date: "20100101"

--- a/config/longrun_configs/amip_edonly.yml
+++ b/config/longrun_configs/amip_edonly.yml
@@ -4,7 +4,6 @@ albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 bucket_albedo_type: "map_temporal"
 checkpoint_dt: "93days"
-co2_model: "maunaloa"
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_cpl: "120secs"
@@ -13,7 +12,6 @@ energy_check: false
 insolation: "timevarying"
 mode_name: "amip"
 netcdf_interpolate_z_over_msl: true
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 rmse_check: true
 start_date: "20100101"

--- a/config/longrun_configs/amip_edonly_1M.yml
+++ b/config/longrun_configs/amip_edonly_1M.yml
@@ -3,7 +3,6 @@ aerosol_radiation: true
 atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 bucket_albedo_type: "map_temporal"
 checkpoint_dt: "31days"
-co2_model: "maunaloa"
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_cpl: "120secs"
@@ -13,7 +12,6 @@ insolation: "timevarying"
 mode_name: "amip"
 moist: "nonequil"
 precip_model: "1M"
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 rmse_check: true
 start_date: "20100101"

--- a/config/longrun_configs/amip_edonly_integrated_land.yml
+++ b/config/longrun_configs/amip_edonly_integrated_land.yml
@@ -3,7 +3,6 @@ aerosol_radiation: true
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 checkpoint_dt: "31days"
-co2_model: "maunaloa"
 dt: "120secs"
 dt_cloud_fraction: "1hours"
 dt_cpl: "120secs"
@@ -13,7 +12,6 @@ insolation: "timevarying"
 land_model: "integrated"
 mode_name: "amip"
 netcdf_interpolate_z_over_msl: true
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 rmse_check: true
 start_date: "20100101"

--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -3,7 +3,6 @@ aerosol_radiation: true
 atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 bucket_albedo_type: "map_temporal"
 checkpoint_dt: "720hours"
-co2: "maunaloa"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
 dt_cpl: "120secs" # 2 minutes
@@ -14,7 +13,6 @@ dt_seaice: "120secs" # 2 minutes
 energy_check: false
 insolation: "timevarying"
 mode_name: "cmip"
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 rmse_check: true
 start_date: "20100101"

--- a/config/longrun_configs/cmip_edonly_land.yml
+++ b/config/longrun_configs/cmip_edonly_land.yml
@@ -2,7 +2,6 @@ FLOAT_TYPE: "Float32"
 aerosol_radiation: true
 atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 checkpoint_dt: "720hours"
-co2: "maunaloa"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
 dt_cpl: "120secs" # 2 minutes
@@ -14,7 +13,6 @@ energy_check: false
 insolation: "timevarying"
 land_model: "integrated"
 mode_name: "cmip"
-prescribe_ozone: true
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 rmse_check: true
 start_date: "20100101"

--- a/config/subseasonal_configs/wxquest_diagedmf.yml
+++ b/config/subseasonal_configs/wxquest_diagedmf.yml
@@ -6,7 +6,6 @@ mode_name: "subseasonal"
 era5_initial_condition_dir: "/net/sampo/data1/wxquest_data/initial_conditions"
 initial_condition: "WeatherModel"
 checkpoint_dt: "7days"
-co2_model: "fixed"
 dt: "30secs"
 dt_cpl: "30secs"
 energy_check: false

--- a/config/subseasonal_configs/wxquest_progedmf.yml
+++ b/config/subseasonal_configs/wxquest_progedmf.yml
@@ -6,7 +6,6 @@ mode_name: "subseasonal"
 era5_initial_condition_dir: "/net/sampo/data1/wxquest_data/initial_conditions"
 initial_condition: "WeatherModel"
 checkpoint_dt: "7days"
-co2_model: "fixed"
 dt: "10secs"
 dt_cpl: "10secs"
 energy_check: false

--- a/experiments/ClimaEarth/Manifest-v1.11.toml
+++ b/experiments/ClimaEarth/Manifest-v1.11.toml
@@ -415,9 +415,9 @@ weakdeps = ["GeoMakie", "Makie"]
 
 [[deps.ClimaAtmos]]
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "ForwardDiff", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SciMLBase", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
-git-tree-sha1 = "528398fe7a4c5e067eea4f5ac3925d1c491d0ab7"
+git-tree-sha1 = "336439045af7c9e1a5f7fc925261dbf909e3ed21"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.32.0"
+version = "0.33.0"
 
 [[deps.ClimaCalibrate]]
 deps = ["Dates", "Distributed", "Distributions", "EnsembleKalmanProcesses", "JLD2", "Logging", "Random", "TOML", "YAML"]

--- a/experiments/ClimaEarth/Manifest.toml
+++ b/experiments/ClimaEarth/Manifest.toml
@@ -412,9 +412,9 @@ weakdeps = ["GeoMakie", "Makie"]
 
 [[deps.ClimaAtmos]]
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "ForwardDiff", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SciMLBase", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
-git-tree-sha1 = "528398fe7a4c5e067eea4f5ac3925d1c491d0ab7"
+git-tree-sha1 = "336439045af7c9e1a5f7fc925261dbf909e3ed21"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.32.0"
+version = "0.33.0"
 
 [[deps.ClimaCalibrate]]
 deps = ["Dates", "Distributed", "Distributions", "EnsembleKalmanProcesses", "JLD2", "Logging", "Random", "TOML", "YAML"]

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -268,13 +268,11 @@ Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:air_density}) =
         sim.integrator.p.params.thermodynamics_params,
         CC.Fields.level(sim.integrator.p.precomputed.ᶜts, 1),
     )
-# When using the `FixedCO2` option, CO2 is stored as that struct type,
-# so we access its value (a scalar) from the struct.
-# When using the `MaunaLoa` option, CO2 is stored as a 1D Array in the tracers
-# cache, so we access it from there.
+# When CO2 is stored as a 1D Array in the tracers cache, we access
+# it from there. Otherwise, we pull a fixed value from ClimaParams.
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:co2}) =
-    sim.integrator.p.atmos.co2 isa CA.FixedCO2 ? sim.integrator.p.atmos.co2.value :
-    sim.integrator.p.tracers.co2[1]
+    :co2 in propertynames(sim.integrator.p.tracers) ? sim.integrator.p.tracers.co2[1] :
+    CAP.trace_gas_params(sim.integrator.p.params).CO2_fixed_value
 
 function Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:diffuse_fraction})
     # Diffuse fraction doesn't matter when we don't have radiation, so return zero

--- a/experiments/ClimaEarth/test/component_model_tests/climaatmos_coarse_short.yml
+++ b/experiments/ClimaEarth/test/component_model_tests/climaatmos_coarse_short.yml
@@ -1,7 +1,6 @@
 FLOAT_TYPE: "Float32"
 aerosol_radiation: true
 approximate_linear_solve_iters: 2
-co2_model: "maunaloa"
 dt: 120secs
 dt_cloud_fraction: 1hours
 dt_rad: 1hours
@@ -14,10 +13,10 @@ moist: equil
 output_default_diagnostics: false
 precip_model: 0M
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
-prescribe_ozone: true
 rad: allskywithclear
 surface_setup: DefaultMoninObukhov
 t_end: 240secs
+time_varying_trace_gases: ["CO2", "O3"]
 vert_diff: "DecayWithHeightDiffusion"
 z_elem: 39
 z_max: 55000.0


### PR DESCRIPTION
PR to update the change in ClimaAtmos for handling trace gases. In the past we used co2_model and prescribe_ozone arguments, now we use time_varying_trace_gases (see info in ClimaAtmos NEWS). I believe this makes ClimaCoupler no longer back compatible with ClimaAtmos versions previous to 0.33.0 so I've deleted that -- please let me know if that should be changed. v 0.33.0 has not been released yet so I don't expect this to pass tests until that has occurred.