### PR TITLE
don't use spun-up land ICs in CMIP

### DIFF
--- a/config/ci_configs/cmip_oceananigans_climaseaice.yml
+++ b/config/ci_configs/cmip_oceananigans_climaseaice.yml
@@ -12,6 +12,7 @@ energy_check: false
 h_elem: 8
 ice_model: "clima_seaice"
 land_model: "integrated"
+land_spun_up_ic: false
 mode_name: "cmip"
 netcdf_output_at_levels: true
 output_default_diagnostics: true

--- a/config/ci_configs/cmip_oceananigans_prescrseaice.yml
+++ b/config/ci_configs/cmip_oceananigans_prescrseaice.yml
@@ -11,6 +11,7 @@ dz_bottom: 100.0
 energy_check: false
 h_elem: 8
 land_model: "integrated"
+land_spun_up_ic: false
 mode_name: "cmip"
 netcdf_output_at_levels: true
 output_default_diagnostics: true

--- a/config/longrun_configs/cmip_edonly_land.yml
+++ b/config/longrun_configs/cmip_edonly_land.yml
@@ -12,6 +12,7 @@ dt_seaice: "120secs" # 2 minutes
 energy_check: false
 insolation: "timevarying"
 land_model: "integrated"
+land_spun_up_ic: false
 mode_name: "cmip"
 prescribed_aerosols: ["CB1", "CB2", "DST01", "OC1", "OC2", "SO4", "SSLT01"]
 rmse_check: true

--- a/experiments/ClimaEarth/README.md
+++ b/experiments/ClimaEarth/README.md
@@ -19,6 +19,15 @@ It runs a [ClimaAtmos.jl](https://github.com/CliMA/ClimaAtmos.jl) atmosphere mod
 and either [ClimaSeaIce.jl](https://github.com/CliMA/ClimaSeaIce.jl) or a simple thermal sea ice model.
 Please find more details about each model below.
 
+!!! note Behavior at the poles with an ocean model on a capped latitude/longitude grid
+    The Oceananigans and ClimaSeaIce models currently run on a capped
+    latitude-longitude grid, which spans from 80°S to 80°N. To avoid having a gap
+    in surface models at the poles, we fill the poles with the selected land model
+    when running with the Oceananigans model. As a result, the land model cannot be
+    started from saved initial conditions when run in this configuration.
+    This will change in the near future when we switch to use a tripolar grid
+    for the Oceananigans and ClimaSeaIce models.
+
 ### Atmosphere
 Dynamical core:
 - Equation: non-hydrostatic and fully compressible


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In CMIP runs we put the land model at the poles because the ocean and sea ice run on capped latitude/longitude which only spans from 80°S to 80°N. As a result, we can't use previously-saved initial conditions for the land model in this setup, because they don't have reasonable values where the land wasn't run.

This PR switches all CMIP runs to use analytical ICs for the land instead, and documents this behavior.

With this change: [CMIP longrun](https://buildkite.com/clima/climacoupler-longruns/builds/1030) with integrated land fails at 14 weeks (same as bucket)
Without this change: [CMIP longrun](https://buildkite.com/clima/climacoupler-longruns/builds/1020) with integrated land fails at ~1 day

## To-do
- [x] update CMIP configs to not use spun up land ICs
- [x] update ClimaEarth readme to explain this behavior


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
