### PR TITLE
Add MPI to env during benchmark pipeline init step

### DIFF
--- a/.buildkite/benchmarks/pipeline.yml
+++ b/.buildkite/benchmarks/pipeline.yml
@@ -16,6 +16,7 @@ steps:
     command:
       - echo "--- Instantiate experiments/ClimaEarth"
       - julia --project=experiments/ClimaEarth -e 'using Pkg; Pkg.instantiate(;verbose=true)'
+      - julia --project=experiments/ClimaEarth -e 'using Pkg; Pkg.add("MPI");'
       - julia --project=experiments/ClimaEarth -e 'using Pkg; Pkg.precompile()'
       - julia --project=experiments/ClimaEarth -e 'using Pkg; Pkg.status()'
     agents:


### PR DESCRIPTION
Commit f7595753c6a2ee3d1f99a5204fc837d5d7530584 removed the step that adds CUDA and MPI to the benchmark env. The MPI add step is needed because it is not a direct dependency. If the ClimaAtmos compat does not have the latest downstream package versions as the lower bound for their compats, then this step may downgrade those packages.

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
