### PR TITLE
wxquest v3

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -51,3 +51,10 @@ git-tree-sha1 = "7f7b6d4ae6055c4c2b6a6dfba5be8b4e6ca1b0be"
 
 [era5_inst_model_levels]
 git-tree-sha1 = "8aae2d7330f90a029a4891be658a691e4e3362dc"
+
+[modis_lai_climatology]
+git-tree-sha1 = "cd070348ab70f5d1b165c814f70e3822c0173eed"
+
+    [[modis_lai_climatology.download]]
+    sha256 = "569cc33c3db2d3096ca1d50c7a30fe19cbc8f00a5d814d57d066b1d633aa2f5f"
+    url = "https://caltech.box.com/shared/static/iquk73vo9983073uxjjri2nxqevq65tk.gz"

--- a/config/atmos_configs/climaatmos_wx_diagedmf.yml
+++ b/config/atmos_configs/climaatmos_wx_diagedmf.yml
@@ -7,7 +7,7 @@ topo_smoothing: true
 topography: "Earth"
 rayleigh_sponge: true
 viscous_sponge: true
-divergence_damping_factor: 50.0
+divergence_damping_factor: 20.0
 scalar_hyperdiffusion_coefficient: 0.929738
 vorticity_hyperdiffusion_coefficient: 0.1857
 insolation: "timevarying"
@@ -15,16 +15,16 @@ rad: allskywithclear
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
 aerosol_radiation: true
-time_varying_trace_gases: ["CO2", "O3"]
+# time_varying_trace_gases: ["CO2", "O3"]
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 turbconv: diagnostic_edmfx
 implicit_diffusion: true
 approximate_linear_solve_iters: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
-h_elem: 16
-z_max: 60000.0
-z_elem: 63
+h_elem: 15
+z_max: 70000.0
+z_elem: 70
 dz_bottom: 30.0
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
@@ -44,4 +44,4 @@ toml: [toml/diagnostic_edmfx_era5_ic.toml]
 
 cloud_model: "quadrature"
 use_itime: true
-deep_atmosphere: false
+deep_atmosphere: true

--- a/config/atmos_configs/climaatmos_wx_progedmf.yml
+++ b/config/atmos_configs/climaatmos_wx_progedmf.yml
@@ -7,7 +7,7 @@ topo_smoothing: true
 topography: "Earth"
 rayleigh_sponge: true
 viscous_sponge: true
-divergence_damping_factor: 50.0
+divergence_damping_factor: 20.0
 scalar_hyperdiffusion_coefficient: 0.929738
 vorticity_hyperdiffusion_coefficient: 0.1857
 insolation: "timevarying"
@@ -15,7 +15,7 @@ rad: allskywithclear
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
 # time_varying_trace_gases: ["CO2", "O3"]
-# prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
+prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true
 implicit_sgs_advection: true
@@ -27,8 +27,8 @@ approximate_linear_solve_iters: 2
 prognostic_tke: true
 edmfx_upwinding: first_order
 h_elem: 15
-z_max: 48000.0
-z_elem: 63
+z_max: 70000.0
+z_elem: 70
 dz_bottom: 30.0
 edmfx_entr_model: "Generalized"
 edmfx_detr_model: "Generalized"
@@ -49,4 +49,4 @@ moist: equil
 
 cloud_model: "quadrature"
 use_itime: true
-deep_atmosphere: false
+deep_atmosphere: true

--- a/config/subseasonal_configs/wxquest_diagedmf.yml
+++ b/config/subseasonal_configs/wxquest_diagedmf.yml
@@ -1,28 +1,40 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_wx_diagedmf.yml"
-coupler_toml: ["toml/amip_diagedmf.toml"]
+coupler_toml: ["toml/wxquest_diagedmf.toml"]
+strict_params: false
+mode_name: "subseasonal"
+era5_initial_condition_dir: "/net/sampo/data1/wxquest_data/initial_conditions/initial_conditions_v1_dev"
 initial_condition: "WeatherModel"
-checkpoint_dt: "7days"
+checkpoint_dt: "40days"
 dt: "120secs"
 dt_cpl: "120secs"
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
+dt_seaice: "120secs"
 energy_check: false
-h_elem: 16
+h_elem: 32
 land_fraction_source: "era5"
 binary_area_fraction: false
