### PR TITLE
Make binary area treatment optional and support era5 land fraction

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -24,3 +24,17 @@ git-tree-sha1 = "53a27731c0a2ec60756af24e4c60ac37da4a32bc"
     [[cmip_model_rmse.download]]
     sha256 = "3e8fa41df226dda9d375f8cb9dbeee3e10f9fceabcad2c7b91c9633b489b0437"
     url = "https://caltech.box.com/shared/static/lmzvnjkxctlb0fanieeqxll0vdrbei9e.gz"
+
+[landsea_mask_60arcseconds]
+git-tree-sha1 = "10ed7ec61def091c44545825cfb4d9599216c3c8"
+
+    [[landsea_mask_60arcseconds.download]]
+    sha256 = "eb88455a39a00bfadb77effbc31a4df561158c0ca1578476edb683d45e3c49da"
+    url = "https://caltech.box.com/shared/static/vivf36pih7e0ttahqarc2nd5jxb4q8jr.gz"
+
+[era5_land_fraction]
+git-tree-sha1 = "7f14ef1c7859da1363b8973743b2a376c008f29f"
+
+    [[era5_land_fraction.download]]
+    sha256 = "1d6acf98656b50f1a324ee3daa267281fb017314d2169dbfda25208299f44870"
+    url = "https://caltech.box.com/shared/static/glqlyb626j3szcjltyuwp534yzzhf770.gz"

--- a/config/subseasonal_configs/wxquest_diagedmf.yml
+++ b/config/subseasonal_configs/wxquest_diagedmf.yml
@@ -10,6 +10,8 @@ dt: "30secs"
 dt_cpl: "30secs"
 energy_check: false
 h_elem: 16
+land_fraction_source: "era5"
+binary_area_fraction: false
 
 ### integrated land ###
 # land_model: "integrated"

--- a/config/subseasonal_configs/wxquest_progedmf.yml
+++ b/config/subseasonal_configs/wxquest_progedmf.yml
@@ -10,6 +10,8 @@ dt: "10secs"
 dt_cpl: "10secs"
 energy_check: false
 h_elem: 32
+land_fraction_source: "era5"
+binary_area_fraction: false
 
 ### integrated land ###
 # land_model: "integrated"

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -166,6 +166,8 @@ specific timesteps should be specified, rather than only `dt`.
 | `--bucket_albedo_type` | String | `"map_static"` | `map_static`, `function`, `map_temporal` | Access bucket surface albedo information from data file |
 | `--bucket_initial_condition` | String | `""` | Any valid file path | File path for a NetCDF file (read documentation about requirements) |
 | `--era5_initial_condition_dir` | String | `nothing` | Any valid directory path | Directory containing ERA5 initial condition files (subseasonal mode). Filenames inferred from `start_date`. Generated with `https://github.com/CliMA/WeatherQuest` |
+| `--land_fraction_source` | String | `"etopo"` | `etopo`, `era5` | Source for land fraction data. `etopo` uses ETOPO-derived landsea_mask artifact (binary), `era5` uses ERA5/IFS land fraction artifact (0.0 - 1.0), which includes large inland seas and lakes. |
+| `--binary_area_fraction` | Bool | `true` | `true`, `false` | Whether to use binary (thresholded) area fractions for land and ice. When true, land fraction > eps becomes 1, and ice fraction > 0.5 becomes 1 |
 
 #### Ice model specific
 
@@ -187,4 +189,5 @@ Input.argparse_settings
 Input.parse_commandline
 Input.get_coupler_config_dict
 Input.get_coupler_args
