### PR TITLE
Add missing env var to nightly buildkite pipeline

### DIFF
--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -8,6 +8,7 @@ env:
   GKSwstype: 100
   SLURM_KILL_BAD_EXIT: 1
   CONFIG_PATH: "config/nightly_configs"
+  BENCHMARK_CONFIG_PATH: "config/benchmark_configs"
 
 timeout_in_minutes: 840
 


### PR DESCRIPTION
Won't work without this defined.