-mode_name: "subseasonal"
-era5_initial_condition_dir: "/net/sampo/data1/wxquest_data/initial_conditions"
-land_model: "bucket"
-bucket_albedo_type: "map_temporal"
+
+### integrated land ###
+land_model: "integrated"
+lai_source: "modis_monthly_climatology"
+
+### bucket land ###
+# land_model: "bucket"
+# bucket_albedo_type: "map_temporal"
+# bucket_albedo_type: "era5"
+# bucket_initial_condition: "/net/sampo/data1/cchristo/WeatherQuest_data/archive_dev4/era5_bucket_processed_20250831_0000.nc"
+
 land_spun_up_ic: false
 land_temperature_anomaly: "nothing"
 radiation_reset_rng_seed: true
-start_date: "20180901"
+start_date: "20100101"
 surface_setup: "PrescribedSurface"
 topo_smoothing: true
 topography: "Earth"
+t_end: "40days"
 netcdf_output_at_levels: true
 output_default_diagnostics: false
 use_coupler_diagnostics: false
@@ -30,6 +42,6 @@ use_land_diagnostics: false
 strict_params: false
 insolation: "timevarying"
 extra_atmos_diagnostics:
-  - short_name: [hfls, hfss, rsus, rlus]
-    period: 1months
+  - short_name: [zg, orog, tas, ta, mslp, pr, ua, va, ts, rhoa, pfull, hur, hus, clw, cl, hfss, hfls, evspsbl, hussfc, rsds, rlds, rlus, rsus, rld, wa, waup]
+    period: 24hours
     reduction_time: average

--- a/config/subseasonal_configs/wxquest_progedmf.yml
+++ b/config/subseasonal_configs/wxquest_progedmf.yml
@@ -2,12 +2,14 @@ FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_wx_progedmf.yml"
 coupler_toml: ["toml/amip_progedmf.toml"]
+strict_params: false
 mode_name: "subseasonal"
 era5_initial_condition_dir: "/net/sampo/data1/wxquest_data/initial_conditions"
 initial_condition: "WeatherModel"
 checkpoint_dt: "7days"
 dt: "10secs"
 dt_cpl: "10secs"
+dt_seaice: "10secs"
 energy_check: false
 h_elem: 32
 land_fraction_source: "era5"
@@ -15,23 +17,25 @@ binary_area_fraction: false
 
 ### integrated land ###
 # land_model: "integrated"
+# lai_source: "modis_monthly_climatology"
 
 ### bucket land ###
 land_model: "bucket"
 bucket_albedo_type: "map_temporal"
-bucket_initial_condition: "/net/sampo/data1/wxquest_data/initial_conditions/era5_bucket_processed_20250907_0000.nc"
+bucket_initial_condition: "/net/sampo/data1/wxquest_data/initial_conditions/era5_bucket_processed_20250831_0000.nc"
 
 land_spun_up_ic: false
 land_temperature_anomaly: "nothing"
 use_land_diagnostics: true
 radiation_reset_rng_seed: true
-start_date: "20250907"
+start_date: "20250831"
 surface_setup: "PrescribedSurface"
 topo_smoothing: true
 topography: "Earth"
 t_end: "7days"
 netcdf_output_at_levels: true
+use_coupler_diagnostics: true
 extra_atmos_diagnostics:
-  - short_name: [tas, mslp, pr, ua, va, rhoa, pfull, hur, hus, clw, cli, clivi, clwvi, cl, arup, tke]
-    period: 1hours
+  - short_name: [zg, orog, tas, ta, mslp, pr, ua, va, ts, rhoa, pfull, hur, hus, clw, cli, clivi, clwvi, cl, arup, tke, hfss, hfls, evspsbl, hussfc, rsds, rlds, rlus, rsus, rld, wa, waup]
+    period: 3hours
     reduction_time: average

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -163,8 +163,9 @@ specific timesteps should be specified, rather than only `dt`.
 | `--land_temperature_anomaly` | String | `"aquaplanet"` | `amip`, `aquaplanet`, `nothing` | Type of temperature anomaly for land model |
 | `--use_land_diagnostics` | Bool | `true` | `true`, `false` | Whether to compute and output land model diagnostics |
 | `--land_spun_up_ic` | Bool | `true` | `true`, `false` | Whether to use integrated land initial conditions from spun up state |