+Input.get_land_fraction
 ```

--- a/experiments/ClimaEarth/Artifacts.toml
+++ b/experiments/ClimaEarth/Artifacts.toml
@@ -38,3 +38,10 @@ git-tree-sha1 = "cbbc6b3752d9cb9b667ec33cfbeb46819f8db418"
     [[landsea_mask_1deg.download]]
     sha256 = "3722b553c2fdf28a6574aea2e0b167d16ab050f34e5969ada45625b3a3ecb6da"
     url = "https://caltech.box.com/shared/static/b3u4dv0dsoswvqgp8y63bzj7awbhwztd.gz"
+
+[era5_land_fraction]
+git-tree-sha1 = "7f14ef1c7859da1363b8973743b2a376c008f29f"
+
+    [[era5_land_fraction.download]]
+    sha256 = "1d6acf98656b50f1a324ee3daa267281fb017314d2169dbfda25208299f44870"
+    url = "https://caltech.box.com/shared/static/glqlyb626j3szcjltyuwp534yzzhf770.gz"

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -148,6 +148,8 @@ function CoupledSimulation(config_dict::AbstractDict)
         parameter_files,
         era5_initial_condition_dir,
         ice_model,
+        land_fraction_source,
+        binary_area_fraction,
     ) = Input.get_coupler_args(config_dict)
 
     # Get default shared parameters from ClimaParams.jl, overriding with any provided parameter files
@@ -259,19 +261,12 @@ function CoupledSimulation(config_dict::AbstractDict)
         surface_elevation,
     )
 
-    #=
-    ### Land-sea Fraction
-    This is a static field that contains the area fraction of land and sea, ranging from 0 to 1.
-    If applicable, sea ice is included in the sea fraction at this stage.
-    Note that land-sea area fraction is different to the land-sea mask, which is a binary field
-    (masks are used internally by the coupler to indicate passive cells that are not populated by a given component model).
-    =#
-
-    # Preprocess the file to be 1s and 0s before remapping into onto the grid
-    land_mask_data =
-        joinpath(@clima_artifact("landsea_mask_60arcseconds", comms_ctx), "landsea_mask.nc")
-    land_fraction = SpaceVaryingInput(land_mask_data, "landsea", boundary_space)
-    land_fraction = ifelse.(land_fraction .> eps(FT), FT(1), FT(0))
+    land_fraction = Input.get_land_fraction(
+        boundary_space,
+        comms_ctx;
+        land_fraction_source,
+        binary_area_fraction,
+    )
 
     #=
     ### Surface Models: AMIP and SlabPlanet Modes
@@ -399,6 +394,7 @@ function CoupledSimulation(config_dict::AbstractDict)
                 start_date,
                 land_fraction,
                 sic_path = subseasonal_sic,
+                binary_area_fraction = binary_area_fraction,
             )
         else
             error("Invalid ice model specified: $(ice_model)")

--- a/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
@@ -69,6 +69,7 @@ for FT in (Float32, Float64)
                 land_fraction = CC.Fields.zeros(space),
                 thermo_params = thermo_params,
                 dt = dt,
+                binary_area_fraction = true,
             )
 
             p = (; cache..., params = params)

--- a/src/Input.jl
+++ b/src/Input.jl
@@ -10,11 +10,15 @@ import YAML
 import Dates
 import ClimaAtmos as CA
 import ClimaUtilities.TimeManager: ITime
+import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
+import ClimaUtilities.ClimaArtifacts: @clima_artifact
+import ClimaCore as CC
 import ClimaCoupler
 import ..Interfacer
 import ..Utilities
 
-export argparse_settings, parse_commandline, get_coupler_config_dict, get_coupler_args
+export argparse_settings,
+    parse_commandline, get_coupler_config_dict, get_coupler_args, get_land_fraction
 
 const MODE_NAME_DICT = Dict(
     "amip" => Interfacer.AMIPMode,
@@ -225,6 +229,14 @@ function argparse_settings()
         help = "Sea ice model to use. [`prescribed` (default), `clima_seaice`]"
         arg_type = String
         default = "prescribed"
+        "--land_fraction_source"
+        help = "Source for land fraction data. [`etopo` (default) uses ETOPO-derived landsea_mask artifact, `era5` uses ERA5 land fraction artifact]"
+        arg_type = String
+        default = "etopo"
+        "--binary_area_fraction"
+        help = "Boolean flag indicating whether to use binary (thresholded) area fractions for land and ice [`true` (default), `false`]. When true, land fraction > eps becomes 1, and ice fraction > 0.5 becomes 1."
+        arg_type = Bool
+        default = true
     end
     return s
 end
@@ -408,6 +420,12 @@ function get_coupler_args(config_dict::Dict)
     # Ice model-specific information
     ice_model = config_dict["ice_model"]
 
+    # Land fraction source
+    land_fraction_source = config_dict["land_fraction_source"]
+
+    # Binary area fraction
+    binary_area_fraction = config_dict["binary_area_fraction"]
+
     return (;
         job_id,
         sim_mode,
@@ -442,6 +460,8 @@ function get_coupler_args(config_dict::Dict)
         parameter_files,
         era5_initial_condition_dir,
         ice_model,
+        land_fraction_source,
+        binary_area_fraction,
     )
 end
 
@@ -542,6 +562,71 @@ function parse_component_dts!(config_dict)
 
     config_dict["component_dt_dict"] = component_dt_dict
     return nothing
+end
+
+
+"""
+    get_land_fraction(boundary_space, comms_ctx; land_fraction_source = "etopo", binary_area_fraction = true)
+
+Read and remap the land-sea fraction field onto the coupler boundary grid.
+
+# Arguments
+- `boundary_space`: The boundary space onto which to remap the land fraction.
+- `comms_ctx`: The communications context.
+- `land_fraction_source`: Source of land fraction data. Either "etopo" (default) or "era5".
+- `binary_area_fraction`: If true (default), threshold land fraction to binary (0 or 1).
+
+# Returns
+- A field containing land fraction values (0 to 1) on the boundary space.
+
+Note: 
+Land-sea Fraction
+    This is a static field that contains the area fraction of land and sea, ranging from 0 to 1.
+    If applicable, sea ice is included in the sea fraction at this stage.
+    Note that land-sea area fraction is different to the land-sea mask, which is a binary field
+    (masks are used internally by the coupler to indicate passive cells that are not populated by a given component model).
+
+    Two sources are supported via the `land_fraction_source` config option:
+    - "etopo": ETOPO-derived binary land-sea mask (landsea_mask_60arcseconds artifact)
+    - "era5": ERA5 land fraction field (era5_land_fraction artifact)
+"""
+function get_land_fraction(
+    boundary_space,
+    comms_ctx;
+    land_fraction_source::String = "etopo",
+    binary_area_fraction::Bool = true,
+)
+    FT = CC.Spaces.undertype(boundary_space)
+
+    if land_fraction_source == "era5"
+        land_fraction_data = joinpath(
+            @clima_artifact("era5_land_fraction", comms_ctx),
+            "era5_land_fraction.nc",
+        )
+        land_fraction = SpaceVaryingInput(land_fraction_data, "lsm", boundary_space)
+    elseif land_fraction_source == "etopo"
+        land_fraction_data = joinpath(
+            @clima_artifact("landsea_mask_60arcseconds", comms_ctx),
+            "landsea_mask.nc",
+        )
+        land_fraction = SpaceVaryingInput(land_fraction_data, "landsea", boundary_space)
+    else
+        error(
+            "Unknown land_fraction_source: $land_fraction_source. Must be \"etopo\" or \"era5\".",
+        )
+    end
+
+    # Ensure land fraction is finite/not NaN and clamp to [0, 1]
+    land_fraction = ifelse.(isfinite.(land_fraction), land_fraction, FT(0))
+    land_fraction = max.(min.(land_fraction, FT(1)), FT(0))
+
+    if binary_area_fraction
+        land_fraction = ifelse.(land_fraction .> eps(FT), FT(1), FT(0))
+    else
+        land_fraction = ifelse.(land_fraction .> eps(FT), land_fraction, FT(0))
+    end
+
+    return land_fraction
 end
 
 end # module Input

--- a/test/input_tests.jl
+++ b/test/input_tests.jl
@@ -89,6 +89,8 @@ end
         "coupler_toml" => [],
         "era5_initial_condition_dir" => nothing,
         "ice_model" => "prescribed",
+        "land_fraction_source" => "etopo",
+        "binary_area_fraction" => true,
         "component_dt_dict" => Dict(
             "dt_atmos" => 400.0,
             "dt_land" => 400.0,
@@ -114,6 +116,7 @@ end
     @test args.sim_mode == ClimaCoupler.Interfacer.AMIPMode
     @test args.land_model == "bucket"
     @test args.ice_model == "prescribed"
+    @test args.land_fraction_source == "etopo"
 
     # Test that component_dt_dict is preserved
     @test args.component_dt_dict isa Dict


### PR DESCRIPTION
Remove binary area fraction clippings and add support for era5 land fraction artifact.
