### PR TITLE
add Poppler_jll compat in docs/

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -12,3 +12,4 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 Documenter = "0.27"
+Poppler_jll = "24"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
docbuild is currently failing on main because Poppler_jll v25 was released 2 days ago and it isn't compatible with the CURL_OPENSSL_4 version on the github runners. We don't need the new version of Poppler_jll so I just pin it to v24 here