-| `--bucket_albedo_type` | String | `"map_static"` | `map_static`, `function`, `map_temporal` | Access bucket surface albedo information from data file |
-| `--bucket_initial_condition` | String | `""` | Any valid file path | File path for a NetCDF file (read documentation about requirements) |
+| `--lai_source` | String | `"modis_monthly"` | `modis_monthly`, `modis_monthly_climatology` | Source for leaf area index data. `modis_monthly` uses full MODIS monthly data, `modis_monthly_climatology` uses MODIS monthly climatology with periodic calendar |
+| `--bucket_albedo_type` | String | `"map_static"` | `map_static`, `function`, `map_temporal`, `era5` | Access bucket surface albedo information from data file. Use `era5` for ERA5-derived processed albedo files (requires `era5_initial_condition_dir`) |
+| `--bucket_initial_condition` | String | `""` | Any valid file path | File path for a NetCDF file (read documentation about requirements). In subseasonal mode, automatically inferred from `era5_initial_condition_dir` if not specified |
 | `--era5_initial_condition_dir` | String | `nothing` | Any valid directory path | Directory containing ERA5 initial condition files (subseasonal mode). Filenames inferred from `start_date`. Generated with `https://github.com/CliMA/WeatherQuest` |
 | `--land_fraction_source` | String | `"etopo"` | `etopo`, `era5` | Source for land fraction data. `etopo` uses ETOPO-derived landsea_mask artifact (binary), `era5` uses ERA5/IFS land fraction artifact (0.0 - 1.0), which includes large inland seas and lakes. |
 | `--binary_area_fraction` | Bool | `true` | `true`, `false` | Whether to use binary (thresholded) area fractions for land and ice. When true, land fraction > eps becomes 1, and ice fraction > 0.5 becomes 1 |

--- a/experiments/ClimaEarth/README.md
+++ b/experiments/ClimaEarth/README.md
@@ -160,11 +160,13 @@ Generates 3-4 week forecasts from ERA5-derived initial conditions. Similar to `a
 - `era5_initial_condition_dir`: directory that contains files named like:
   - `sst_processed_YYYYMMDD_0000.nc`
   - `sic_processed_YYYYMMDD_0000.nc`
-  - `era5_land_processed_YYYYMMDD_0000.nc`
-  - `era5_bucket_processed_YYYYMMDD_0000.nc`
+  - `era5_land_processed_YYYYMMDD_0000.nc` (for integrated land model)
+  - `era5_bucket_processed_YYYYMMDD_0000.nc` (for bucket land model, auto-inferred if `bucket_initial_condition` not specified)
+  - `albedo_processed_YYYYMMDD_0000.nc` (optional  ERA5 global surface albedo field, used when `bucket_albedo_type: "era5"`)
 
 - **How filename inference works**: given `start_date` formatted as `YYYYMMDD`, the model constructs paths
-  - `joinpath(era5_initial_condition_dir, "sst_processed_YYYYMMDD_0000.nc")` for the initial conditions.
+  - `joinpath(era5_initial_condition_dir, "sst_processed_YYYYMMDD_0000.nc")` for SST
+  - `joinpath(era5_initial_condition_dir, "era5_bucket_processed_YYYYMMDD_0000.nc")` for bucket IC (if not explicitly set)
 
 - **Contents and expected variables**:
   - `sst_processed_YYYYMMDD_0000.nc`:
@@ -194,6 +196,12 @@ Generates 3-4 week forecasts from ERA5-derived initial conditions. Similar to `a
       - `tsn` (K): temperature of snow layer, dims `(lat, lon)`
       - `skt` (K): skin temperature, dims `(lat, lon)`
     - era5 land level midpoints: 0.035, 0.175, 0.64, 1.945 (m)
+
+  - `albedo_processed_YYYYMMDD_0000.nc` (optional, ERA5 global surface albedo field):
+    - Used when `bucket_albedo_type: "era5"` is specified
+    - Variable: `sw_alb_clr` (clear-sky surface albedo)
+    - Units: fraction (0–1)
+    - Dimensions: `(time, lat, lon)` - temporally interpolated monthly data
 
 ## Configuration files
 We use configuration files to specify all simulation parameters and options. The configuration files are organized hierarchically:

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -128,13 +128,13 @@ function CoupledSimulation(config_dict::AbstractDict)
         land_model,
         land_temperature_anomaly,
         land_spun_up_ic,
+        lai_source,
         bucket_albedo_type,
-        bucket_initial_condition,
         energy_check,
         use_coupler_diagnostics,
         output_dir_root,
         parameter_files,
