### PR TITLE
remove old pkgversion checks

### DIFF
--- a/experiments/ClimaCore/heat-diffusion/run.jl
+++ b/experiments/ClimaCore/heat-diffusion/run.jl
@@ -192,12 +192,8 @@ domain_atm = CC.Domains.IntervalDomain(
 );
 context = CC.ClimaComms.context()
 mesh_atm = CC.Meshes.IntervalMesh(domain_atm, nelems = parameters.n); # struct, allocates face boundaries to 5,6: atmos
-if pkgversion(CC) >= v"0.14.10"
-    device = CC.ClimaComms.device(context)
-    center_space_atm = CC.Spaces.CenterFiniteDifferenceSpace(device, mesh_atm) # collection of the above, discretises space into FD and provides coords
-else
-    center_space_atm = CC.Spaces.CenterFiniteDifferenceSpace(mesh_atm) # collection of the above, discretises space into FD and provides coords
-end
+device = CC.ClimaComms.device(context)
+center_space_atm = CC.Spaces.CenterFiniteDifferenceSpace(device, mesh_atm) # collection of the above, discretises space into FD and provides coords
 
 # - initialize prognostic variables, either as ClimaCore's Field objects or as Arrays
 T_atm_0 = CC.Fields.ones(FT, center_space_atm) .* parameters.T_atm_ini; # initiates a spatially uniform atm progostic var

--- a/experiments/ClimaCore/sea_breeze/atmos_rhs.jl
+++ b/experiments/ClimaCore/sea_breeze/atmos_rhs.jl
@@ -121,12 +121,8 @@ function hvspace_2D(xlim = (-π, π), zlim = (0, 4π), helem = 20, velem = 20, n
     )
     context = ClimaComms.context()
     vertmesh = CC.Meshes.IntervalMesh(vertdomain, nelems = velem)
-    if pkgversion(CC) >= v"0.14.10"
-        device = ClimaComms.device(context)
-        vert_center_space = CC.Spaces.CenterFiniteDifferenceSpace(device, vertmesh)
-    else
-        vert_center_space = CC.Spaces.CenterFiniteDifferenceSpace(vertmesh)
-    end
+    device = ClimaComms.device(context)
+    vert_center_space = CC.Spaces.CenterFiniteDifferenceSpace(device, vertmesh)
 
     horzdomain = CC.Domains.IntervalDomain(
         CC.Geometry.XPoint{FT}(xlim[1]),

--- a/experiments/ClimaEarth/components/ocean/clima_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/clima_seaice.jl
@@ -149,7 +149,7 @@ function ClimaSeaIceSimulation(
     remapping = ocean.remapping
 
     # Before version 0.96.22, the NetCDFWriter was broken on GPU
-    if arch isa OC.CPU || pkgversion(OC) >= v"0.96.22"
+    if arch isa OC.CPU
         # Save all tracers and velocities to a NetCDF file at daily frequency
         outputs = OC.prognostic_fields(ice.model)
         jld_writer = OC.JLD2Writer(

--- a/experiments/ClimaEarth/components/ocean/oceananigans.jl
+++ b/experiments/ClimaEarth/components/ocean/oceananigans.jl
@@ -184,7 +184,7 @@ function OceananigansSimulation(
     )
 
     # Before version 0.96.22, the NetCDFWriter was broken on GPU
-    if arch isa OC.CPU || pkgversion(OC) >= v"0.96.22"
+    if arch isa OC.CPU
         # Save all tracers and velocities to a NetCDF file at daily frequency
         outputs = merge(ocean.model.tracers, ocean.model.velocities)
         surface_writer = OC.NetCDFWriter(

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -195,19 +195,11 @@ function CoupledSimulation(config_dict::AbstractDict)
             t_start = restart_t
         end
 
-        if pkgversion(CA) >= v"0.29.1"
-            # We only support a round number of seconds
-            isinteger(float(t_start)) ||
-                error("Cannot restart from a non integer number of seconds")
-            t_start_int = Int(float(t_start))
-            atmos_config_dict.parsed_args["t_start"] = "$(t_start_int)secs"
-        else
-            # There was no `t_start`, so we have to use a workaround for this.
-            # This does not support passing the command-line arguments (unless
-            # restart_dir is exactly the same as output_dir_root)
-            atmos_config_dict.parsed_args["restart_file"] =
-                climaatmos_restart_path(output_dir_root, restart_t)
-        end
+        # We only support a round number of seconds
+        isinteger(float(t_start)) ||
+            error("Cannot restart from a non integer number of seconds")
+        t_start_int = Int(float(t_start))
+        atmos_config_dict.parsed_args["t_start"] = "$(t_start_int)secs"
 
         @info "Starting from t_start $(t_start)"
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We have some `pkgversion` checks in the code to enable support across package versions. We don't need to keep these around for versions that are no longer included in our compats, so I cleaned them up in this PR.


## To-do
- [x] for each package version that we don't support anymore, remove the pkgversion check and keep the newer branch
