### PR TITLE
Add flagship AMIP to nightly pipeline

### DIFF
--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -106,3 +106,15 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 30GB
+
+      - label: "Flagship AMIP GPU with prognostic EDMF + 1M + integrated land (16 helems)"
+        key: "gpu_amip_progedmf_1M_land_he16"
+        command: "srun julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $BENCHMARK_CONFIG_PATH/amip_progedmf_1m_land_he16.yml --job_id gpu_amip_progedmf_1M_land_he16"
+        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_progedmf_1M_land_he16/artifacts/*"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus_per_task: 1
+          slurm_cpus_per_task: 4
+          slurm_ntasks: 1
+          slurm_mem: 16GB


### PR DESCRIPTION
The purpose here is to get faster performance feedback for any code merged to `main` in the important CliMA repos, since our current measurements use the weekly pipeline with pinned deps.

Resolves #1660 