-        era5_initial_condition_dir,
+        era5_filepaths,
         ocean_model,
         ice_model,
         land_fraction_source,
@@ -269,20 +269,10 @@ function CoupledSimulation(config_dict::AbstractDict)
 
     @info(sim_mode)
     land_sim = ice_sim = ocean_sim = nothing
-    # Build ERA5-based file paths if subseasonal mode is selected
-    subseasonal_sst = subseasonal_sic = subseasonal_land_ic = nothing
-    if sim_mode <: SubseasonalMode
-        isnothing(era5_initial_condition_dir) &&
-            error("subseasonal mode requires --era5_initial_condition_dir")
-        # Filenames inferred from start_date, which is YYYYMMDD
-        datestr = Dates.format(start_date, Dates.dateformat"yyyymmdd")
-        subseasonal_sst =
-            joinpath(era5_initial_condition_dir, "sst_processed_$(datestr)_0000.nc")
-        subseasonal_sic =
-            joinpath(era5_initial_condition_dir, "sic_processed_$(datestr)_0000.nc")
-        subseasonal_land_ic =
-            joinpath(era5_initial_condition_dir, "era5_land_processed_$(datestr)_0000.nc")
-    end
+
+    # Unpack ERA5-based file paths (populated for subseasonal mode, nothing otherwise)
+    (; sst_path, sic_path, land_ic_path, albedo_path, bucket_initial_condition) =
+        era5_filepaths
 
     ## Construct the land model component
     # Determine whether to use a shared surface space
@@ -306,9 +296,11 @@ function CoupledSimulation(config_dict::AbstractDict)
         # Arguments used by bucket model
         albedo_type = bucket_albedo_type,
         bucket_initial_condition,
+        era5_albedo_file_path = albedo_path,
         # Arguments used by integrated model
         land_spun_up_ic,
-        land_ic_path = subseasonal_land_ic,
+        land_ic_path,
+        lai_source,
     )
 
     ## Construct the ocean model component
@@ -327,7 +319,7 @@ function CoupledSimulation(config_dict::AbstractDict)
         output_dir = dir_paths.ocean_output_dir,
         ice_model,
         # Arguments used by prescribed ocean
-        sst_path = subseasonal_sst,
+        sst_path,
         # Arguments used by slab ocean
         saveat,
         evolving = evolving_ocean,
@@ -351,7 +343,7 @@ function CoupledSimulation(config_dict::AbstractDict)
         thermo_params,
         comms_ctx,
         land_fraction,
-        sic_path = subseasonal_sic,
+        sic_path,
         binary_area_fraction,
     )
 

--- a/ext/ClimaCouplerClimaLandExt.jl
+++ b/ext/ClimaCouplerClimaLandExt.jl
@@ -17,6 +17,7 @@ import Dates
 import ClimaUtilities.TimeVaryingInputs:
     LinearInterpolation, PeriodicCalendar, TimeVaryingInput
 import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
+import ClimaUtilities.ClimaArtifacts: @clima_artifact
 import ClimaCoupler:
     Checkpointer, FieldExchanger, FluxCalculator, Interfacer, Utilities, Plotting
 import SciMLBase
@@ -30,6 +31,7 @@ import ClimaComms
 import ClimaUtilities.TimeManager: ITime
 using NCDatasets
 import StaticArrays
+import Interpolations
 
 include("climaland/climaland_helpers.jl")
 include("climaland/climaland_bucket.jl")

--- a/ext/climaland/climaland_integrated.jl
+++ b/ext/climaland/climaland_integrated.jl
@@ -50,6 +50,7 @@ end
         use_land_diagnostics::Bool = true,
         parameter_files = [],
         land_ic_path::Union{Nothing,String} = nothing,
+        lai_source::String = "modis_monthly",
     ) where {FT, TT <: Union{Float64, ITime}}
 
 Creates a ClimaLandSimulation object containing a land domain,
@@ -58,6 +59,11 @@ a ClimaLand.LandModel, and an integrator.
 This type of model contains a canopy model, soil model, snow model, and
 soil CO2 model. Specific details about the complexity of the model
 can be found in the ClimaLand.jl documentation.
