### PR TITLE
convert momentum fluxes to Cartesian basis for Oceananigans

### DIFF
--- a/experiments/ClimaEarth/components/ocean/clima_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/clima_seaice.jl
@@ -303,17 +303,22 @@ function FluxCalculator.update_turbulent_fluxes!(sim::ClimaSeaIceSimulation, fie
     grid = sim.ice.model.grid
     ice_concentration = sim.ice.model.ice_concentration
 
+    # Convert the momentum fluxes from contravariant to Cartesian basis
+    contravariant_to_cartesian!(sim.remapping.temp_uv_vec, F_turb_ρτxz, F_turb_ρτyz)
+    F_turb_ρτxz_uv = sim.remapping.temp_uv_vec.components.data.:1
+    F_turb_ρτyz_uv = sim.remapping.temp_uv_vec.components.data.:2
+
     # Remap momentum fluxes onto reduced 2D Center, Center fields using scratch arrays and fields
     CC.Remapping.interpolate!(
         sim.remapping.scratch_arr1,
         sim.remapping.remapper_cc,
-        F_turb_ρτxz,
+        F_turb_ρτxz_uv,
     )
     OC.set!(sim.remapping.scratch_cc1, sim.remapping.scratch_arr1) # zonal momentum flux
     CC.Remapping.interpolate!(
         sim.remapping.scratch_arr2,
         sim.remapping.remapper_cc,
-        F_turb_ρτyz,
+        F_turb_ρτyz_uv,
     )
     OC.set!(sim.remapping.scratch_cc2, sim.remapping.scratch_arr2) # meridional momentum flux
 

--- a/experiments/ClimaEarth/components/ocean/climaocean_helpers.jl
+++ b/experiments/ClimaEarth/components/ocean/climaocean_helpers.jl
@@ -147,3 +147,30 @@ Fields to Face/Center and Center/Face coordinates, respectively.
         τy[i, j, 1] = OC.Operators.ℑyᵃᶠᵃ(i, j, 1, grid, τy_cc)
     end
 end
+
+"""
+    contravariant_to_cartesian!(ρτ_flux_uv, ρτxz, ρτyz)
+
+Convert the covariant vector components `ρτxz` and `ρτyz` from the
+contravariant basis (as they are output by the surface flux calculation)
+to the Cartesian basis. These are now in an extrinsic coordinate system
+that can be rotated onto the ocean/sea ice grid by `_rotate_vector!`.
+"""
+function contravariant_to_cartesian!(ρτ_flux_uv, ρτxz, ρτyz)
+    # Get the local geometry of the boundary space
+    local_geometry = CC.Fields.local_geometry_field(ρτxz)
+
+    # Get the vector components in the CT1 and CT2 directions
+    xz = @. CA.CT12(
+        CA.CT1(CA.unit_basis_vector_data(CA.CT1, local_geometry)),
+        local_geometry,
+    )
+    yz = @. CA.CT12(
+        CA.CT2(CA.unit_basis_vector_data(CA.CT2, local_geometry)),
+        local_geometry,
+    )
+
+    # Convert the vector components to a UVVector on the Cartesian basis
+    @. ρτ_flux_uv = @. CC.Geometry.UVVector(ρτxz * xz + ρτyz * yz, local_geometry)
+    return nothing
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In CMIP runs, we noticed grid imprinting on ocean velocities. This suggests that the momentum fluxes are not being correctly rotated when they're provided to the ocean (and sea ice). We have a function `_rotate_vector!` which calls `OC.Operators.intrinsic_vector`, but it doesn't seem like this would support the ClimaCore contravariant basis as an extrinsic basis ([docs](https://clima.github.io/OceananigansDocumentation/stable/appendix/library/#Oceananigans.Operators.intrinsic_vector-Tuple%7BAny,%20Any,%20Any,%20Oceananigans.Grids.AbstractGrid,%20Any,%20Any,%20Any%7D)).

`intrinsic_vector` does support rotating from Cartesian coordinates to the Oceananigans coordinates (which in the case of a LatitudeLongitudeGrid are the same, but will not be the same for TripolarGrid). This PR converts the momentum fluxes from the contravariant basis to a Cartesian basis before rotating them onto the Oceananigans grid.

## Cubed sphere grid imprinting in ocean velocities
### Before this PR
From [this build](https://buildkite.com/clima/climacoupler-ci/builds/7550#019b9eee-2eaf-49ee-b491-b6a29f4d0457): CMIP + integrated land + ClimaSeaIce
<img width="1126" height="766" alt="Screenshot 2026-01-09 at 11 07 38 AM" src="https://github.com/user-attachments/assets/9612e1a8-26d9-4736-a4b3-511fbc57f057" />

### After this PR
From [this build](https://buildkite.com/clima/climacoupler-ci/builds/7564#019ba353-2e3b-4cf9-aff4-4ba8c5ce82e8)
<img width="1126" height="766" alt="Screenshot 2026-01-09 at 11 19 43 AM" src="https://github.com/user-attachments/assets/d90943af-93c0-4f78-8175-0866c743da27" />

## Content
- [x] Add a function to convert from contravariant basis to UVVector (Cartesian basis)
- [x] Use this function when providing momentum fluxes to Oceananigans and ClimaSeaIce models
- [ ] Add temp fields to avoid allocations


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
