### PR TITLE
larger dts for nightly AMIPs [skip ci]

### DIFF
--- a/config/nightly_configs/amip_coarse_diagedmf.yml
+++ b/config/nightly_configs/amip_coarse_diagedmf.yml
@@ -4,8 +4,11 @@ atmos_config_file: "config/atmos_configs/climaatmos_diagedmf.yml"
 bucket_albedo_type: "map_temporal"
 checkpoint_dt: "366days"
 coupler_toml: ["toml/amip_diagedmf.toml"]
-dt: "240secs"
-dt_cpl: "240secs"
+dt_atmos: "4mins"
+dt_cpl: "32mins"
+dt_land: "8mins"
+dt_ocean: "8mins"
+dt_seaice: "8mins"
 dz_bottom: 100.0
 energy_check: false
 h_elem: 8

--- a/config/nightly_configs/amip_coarse_diagedmf_land.yml
+++ b/config/nightly_configs/amip_coarse_diagedmf_land.yml
@@ -3,8 +3,11 @@ albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_diagedmf.yml"
 checkpoint_dt: "366days"
 coupler_toml: ["toml/amip_diagedmf.toml"]
-dt: "240secs"
-dt_cpl: "240secs"
+dt_atmos: "4mins"
+dt_cpl: "32mins"
+dt_land: "8mins"
+dt_ocean: "8mins"
+dt_seaice: "8mins"
 dz_bottom: 100.0
 energy_check: false
 h_elem: 8

--- a/config/nightly_configs/amip_coarse_edonly.yml
+++ b/config/nightly_configs/amip_coarse_edonly.yml
@@ -4,8 +4,11 @@ atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 bucket_albedo_type: "map_temporal"
 checkpoint_dt: "366days"
 coupler_toml: ["toml/amip_diagedmf.toml"]
-dt: "240secs"
-dt_cpl: "240secs"
+dt_atmos: "4mins"
+dt_cpl: "32mins"
+dt_land: "8mins"
+dt_ocean: "8mins"
+dt_seaice: "8mins"
 dz_bottom: 100.0
 energy_check: false
 h_elem: 8

--- a/config/nightly_configs/amip_coarse_progedmf.yml
+++ b/config/nightly_configs/amip_coarse_progedmf.yml
@@ -4,8 +4,11 @@ atmos_config_file: "config/atmos_configs/climaatmos_progedmf.yml"
 bucket_albedo_type: "map_temporal"
 checkpoint_dt: "186days"
 coupler_toml: ["toml/amip_progedmf.toml"]
-dt: "60secs"
-dt_cpl: "60secs"
+dt_atmos: "1mins"
+dt_cpl: "10mins"
+dt_land: "5mins"
+dt_ocean: "5mins"
+dt_seaice: "5mins"
 dz_bottom: 100.0
 energy_check: false
 h_elem: 8


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
I tried out two nightly AMIPs (diag EDMF + integrated land; ED only + bucket) with 30 minute coupling timesteps [here](https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/735) and they ran fine. This PR increases the timesteps for all runs in the nightly AMIP pipeline except for the newest one which uses a benchmark config.

Last night's nightly AMIP failed because of the land version. I think we should wait to merge this until tomorrow so we can verify that the nightly AMIPs run ok tonight.

After approval I'll merge this without running CI since it only changes nightly configs.