+
+# Arguments
+- `lai_source::String = "modis_monthly"`: Source for leaf area index data. Options:
+  - `"modis_monthly"`: Time-varying LAI from full MODIS monthly data (default)
+  - `"modis_monthly_climatology"`: Time-varying LAI from MODIS monthly climatology (uses PeriodicCalendar)
 """
 function ClimaLandSimulation(
     ::Type{FT};
@@ -78,6 +84,7 @@ function ClimaLandSimulation(
     use_land_diagnostics::Bool = true,
     coupled_param_dict = CP.create_toml_dict(FT),
     land_ic_path::Union{Nothing, String} = nothing,
+    lai_source::String = "modis_monthly",
     extra_kwargs...,
 ) where {FT, TT <: Union{Float64, ITime}}
     # Get default land parameters from ClimaLand.LandParameters
@@ -124,12 +131,32 @@ function ClimaLandSimulation(
 
     # Set up leaf area index (LAI)
     stop_date = start_date + Dates.Second(float(tspan[2] - tspan[1]))
-    LAI = CL.prescribed_lai_modis(
-        surface_space,
-        start_date,
-        stop_date;
-        time_interpolation_method = LinearInterpolation(),
-    )
+    if lai_source == "modis_monthly"
+        # Full monthly MODIS LAI data
+        LAI = CL.prescribed_lai_modis(
+            surface_space,
+            start_date,
+            stop_date;
+            time_interpolation_method = LinearInterpolation(),
+        )
+    elseif lai_source == "modis_monthly_climatology"
+        # MODIS LAI monthly climatology
+        modis_lai_clim_path = joinpath(
+            @clima_artifact("modis_lai_climatology", ClimaComms.context(surface_space)),
+            "modis_lai_climatology.nc",
+        )
+        LAI = CL.prescribed_lai_modis(
+            surface_space,
+            start_date,
+            stop_date;
+            modis_lai_ncdata_path = modis_lai_clim_path,
+            time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+        )
+    else
+        error(
+            "Unknown lai_source: $lai_source. Must be \"modis_monthly\" or \"modis_monthly_climatology\"",
+        )
+    end
 
     ground = CL.PrognosticGroundConditions{FT}()
     canopy_forcing = (; forcing.atmos, forcing.radiation, ground)

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -430,6 +430,8 @@ and directory `era5_initial_condition_dir`, filenames containing the initial con
   - `skt` (K), `tsn` (K),`swe` (m), `swvl` (m^3/m^3), `si` (m^3/m^3), `sie` (J/m^3), `stl` (K)
 - Land IC (bucket land): `era5_bucket_processed_YYYYMMDD_0000.nc`, with fields
   - `W` (m), `Ws` (m), `S` (m), `T` (K), `tsn` (K), `skt` (K); dims `(lat, lon)`
+- Albedo (optional, when `bucket_albedo_type: "era5"`): `albedo_processed_YYYYMMDD_0000.nc`, with fields
+  - `sw_alb_clr` (clear-sky surface albedo, fraction 0-1); dims `(time, lat, lon)`
 and are used to initialize the coupler components.
 
 """

--- a/test/input_tests.jl
+++ b/test/input_tests.jl
@@ -84,6 +84,7 @@ end
         "land_model" => "bucket",
         "land_temperature_anomaly" => "aquaplanet",
         "land_spun_up_ic" => true,
+        "lai_source" => "modis_monthly",
         "bucket_albedo_type" => "map_static",
         "bucket_initial_condition" => "",
         "coupler_toml" => [],

--- a/toml/wxquest_diagedmf.toml
+++ b/toml/wxquest_diagedmf.toml
@@ -1,0 +1,38 @@
+[alpha_rayleigh_w]
+value = 10.0
+
+[zd_rayleigh]
+value = 45000.0
+
+[zd_viscous]
+value = 45000.0
+
+[precipitation_timescale]
+value = 600
+
+[entr_inv_tau]
+value = 0.002
+
+[entr_coeff]
+value = 0
+
+[detr_inv_tau]
+value = 0
+
+[detr_buoy_coeff]
+value = 0.12
+
+[detr_vertdiv_coeff]
+value = 0.6
+
+[min_area_limiter_scale]
+value = 0
+
+[max_area_limiter_scale]
+value = 0
+
+[mixing_length_Prandtl_maximum]
+value = 4.2
+
+[land_bucket_capacity]
+value = 0.8


### PR DESCRIPTION
Update configurations for weatherquest runs. Add functionality for running Coupler through ERA5 historical period.

Includes options for: 
1.  running bucket with prescribed ERA5 albedo
2. running integrated land with MODIS climatology (to run coupler before 2010)
3. initializing sea ice with ERA5 surface ice temperatures