### PR TITLE
Fix artifact output paths 

### DIFF
--- a/.buildkite/amip/pipeline.yml
+++ b/.buildkite/amip/pipeline.yml
@@ -42,7 +42,7 @@ steps:
         command:
           - echo "--- Run simulation"
           - "srun --cpu-bind=threads --cpus-per-task=4 julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_land.yml --job_id amip"
-        artifact_paths: "experiments/ClimaEarth/output/amip/artifacts/*"
+        artifact_paths: "output/amip/artifacts/*"
         timeout_in_minutes: 5760
         env:
           CLIMACOMMS_DEVICE: "CUDA"

--- a/.buildkite/benchmarks/pipeline.yml
+++ b/.buildkite/benchmarks/pipeline.yml
@@ -33,7 +33,7 @@ steps:
       - label: "GPU AMIP with prognostic EDMF + 1M + integrated land (16 helems)"
         key: "gpu_amip_progedmf_1M_land_he16"
         command: "srun julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $BENCHMARK_CONFIG_PATH/amip_progedmf_1m_land_he16.yml --job_id gpu_amip_progedmf_1M_land_he16"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_progedmf_1M_land_he16/artifacts/*"
+        artifact_paths: "output/gpu_amip_progedmf_1M_land_he16/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -45,7 +45,7 @@ steps:
       - label: "GPU AMIP with prognostic EDMF + 1M + integrated land (30 helems)"
         key: "gpu_amip_progedmf_1M_land_he30"
         command: "srun julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $BENCHMARK_CONFIG_PATH/amip_progedmf_1m_land_he30.yml --job_id gpu_amip_progedmf_1M_land_he30"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_progedmf_1M_land_he30/artifacts/*"
+        artifact_paths: "output/gpu_amip_progedmf_1M_land_he30/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -59,7 +59,7 @@ steps:
       - label: "GPU ClimaAtmos without diagnostic EDMF"
         key: "gpu_climaatmos"
         command: "srun julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/component_model_tests/climaatmos_standalone/atmos_driver.jl --config_file $BENCHMARK_CONFIG_PATH/climaatmos.yml --job_id gpu_climaatmos"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_climaatmos/artifacts/*"
+        artifact_paths: "output/gpu_climaatmos/artifacts/*"
         env:
           CLIMACOMMS_CONTEXT: "MPI"
           CLIMACOMMS_DEVICE: "CUDA"
@@ -72,7 +72,7 @@ steps:
       - label: "GPU ClimaAtmos with diagnostic EDMF"
         key: "gpu_climaatmos_diagedmf"
         command: "srun julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/component_model_tests/climaatmos_standalone/atmos_driver.jl --config_file $BENCHMARK_CONFIG_PATH/climaatmos_diagedmf.yml --job_id gpu_climaatmos_diagedmf"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_climaatmos_diagedmf/artifacts/*"
+        artifact_paths: "output/gpu_climaatmos_diagedmf/artifacts/*"
         env:
           CLIMACOMMS_CONTEXT: "MPI"
           CLIMACOMMS_DEVICE: "CUDA"
@@ -85,7 +85,7 @@ steps:
       - label: "GPU AMIP with diagnostic EDMF"
         key: "gpu_amip_diagedmf"
         command: "srun julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $BENCHMARK_CONFIG_PATH/amip_diagedmf.yml --job_id gpu_amip_diagedmf"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_diagedmf/artifacts/*"
+        artifact_paths: "output/gpu_amip_diagedmf/artifacts/*"
         env:
           CLIMACOMMS_CONTEXT: "MPI"
           CLIMACOMMS_DEVICE: "CUDA"
@@ -98,7 +98,7 @@ steps:
       - label: "GPU AMIP with diagnostic EDMF and IO"
         key: "gpu_amip_diagedmf_io"
         command: "srun julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $BENCHMARK_CONFIG_PATH/amip_diagedmf_io.yml --job_id gpu_amip_diagedmf_io"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_diagedmf_io/artifacts/*"
+        artifact_paths: "output/gpu_amip_diagedmf_io/artifacts/*"
         env:
           CLIMACOMMS_CONTEXT: "MPI"
           CLIMACOMMS_DEVICE: "CUDA"
@@ -122,7 +122,7 @@ steps:
             --job_id_coupled_progedmf_coarse gpu_amip_progedmf_1M_land_he16 \
             --job_id_coupled_progedmf_fine gpu_amip_progedmf_1M_land_he30 \
             --build_id $BUILDKITE_BUILD_NUMBER
-        artifact_paths: "experiments/ClimaEarth/output/compare_amip_climaatmos_amip_diagedmf/*"
+        artifact_paths: "output/compare_amip_climaatmos_amip_diagedmf/*"
         depends_on:
           - "gpu_climaatmos"
           - "gpu_climaatmos_diagedmf"

--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -57,14 +57,14 @@ steps:
       - label: "Aquaplanet: evolving slab ocean"
         key: "slabplanet_aqua_evolve_ocean"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/slabplanet_aqua_evolve_ocean.yml --job_id slabplanet_aqua_evolve_ocean"
-        artifact_paths: "experiments/ClimaEarth/output/slabplanet_aqua_evolve_ocean/artifacts/*"
+        artifact_paths: "output/slabplanet_aqua_evolve_ocean/artifacts/*"
         agents:
           slurm_mem: 32GB
 
       - label: "Slabplanet: evolving slab ocean, bucket"
         key: "slabplanet_evolve_ocean"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/slabplanet_evolve_ocean.yml --job_id slabplanet_evolve_ocean"
-        artifact_paths: "experiments/ClimaEarth/output/slabplanet_evolve_ocean/artifacts/*"
+        artifact_paths: "output/slabplanet_evolve_ocean/artifacts/*"
         agents:
           slurm_mem: 32GB
 
@@ -75,7 +75,7 @@ steps:
       - label: "GPU AMIP + ED only"
         key: "amip_edonly_gpu"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_edonly.yml --job_id amip_edonly_gpu"
-        artifact_paths: "experiments/ClimaEarth/output/amip_edonly_gpu/artifacts/*"
+        artifact_paths: "output/amip_edonly_gpu/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -88,7 +88,7 @@ steps:
       - label: "GPU AMIP + ED only + 1M microphysics"
         key: "amip_edonly_1M_gpu"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_edonly_1M.yml --job_id amip_edonly_1M_gpu"
-        artifact_paths: "experiments/ClimaEarth/output/amip_edonly_1M_gpu/artifacts/*"
+        artifact_paths: "output/amip_edonly_1M_gpu/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -102,7 +102,7 @@ steps:
       - label: "GPU AMIP + ED only + integrated land"
         key: "amip_edonly_integrated_land_gpu" # runs for 4 months only because of instability after that time
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_edonly_integrated_land.yml --job_id amip_edonly_integrated_land_gpu"
-        artifact_paths: "experiments/ClimaEarth/output/amip_edonly_integrated_land_gpu/artifacts/*"
+        artifact_paths: "output/amip_edonly_integrated_land_gpu/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -116,7 +116,7 @@ steps:
         key: "amip_diagedmf_gpu"
         command:
           - "julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_diagedmf.yml --job_id amip_diagedmf_gpu"
-        artifact_paths: "experiments/ClimaEarth/output/amip_diagedmf_gpu/artifacts/*"
+        artifact_paths: "output/amip_diagedmf_gpu/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -130,7 +130,7 @@ steps:
         key: "amip_diagedmf_1m_gpu"
         command:
           - "julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_diagedmf_1m.yml --job_id amip_diagedmf_1m_gpu"
-        artifact_paths: "experiments/ClimaEarth/output/amip_diagedmf_1m_gpu/artifacts/*"
+        artifact_paths: "output/amip_diagedmf_1m_gpu/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -144,7 +144,7 @@ steps:
         key: "amip_diagedmf_integrated_land_gpu"
         command:
           - "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_diagedmf_integrated_land.yml --job_id amip_diagedmf_integrated_land_gpu"
-        artifact_paths: "experiments/ClimaEarth/output/amip_diagedmf_integrated_land_gpu/artifacts/*"
+        artifact_paths: "output/amip_diagedmf_integrated_land_gpu/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -161,7 +161,7 @@ steps:
         key: "cmip_edonly_land"
         command:
             - "julia --color=yes --project=experiments/ClimaEarth experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_edonly_land.yml --job_id cmip_edonly_land"
-        artifact_paths: "experiments/ClimaEarth/output/cmip_edonly_land/artifacts/*"
+        artifact_paths: "output/cmip_edonly_land/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -173,7 +173,7 @@ steps:
         key: "cmip_edonly_bucket"
         command:
             - "julia --color=yes --project=experiments/ClimaEarth experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_edonly_bucket.yml --job_id cmip_edonly_bucket"
-        artifact_paths: "experiments/ClimaEarth/output/cmip_edonly_bucket/artifacts/*"
+        artifact_paths: "output/cmip_edonly_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:

--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -53,7 +53,7 @@ steps:
         command:
           - echo "--- Run simulation"
           - "julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_diagedmf.yml --job_id amip_coarse_diagedmf"
-        artifact_paths: "experiments/ClimaEarth/output/amip_coarse_diagedmf/artifacts/*"
+        artifact_paths: "output/amip_coarse_diagedmf/artifacts/*"
         timeout_in_minutes: 840
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -68,7 +68,7 @@ steps:
         command:
           - echo "--- Run simulation"
           - "julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_diagedmf_land.yml --job_id amip_coarse_diagedmf_land"
-        artifact_paths: "experiments/ClimaEarth/output/amip_coarse_diagedmf_land/artifacts/*"
+        artifact_paths: "output/amip_coarse_diagedmf_land/artifacts/*"
         timeout_in_minutes: 840
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -83,7 +83,7 @@ steps:
         command:
           - echo "--- Run simulation"
           - "julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_progedmf.yml --job_id amip_coarse_progedmf"
-        artifact_paths: "experiments/ClimaEarth/output/amip_coarse_progedmf/artifacts/*"
+        artifact_paths: "output/amip_coarse_progedmf/artifacts/*"
         timeout_in_minutes: 840
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -98,7 +98,7 @@ steps:
         command:
           - echo "--- Run simulation"
           - "julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_edonly.yml --job_id amip_coarse_edonly"
-        artifact_paths: "experiments/ClimaEarth/output/amip_coarse_edonly/artifacts/*"
+        artifact_paths: "output/amip_coarse_edonly/artifacts/*"
         timeout_in_minutes: 840
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -111,7 +111,7 @@ steps:
       - label: "Flagship AMIP GPU with prognostic EDMF + 1M + integrated land (16 helems)"
         key: "gpu_amip_progedmf_1M_land_he16"
         command: "srun julia --threads=3 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $BENCHMARK_CONFIG_PATH/amip_progedmf_1m_land_he16.yml --job_id gpu_amip_progedmf_1M_land_he16"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_progedmf_1M_land_he16/artifacts/*"
+        artifact_paths: "output/gpu_amip_progedmf_1M_land_he16/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -149,35 +149,35 @@ steps:
       - label: "Slabplanet: default"
         key: "slabplanet_default"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/slabplanet_default.yml --job_id slabplanet_default"
-        artifact_paths: "experiments/ClimaEarth/output/slabplanet_default/artifacts/*"
+        artifact_paths: "output/slabplanet_default/artifacts/*"
         agents:
           slurm_mem: 20GB
 
       - label: "Slabplanet: dry, no radiation, fixed ocean T"
         key: "slabplanet_dry_norad"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/slabplanet_dry_norad.yml --job_id slabplanet_dry_norad"
-        artifact_paths: "experiments/ClimaEarth/output/slabplanet_dry_norad/artifacts/*"
+        artifact_paths: "output/slabplanet_dry_norad/artifacts/*"
         agents:
           slurm_mem: 20GB
 
       - label: "Slabplanet: extra atmos diagnostics"
         key: "slabplanet_atmos_diags"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/slabplanet_atmos_diags.yml --job_id slabplanet_atmos_diags"
-        artifact_paths: "experiments/ClimaEarth/output/slabplanet_atmos_diags/artifacts/*"
+        artifact_paths: "output/slabplanet_atmos_diags/artifacts/*"
         agents:
           slurm_mem: 20GB
 
       - label: "Slabplanet terra: atmos and bucket"
         key: "slabplanet_terra"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/slabplanet_terra.yml --job_id slabplanet_terra"
-        artifact_paths: "experiments/ClimaEarth/output/slabplanet_terra/artifacts/*"
+        artifact_paths: "output/slabplanet_terra/artifacts/*"
         agents:
           slurm_mem: 20GB
 
       - label: "Slabplanet aqua: atmos and slab ocean"
         key: "slabplanet_aqua"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/slabplanet_aqua.yml --job_id slabplanet_aqua"
-        artifact_paths: "experiments/ClimaEarth/output/slabplanet_aqua/artifacts/*"
+        artifact_paths: "output/slabplanet_aqua/artifacts/*"
         agents:
           slurm_mem: 20GB
 
@@ -187,13 +187,13 @@ steps:
       - label: "AMIP: default"
         key: "amip_default"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl"
-        artifact_paths: "experiments/ClimaEarth/output/amip_default/artifacts/*"
+        artifact_paths: "output/amip_default/artifacts/*"
         agents:
           slurm_mem: 20GB
 
       - label: "AMIP: integrated land non-spun up initial condition test"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_land_ic.yml --job_id amip_land_ic"
-        artifact_paths: "experiments/ClimaEarth/output/amip_land_ic/artifacts/*"
+        artifact_paths: "output/amip_land_ic/artifacts/*"
         agents:
           slurm_ntasks: 1
           slurm_mem: 20GB
@@ -201,7 +201,7 @@ steps:
       - label: "AMIP - Float64 + hourly checkpoint"
         key: "amip"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_ft64_hourly_checkpoints.yml --job_id amip_coarse_ft64_hourly_checkpoints"
-        artifact_paths: "experiments/ClimaEarth/output/amip_coarse_ft64_hourly_checkpoints/artifacts/*"
+        artifact_paths: "output/amip_coarse_ft64_hourly_checkpoints/artifacts/*"
         env:
           FLAME_PLOT: ""
           BUILD_HISTORY_HANDLE: ""
@@ -211,14 +211,14 @@ steps:
 
       - label: "AMIP - Component dts test"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_component_dts.yml --job_id target_amip_component_dts"
-        artifact_paths: "experiments/ClimaEarth/output/target_amip_component_dts/artifacts/*"
+        artifact_paths: "output/target_amip_component_dts/artifacts/*"
         agents:
           slurm_ntasks: 1
           slurm_mem: 20GB
 
       - label: "MPI AMIP"
         command: "srun julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_coarse_mpi.yml --job_id amip_coarse_mpi"
-        artifact_paths: "experiments/ClimaEarth/output/amip_coarse_mpi/artifacts/*"
+        artifact_paths: "output/amip_coarse_mpi/artifacts/*"
         timeout_in_minutes: 30
         env:
           CLIMACOMMS_CONTEXT: "MPI"
@@ -230,7 +230,7 @@ steps:
       - label: "Unthreaded AMIP FINE" # also reported by longruns with a flame graph
         key: "unthreaded_amip_fine"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_n1_shortrun.yml --job_id target_amip_n1_shortrun"
-        artifact_paths: "experiments/ClimaEarth/output/target_amip_n1_shortrun/artifacts/*"
+        artifact_paths: "output/target_amip_n1_shortrun/artifacts/*"
         env:
           BUILD_HISTORY_HANDLE: ""
         agents:
@@ -256,7 +256,7 @@ steps:
       - label: "GPU Slabplanet: albedo from function"
         key: "gpu_slabplanet_albedo_function"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/slabplanet_albedo_function.yml --job_id gpu_slabplanet_albedo_function"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_slabplanet_albedo_function/artifacts/*"
+        artifact_paths: "output/gpu_slabplanet_albedo_function/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -267,7 +267,7 @@ steps:
       - label: "GPU AMIP: ED only + integrated land"
         key: "gpu_amip_edonly_integrated_land"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_edonly_integrated_land.yml --job_id gpu_amip_edonly_integrated_land"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_edonly_integrated_land/artifacts/*"
+        artifact_paths: "output/gpu_amip_edonly_integrated_land/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -277,7 +277,7 @@ steps:
       - label: "GPU AMIP: ED only + bucket"
         key: "gpu_amip_edonly_bucket"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_edonly_bucket.yml --job_id gpu_amip_edonly_bucket"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_edonly_bucket/artifacts/*"
+        artifact_paths: "output/gpu_amip_edonly_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -287,7 +287,7 @@ steps:
       - label: "GPU AMIP: diag. EDMF + integrated land"
         key: "gpu_amip_diagedmf_integrated_land"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_diagedmf_integrated_land.yml --job_id gpu_amip_diagedmf_integrated_land"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_diagedmf_integrated_land/artifacts/*"
+        artifact_paths: "output/gpu_amip_diagedmf_integrated_land/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -297,7 +297,7 @@ steps:
       - label: "GPU AMIP: diag. EDMF + bucket"
         key: "gpu_amip_diagedmf_bucket"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_diagedmf_bucket.yml --job_id gpu_amip_diagedmf_bucket"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_diagedmf_bucket/artifacts/*"
+        artifact_paths: "output/gpu_amip_diagedmf_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -307,7 +307,7 @@ steps:
       - label: "GPU AMIP: prog. EDMF + bucket"
         key: "gpu_amip_progedmf_bucket"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_progedmf_bucket.yml --job_id gpu_amip_progedmf_bucket"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_progedmf_bucket/artifacts/*"
+        artifact_paths: "output/gpu_amip_progedmf_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -318,7 +318,7 @@ steps:
       - label: "GPU AMIP test: albedo from function"
         key: "gpu_amip_albedo_function"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_albedo_function.yml --job_id gpu_amip_albedo_function"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_albedo_function/artifacts/*"
+        artifact_paths: "output/gpu_amip_albedo_function/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -328,7 +328,7 @@ steps:
       - label: "GPU AMIP: albedo from temporal map + 0M"
         key: "gpu_amip_albedo_temporal_map"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_albedo_temporal_map.yml --job_id gpu_amip_albedo_temporal_map"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_albedo_temporal_map/artifacts/*"
+        artifact_paths: "output/gpu_amip_albedo_temporal_map/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -338,7 +338,7 @@ steps:
       - label: "GPU AMIP: albedo from temporal map + 1M"
         key: "gpu_amip_albedo_temporal_map_1M"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/amip_albedo_temporal_map_1M.yml --job_id gpu_amip_albedo_temporal_map_1M"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_amip_albedo_temporal_map_1M/artifacts/*"
+        artifact_paths: "output/gpu_amip_albedo_temporal_map_1M/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -351,7 +351,7 @@ steps:
       - label: "GPU CMIP: ClimaAtmos + bucket land + Oceananigans + PrescribedSeaIce"
         key: "gpu_cmip_oceananigans_prescrseaice_bucket"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_oceananigans_prescrseaice_bucket.yml --job_id gpu_cmip_oceananigans_prescrseaice_bucket"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_cmip_oceananigans_prescrseaice_bucket/artifacts/*"
+        artifact_paths: "output/gpu_cmip_oceananigans_prescrseaice_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -361,7 +361,7 @@ steps:
       - label: "GPU CMIP: ClimaAtmos + bucket land + Oceananigans + ClimaSeaIce"
         key: "gpu_cmip_oceananigans_climaseaice_bucket"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice_bucket.yml --job_id gpu_cmip_oceananigans_climaseaice_bucket"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_cmip_oceananigans_climaseaice_bucket/artifacts/*"
+        artifact_paths: "output/gpu_cmip_oceananigans_climaseaice_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -371,7 +371,7 @@ steps:
       - label: "GPU CMIP: ClimaAtmos + integrated land + Oceananigans + PrescribedSeaIce"
         key: "gpu_cmip_oceananigans_prescrseaice"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_oceananigans_prescrseaice.yml --job_id gpu_cmip_oceananigans_prescrseaice"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_cmip_oceananigans_prescrseaice/artifacts/*"
+        artifact_paths: "output/gpu_cmip_oceananigans_prescrseaice/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:
@@ -381,7 +381,7 @@ steps:
       - label: "GPU CMIP: ClimaAtmos + integrated land + Oceananigans + ClimaSeaIce"
         key: "gpu_cmip_oceananigans_climaseaice"
         command: "julia --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/run_amip.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice.yml --job_id gpu_cmip_oceananigans_climaseaice"
-        artifact_paths: "experiments/ClimaEarth/output/gpu_cmip_oceananigans_climaseaice/artifacts/*"
+        artifact_paths: "output/gpu_cmip_oceananigans_climaseaice/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:


### PR DESCRIPTION
Clean up artifact output directories so buildkite results correctly display plots. 
closes #1666 