### PR TITLE
Fix ambigous variable in benchmark table

### DIFF
--- a/experiments/ClimaEarth/user_io/benchmarks.jl
+++ b/experiments/ClimaEarth/user_io/benchmarks.jl
@@ -51,7 +51,7 @@ run_names = [
 # For each run, get the run info and append it to the table
 for (run_name, description) in run_names
     run_info = SimOutput.get_run_info(parsed_args, run_name)
-    data = SimOutput.append_table_data(data, description, run_info...)
+    global data = SimOutput.append_table_data(data, description, run_info...)
 end
 
 # Output table to file, note that this must match the slack upload command in the pipeline.yml file


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Fixes [failure](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/293#019b8761-735f-471a-b9e2-84221037a870/L173) in benchmark


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
- use the `global` keyword with the ambiguous var 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
