### PR TITLE
Add support for breaking ClimaLand change

### DIFF
--- a/experiments/ClimaEarth/components/land/climaland_integrated.jl
+++ b/experiments/ClimaEarth/components/land/climaland_integrated.jl
@@ -140,8 +140,18 @@ function ClimaLandSimulation(
         stop_date;
         time_interpolation_method = LinearInterpolation(),
     )
-
-    model = CL.LandModel{FT}(forcing, LAI, toml_dict, domain, dt)
+    if pkgversion(CL) <= v"1.2.1" # remove this conditional when ClimaLand compat is updated
+        model = CL.LandModel{FT}(forcing, LAI, toml_dict, domain, dt)
+    else
+        model = CL.LandModel{FT}(
+            forcing,
+            LAI,
+            toml_dict,
+            domain,
+            dt;
+            prognostic_land_components = (:canopy, :snow, :soil, :soilco2),
+        )
+    end
 
     Y, p, coords = CL.initialize(model)
 


### PR DESCRIPTION
PR [1580](https://github.com/CliMA/ClimaLand.jl/pull/1580) changes the LandModel constructor to not include a soilco2 model by default.

I'm not sure if this is better than waiting for the next ClimaLand release and bumping the compat.
----
- [x] I have read and checked the items on the review checklist.
