### PR TITLE
change default output dir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,11 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
-#### Update interfaces to surface-flux calculator to support dynamic roughness.
+#### Change default simulation output directory PRPR[#1653](https://github.com/CliMA/ClimaCoupler.jl/pull/1653)
+Changes the default output directory from `experiments/ClimaEarth/output/` to `output`.
+The internal structure within the output directory remains the same.
+
+#### Update interfaces to surface-flux calculator to support dynamic roughness PR[#1567](https://github.com/CliMA/ClimaCoupler.jl/pull/1567)
 Adds the `roughness_model` argument to the surface-flux input constructor. Default
 behaviour is the `SF.ScalarRoughness()` type. Upcoming changes will account for the
 value of the `roughness_model` to be inferred from the mask value (e.g. prescribed

--- a/src/Input.jl
+++ b/src/Input.jl
@@ -166,9 +166,9 @@ function argparse_settings()
         default = false
         # Output information
         "--coupler_output_dir"
-        help = "Directory to save output files. Note that TempestRemap fails if interactive and paths are too long. [\"experiments/ClimaEarth/output\" (default)]"
+        help = "Directory to save output files. Note that TempestRemap fails if interactive and paths are too long. [\"output\" (default)]"
         arg_type = String
-        default = "experiments/ClimaEarth/output"
+        default = "output"
         # ClimaAtmos specific
         "--surface_setup"
         help = "Triggers ClimaAtmos into the coupled mode [`PrescribedSurface` (default), `DefaultMoninObukhov`]" # retained here for standalone Atmos benchmarks


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The current default output directory is `experiments/ClimaEarth/output/` which results in output being saved in `experiments/ClimaEarth/experiments/ClimaEarth/output/` when a simulation is run from the `experiments/ClimaEarth/` directory. This can be difficult to find, and I don't think the output necessarily needs to be in the `experiments/ClimaEarth/` directory, so this PR changes it to just `output/`.

The structure of output inside the output folder is unchanged.

