### PR TITLE
rename abstract component types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Rename abstract component types PR[#1688](https://github.com/CliMA/ClimaCoupler.jl/pull/1688)
+To follow abstract type naming convention. For example, `XModelSimulation` is now
+`AbstractXSimulation`.
+
 #### Add generic component model constructors PR[#1683](https://github.com/CliMA/ClimaCoupler.jl/pull/1683)
 In preparation for adding extensions for each component model, generalize the component
 model constructor interface and extend it for each component. This PR also drops

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -12,49 +12,49 @@ contains one `atmos_sim`, and at least one surface simulation (`land_sim`,
 for a given run, it may be omitted.
 
 ## Component simulations
-Individual component model simulations fall under `ComponentModelSimulation`,
+Individual component model simulations fall under `AbstractComponentSimulation`,
 which together combine to make the `CoupledSimulation`.
-We have two types of `ComponentModelSimulations`: `AtmosModelSimulation` and
-`SurfaceModelSimulation`. The two have different requirements,
-which are detailed below. `SurfaceModelSimulation` is further divided into
-`SeaIceModelSimulation`, `LandModelSimulation`, and `OceanModelSimulation`,
+We have two types of `AbstractComponentSimulation`s: `AbstractAtmosSimulation` and
+`AbstractSurfaceSimulation`. The two have different requirements,
+which are detailed below. `AbstractSurfaceSimulation` is further divided into
+`AbstractSeaIceSimulation`, `AbstractLandSimulation`, and `AbstractOceanSimulation`,
 representing the 3 currently-supported options for surface models.
 
-### ComponentModelSimulation - required functions
+### AbstractComponentSimulation - required functions
 A component model simulation should be implemented as a struct that is a concrete subtype
-of a `ComponentModelSimulation`. This struct should contain all of the
+of a `AbstractComponentSimulation`. This struct should contain all of the
 information needed to run that simulation.
 
-Each `ComponentModelSimulation` must extend the following functions to be able
+Each `AbstractComponentSimulation` must extend the following functions to be able
 to use our coupler. For some existing models, these are defined within
 ClimaCoupler.jl in that model’s file in `experiments/ClimaEarth/components/`, but it is preferable
 for these to be defined in a model’s own repository. Note that the dispatch
-`::ComponentModelSimulation` in the function definitions given below should
+`::AbstractComponentSimulation` in the function definitions given below should
 be replaced with the particular component model extending these functions.
-- constructor: construct and return an instance of the `ComponentModelSimulation`,
+- constructor: construct and return an instance of the `AbstractComponentSimulation`,
 and perform all initialization. This function should return a simulation that
 is ready to be stepped in the coupled simulation. The interface for this
 function varies across component models.
 
-- `step!(::ComponentModelSimulation, t)`: A function to update the
+- `step!(::AbstractComponentSimulation, t)`: A function to update the
 simulation in-place with values calculate for time `t`. For the
 models we currently have implemented, this is a simple wrapper around
 the `step!` function implemented in SciMLBase.jl.
 
-### ComponentModelSimulation - optional functions
-- `Checkpointer.get_model_prog_state(::ComponentModelSimulation)`:
+### AbstractComponentSimulation - optional functions
+- `Checkpointer.get_model_prog_state(::AbstractComponentSimulation)`:
 A function that returns the state vector of the simulation at its current
 state. This is used for checkpointing the simulation.
 
-- `Checkpointer.get_model_cache(::ComponentModelSimulation)`:
+- `Checkpointer.get_model_cache(::AbstractComponentSimulation)`:
 A function that returns the cache of the simulation at its current state.
 This is used for checkpointing the simulation.
 
-- `Checkpointer.restore_cache(::ComponentModelSimulation, new_cache)`:
+- `Checkpointer.restore_cache(::AbstractComponentSimulation, new_cache)`:
 A function that updates the cache of the simulation with the provided
 `new_cache`. This is used for restarting the simulation.
 
-- `get_field(::ComponentModelSimulation, ::Val{property})`:
+- `get_field(::AbstractComponentSimulation, ::Val{property})`:
 Default `get_field` functions are provided for `energy` and `water` fields,
 described in the table below.
 These quantities are used to track conservation, and the defaults
@@ -66,7 +66,7 @@ functions must be extended for all models being run.
 | `energy`     | vertically integrated energy per surface area | J m⁻²  | `nothing`     |
 | `water`      | vertically integrated water per surface area  | kg m⁻² | `nothing`     |
 
-- `add_coupler_fields!(coupler_field_names, ::ComponentModelSimulation)`:
+- `add_coupler_fields!(coupler_field_names, ::AbstractComponentSimulation)`:
 A set of default coupler exchange fields is initialized for each coupled simulation,
 but depending on the component models being run, additional coupler fields may
 be required. For example, the integrated land model requires the concentration
@@ -120,28 +120,28 @@ The default coupler exchange fields are the following, defined in
     so storing them in the coupler fields allows us to avoid regridding them to the coupler
     space multiple times per coupling timestep.
 
-- `update_sim!(::ComponentModelSimulation, csf)`: A
+- `update_sim!(::AbstractComponentSimulation, csf)`: A
 function to update each of the fields of the component model simulation
 that are updated by the coupler. ClimaCoupler.jl provides defaults of
-this function for both `AtmosModelSimulation` and
-`SurfaceModelSimulation` that update each of the fields expected by
+this function for both `AbstractAtmosSimulation` and
+`AbstractSurfaceSimulation` that update each of the fields expected by
 the coupler. This function will need to be extended for any model
 that requires additional fields (specified via `add_coupler_fields!`).
 
-- `set_cache!(sim::ComponentModelSimulation)`: A function to perform any
+- `set_cache!(sim::AbstractComponentSimulation)`: A function to perform any
 initialization of the component model caches that isn't done during the model
 simulation initialization, and that must be done after the initial exchange.
 This is necessary, for example, when component models have cache
 interdependencies that must be handled in a specific order.
 Cache variables that are computed as part of the tendencies do not need to be set here.
 
-### AtmosModelSimulation - required functions
+### AbstractAtmosSimulation - required functions
 In addition to the functions required for a general
-`ComponentModelSimulation`, an `AtmosModelSimulation` requires the
+`AbstractComponentSimulation`, an `AbstractAtmosSimulation` requires the
 following functions to retrieve and update its fields.
-- `get_field(::AtmosModelSimulation. ::Val{property})`: This getter
+- `get_field(::AbstractAtmosSimulation. ::Val{property})`: This getter
 function returns the value of the field property for the simulation
-in its current state. For an `AtmosModelSimulation`, it must be extended
+in its current state. For an `AbstractAtmosSimulation`, it must be extended
 for the following properties:
 
 | Coupler name                | Description                                                               | Units      |
@@ -162,7 +162,7 @@ for the following properties:
 | `u_int`                     | zonal wind velocity vector at the first internal model level              | m s⁻¹      |
 | `v_int`                     | meridional wind velocity vector at the first internal model level         | m s⁻¹      |
 
-- `update_field!(::AtmosModelSimulation. ::Val{property}, field)`:
+- `update_field!(::AbstractAtmosSimulation. ::Val{property}, field)`:
 A function to update the value of property in the component model
 simulation, using the values in `field`. This update should
 be done in place. If this function isn't extended for a property,
@@ -188,12 +188,12 @@ ClimaAtmos should also add the following coupler fields for Monin-Obukhov simila
 | `buoyancy_flux` | flux of buoyancy  | m⁻²s⁻³ |
 
 
-### AtmosModelSimulation - required functions to run with the ClimaLandSimulation
+### AbstractAtmosSimulation - required functions to run with the ClimaLandSimulation
 
 Coupling with the integrated `ClimaLandSimulation` requires the following functions, in addition
-to the functions required for coupling with a general `SurfaceModelSimulation`.
+to the functions required for coupling with a general `AbstractSurfaceSimulation`.
 
-- `get_field(::AtmosModelSimulation. ::Val{property})`:
+- `get_field(::AbstractAtmosSimulation. ::Val{property})`:
 This getter function must be extended
 for the following properties:
 
@@ -209,12 +209,12 @@ for the following properties:
     if the model is setup with no radiation. Because of this, a `ClimaAtmosSimulation` must have
     radiation enabled if running with the full `ClimaLand` model.
 
-### SurfaceModelSimulation - required functions
-Analogously to the `AtmosModelSimulation`, a `SurfaceModelSimulation`
-requires additional functions to those required for a general `ComponentModelSimulation`.
-- `get_field(::SurfaceModelSimulation, ::Val{property})`: This getter
+### AbstractSurfaceSimulation - required functions
+Analogously to the `AbstractAtmosSimulation`, an `AbstractSurfaceSimulation`
+requires additional functions to those required for a general `AbstractComponentSimulation`.
+- `get_field(::AbstractSurfaceSimulation, ::Val{property})`: This getter
 function returns the value of the field property for the simulation at
-the current time. For a `SurfaceModelSimulation`, it must be extended
+the current time. For an `AbstractSurfaceSimulation`, it must be extended
 for the following properties:
 
 | Coupler name             | Description                                                    | Units   |
@@ -246,7 +246,7 @@ for the following properties:
     agree, with differences only arising from `area_fraction` corrections and
     the fields existing on different spaces.
 
-- `update_field!(::SurfaceModelSimulation, ::Val{property}, field)`:
+- `update_field!(::AbstractSurfaceSimulation, ::Val{property}, field)`:
 A function to update the value of property in the component model
 simulation, using the values in `field` passed from the coupler
 This update should be done in place. If this function
@@ -268,12 +268,12 @@ properties needed by a component model.
 | `turbulent_moisture_flux`                     | aerodynamic turbulent surface fluxes of energy (evaporation)                 | kg m⁻² s⁻¹ |
 
 !!! note
-    `update_field!(::SurfaceModelSimulation, ::Val{:area_fraction}, field)` is
+    `update_field!(::AbstractSurfaceSimulation, ::Val{:area_fraction}, field)` is
     not required to be extended for land models, since they're assumed to have a
     constant area fraction.
 
-### SurfaceModelSimulation - optional functions
-- `get_field(::SurfaceModelSimulation, ::Val{property})`:
+### AbstractSurfaceSimulation - optional functions
+- `get_field(::AbstractSurfaceSimulation, ::Val{property})`:
 For some quantities, default `get_field` functions are provided, which may be
 overwritten or used as-is. These currently include the following:
 
@@ -283,14 +283,14 @@ overwritten or used as-is. These currently include the following:
 | `height_disp` | displacement height relative to the surface                               | m     |             0 |
 
 
-- `update_turbulent_fluxes!(::ComponentModelSimulation, fields::NamedTuple)`:
+- `update_turbulent_fluxes!(::AbstractComponentSimulation, fields::NamedTuple)`:
 This function updates the turbulent fluxes of the component model simulation
 at this point in horizontal space. The values are updated using the energy
 and moisture turbulent fluxes stored in fields which are calculated by the
 coupler.
 
 ### Prescribed surface conditions - SurfaceStub
-- `SurfaceStub` is a `SurfaceModelSimulation`, but it only contains required
+- `SurfaceStub` is an `AbstractSurfaceSimulation`, but it only contains required
   data in `<surface_stub>.cache`, e.g., for the calculation of surface fluxes
   through a prescribed surface state. This model is intended to be used for
   testing or as a simple stand-in model. The above adapter functions are already
@@ -324,9 +324,9 @@ end
 ## Interfacer API
 ```@docs
     Interfacer.CoupledSimulation
-    Interfacer.AtmosModelSimulation
-    Interfacer.SurfaceModelSimulation
-    Interfacer.ComponentModelSimulation
+    Interfacer.AbstractAtmosSimulation
+    Interfacer.AbstractSurfaceSimulation
+    Interfacer.AbstractComponentSimulation
     Interfacer.AbstractSurfaceStub
     Interfacer.SurfaceStub
     Interfacer.get_field

--- a/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
+++ b/experiments/ClimaEarth/components/atmosphere/climaatmos.jl
@@ -15,9 +15,9 @@ import ClimaCoupler:
 import ClimaUtilities.TimeManager: ITime
 
 ###
-### Functions required by ClimaCoupler.jl for an AtmosModelSimulation
+### Functions required by ClimaCoupler.jl for an AbstractAtmosSimulation
 ###
-struct ClimaAtmosSimulation{P, D, I, OW} <: Interfacer.AtmosModelSimulation
+struct ClimaAtmosSimulation{P, D, I, OW} <: Interfacer.AbstractAtmosSimulation
     params::P
     domain::D
     integrator::I

--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -15,7 +15,7 @@ include("climaland_helpers.jl")
 
 
 ###
-### Functions required by ClimaCoupler.jl for a SurfaceModelSimulation
+### Functions required by ClimaCoupler.jl for a AbstractSurfaceSimulation
 ###
 """
     BucketSimulation{M, I, A}
@@ -34,7 +34,7 @@ struct BucketSimulation{
     A <: CC.Fields.Field,
     OW,
     RF,
-} <: Interfacer.LandModelSimulation
+} <: Interfacer.AbstractLandSimulation
     model::M
     integrator::I
     area_fraction::A
@@ -437,13 +437,13 @@ we may compute fluxes in the bucket model's internal `step!` function.
 # Arguments
 - `csf`: [CC.Fields.Field] containing a NamedTuple of turbulent flux fields: `F_turb_ρτxz`, `F_turb_ρτyz`, `F_lh`, `F_sh`, `F_turb_moisture`.
 - `sim`: [BucketSimulation] the bucket simulation to compute fluxes for.
-- `atmos_sim`: [Interfacer.AtmosModelSimulation] the atmosphere simulation to compute fluxes with.
+- `atmos_sim`: [Interfacer.AbstractAtmosSimulation] the atmosphere simulation to compute fluxes with.
 - `thermo_params`: [ClimaParams.ThermodynamicParameters] the thermodynamic parameters for the simulation.
 """
 function FluxCalculator.compute_surface_fluxes!(
     csf,
     sim::BucketSimulation,
-    atmos_sim::Interfacer.AtmosModelSimulation,
+    atmos_sim::Interfacer.AbstractAtmosSimulation,
     thermo_params,
 )
     boundary_space = axes(csf)
@@ -530,7 +530,7 @@ end
 Updates the surface component model cache with the current coupler fields besides turbulent fluxes.
 
 # Arguments
-- `sim`: [Interfacer.SurfaceModelSimulation] containing a surface model simulation object.
+- `sim`: [Interfacer.AbstractSurfaceSimulation] containing a surface model simulation object.
 - `csf`: [NamedTuple] containing coupler fields.
 """
 function FieldExchanger.update_sim!(sim::BucketSimulation, csf)

--- a/experiments/ClimaEarth/components/land/climaland_integrated.jl
+++ b/experiments/ClimaEarth/components/land/climaland_integrated.jl
@@ -34,7 +34,7 @@ struct ClimaLandSimulation{
     I <: SciMLBase.AbstractODEIntegrator,
     A <: CC.Fields.Field,
     OW,
-} <: Interfacer.ImplicitFluxSimulation
+} <: Interfacer.AbstractImplicitFluxSimulation
     model::M
     integrator::I
     area_fraction::A
@@ -365,7 +365,7 @@ function ClimaLandSimulation(
 end
 
 ###############################################################################
-### Functions required by ClimaCoupler.jl for a SurfaceModelSimulation
+### Functions required by ClimaCoupler.jl for a AbstractSurfaceSimulation
 ###############################################################################
 
 Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:area_fraction}) = sim.area_fraction
@@ -579,13 +579,13 @@ The land model cache contains the computed fluxes for each sub-component.
 # Arguments
 - `csf`: [CC.Fields.Field] containing a NamedTuple of turbulent flux fields: `F_turb_ρτxz`, `F_turb_ρτyz`, `F_lh`, `F_sh`, `F_turb_moisture`.
 - `sim`: [ClimaLandSimulation] the integrated land simulation to compute fluxes for.
-- `atmos_sim`: [Interfacer.AtmosModelSimulation] the atmosphere simulation to compute fluxes with.
+- `atmos_sim`: [Interfacer.AbstractAtmosSimulation] the atmosphere simulation to compute fluxes with.
 - `thermo_params`: [ClimaParams.ThermodynamicParameters] the thermodynamic parameters for the simulation.
 """
 function FluxCalculator.compute_surface_fluxes!(
     csf,
     sim::ClimaLandSimulation,
-    atmos_sim::Interfacer.AtmosModelSimulation,
+    atmos_sim::Interfacer.AbstractAtmosSimulation,
     thermo_params,
 )
     boundary_space = axes(csf)

--- a/experiments/ClimaEarth/components/ocean/clima_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/clima_seaice.jl
@@ -31,7 +31,7 @@ It contains the following objects:
 - `ice_properties::IP`: A NamedTuple of sea ice properties, including melting speed, Stefan-Boltzmann constant,
     and the Celsius to Kelvin conversion constant.
 """
-struct ClimaSeaIceSimulation{SIM, A, REMAP, NT, IP} <: Interfacer.SeaIceModelSimulation
+struct ClimaSeaIceSimulation{SIM, A, REMAP, NT, IP} <: Interfacer.AbstractSeaIceSimulation
     ice::SIM
     area_fraction::A
     remapping::REMAP
@@ -274,7 +274,7 @@ function sea_ice_simulation(
 end
 
 ###############################################################################
-### Functions required by ClimaCoupler.jl for a SurfaceModelSimulation
+### Functions required by ClimaCoupler.jl for a AbstractSurfaceSimulation
 ###############################################################################
 
 # Timestep the simulation forward to time `t`

--- a/experiments/ClimaEarth/components/ocean/oceananigans.jl
+++ b/experiments/ClimaEarth/components/ocean/oceananigans.jl
@@ -24,7 +24,8 @@ It contains the following objects:
 - `remapping::REMAP`: Objects needed to remap from the exchange (spectral) grid to Oceananigans spaces.
 - `ice_concentration::SIC`: An Oceananigans Field representing the sea ice concentration on the ocean/sea ice grid.
 """
-struct OceananigansSimulation{SIM, A, OPROP, REMAP, SIC} <: Interfacer.OceanModelSimulation
+struct OceananigansSimulation{SIM, A, OPROP, REMAP, SIC} <:
+       Interfacer.AbstractOceanSimulation
     ocean::SIM
     area_fraction::A
     ocean_properties::OPROP
@@ -313,7 +314,7 @@ function FieldExchanger.resolve_area_fractions!(
 end
 
 ###############################################################################
-### Functions required by ClimaCoupler.jl for a SurfaceModelSimulation
+### Functions required by ClimaCoupler.jl for a AbstractSurfaceSimulation
 ###############################################################################
 
 # Timestep the simulation forward to time `t`

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -7,9 +7,6 @@ import Interpolations # triggers InterpolationsExt in ClimaUtilities
 import Thermodynamics as TD
 import ClimaCoupler: Checkpointer, FluxCalculator, Interfacer, Utilities
 
-###
-### Functions required by ClimaCoupler.jl for a SurfaceModelSimulation
-###
 """
     PrescribedIceSimulation{P, I}
 
@@ -28,7 +25,7 @@ Ice concentration is prescribed, and we solve the following energy equation:
 In the current version, the sea ice has a prescribed thickness. T_sfc is extrapolated from T_base
 and T_bulk assuming the ice temperature varies linearly between the ice surface and the base.
 """
-struct PrescribedIceSimulation{P, I} <: Interfacer.SeaIceModelSimulation
+struct PrescribedIceSimulation{P, I} <: Interfacer.AbstractSeaIceSimulation
     params::P
     integrator::I
 end

--- a/experiments/ClimaEarth/components/ocean/slab_ocean.jl
+++ b/experiments/ClimaEarth/components/ocean/slab_ocean.jl
@@ -6,7 +6,7 @@ import ClimaUtilities.TimeManager: date
 import ClimaCoupler: Checkpointer, FluxCalculator, Interfacer, Utilities, FieldExchanger
 
 ###
-### Functions required by ClimaCoupler.jl for a SurfaceModelSimulation
+### Functions required by ClimaCoupler.jl for a AbstractSurfaceSimulation
 ###
 """
     SlabOceanSimulation{P, I}
@@ -16,7 +16,7 @@ Equation:
     (h * ρ * c) dTdt = (-F_turb_energy + (1 - α) * SW_d + LW_d - LW_u)
 
 """
-struct SlabOceanSimulation{P, I} <: Interfacer.OceanModelSimulation
+struct SlabOceanSimulation{P, I} <: Interfacer.AbstractOceanSimulation
     params::P
     integrator::I
 end

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -199,7 +199,7 @@ function CoupledSimulation(config_dict::AbstractDict)
     #=
     ## Component Model Initialization
     Here we set initial and boundary conditions for each component model. Each component model is required to have an `init` function that
-    returns a `ComponentModelSimulation` object (see `Interfacer` docs for more details).
+    returns a `AbstractComponentSimulation` object (see `Interfacer` docs for more details).
     =#
 
     #=

--- a/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/prescr_seaice_tests.jl
@@ -149,7 +149,7 @@ for FT in (Float32, Float64)
         @test maximum(dY) ≈ FT(0)
     end
 
-    @testset "dss_state! SeaIceModelSimulation for FT=$FT" begin
+    @testset "dss_state! AbstractSeaIceSimulation for FT=$FT" begin
         coupled_param_dict = CP.create_toml_dict(FT)
         boundary_space = CC.CommonSpaces.CubedSphereSpace(
             FT;

--- a/experiments/ClimaEarth/test/debug_plots_tests.jl
+++ b/experiments/ClimaEarth/test/debug_plots_tests.jl
@@ -12,16 +12,16 @@ using Makie, GeoMakie, CairoMakie, ClimaCoreMakie # trigger ClimaCouplerMakieExt
 ENV["GKSwstype"] = "nul"
 FT = Float64
 
-struct ClimaAtmosSimulation{C} <: Interfacer.AtmosModelSimulation
+struct ClimaAtmosSimulation{C} <: Interfacer.AbstractAtmosSimulation
     cache::C
 end
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:atmos_field}) = sim.cache.atmos_field
 
-struct BucketSimulation{C} <: Interfacer.SurfaceModelSimulation
+struct BucketSimulation{C} <: Interfacer.AbstractSurfaceSimulation
     cache::C
 end
 
-struct ClimaLandSimulation{C} <: Interfacer.SurfaceModelSimulation
+struct ClimaLandSimulation{C} <: Interfacer.AbstractSurfaceSimulation
     cache::C
 end
 

--- a/ext/ClimaCouplerMakieExt/debug_plots.jl
+++ b/ext/ClimaCouplerMakieExt/debug_plots.jl
@@ -157,11 +157,11 @@ function Plotting.debug(cs_fields::CC.Fields.Field, dir, cs_fields_ref = nothing
 end
 
 """
-    debug(sim::Interfacer.ComponentModelSimulation, dir)
+    debug(sim::Interfacer.AbstractComponentSimulation, dir)
 
 Plot the fields of a component model simulation and save plots to a directory.
 """
-function Plotting.debug(sim::Interfacer.ComponentModelSimulation, dir)
+function Plotting.debug(sim::Interfacer.AbstractComponentSimulation, dir)
     field_names = Plotting.debug_plot_fields(sim)
     fig = Makie.Figure(size = (1500, 800))
     min_square_len = ceil(Int, sqrt(length(field_names)))
@@ -238,11 +238,11 @@ function Plotting.print_extrema(
 end
 
 """
-    Plotting.debug_plot_fields(sim::Interfacer.SurfaceModelSimulation)
+    Plotting.debug_plot_fields(sim::Interfacer.AbstractSurfaceSimulation)
 
 Return the default fields to include in debug plots for a surface model.
 This should be extended for any atmosphere model, and any surface model
 that has additional fields to plot.
 """
-Plotting.debug_plot_fields(sim::Interfacer.SurfaceModelSimulation) =
+Plotting.debug_plot_fields(sim::Interfacer.AbstractSurfaceSimulation) =
     (:area_fraction, :surface_temperature)

--- a/src/Checkpointer.jl
+++ b/src/Checkpointer.jl
@@ -19,24 +19,24 @@ import JLD2
 export get_model_prog_state, checkpoint_model_state, checkpoint_sims, restore!
 
 """
-    get_model_prog_state(sim::Interfacer.ComponentModelSimulation)
+    get_model_prog_state(sim::Interfacer.AbstractComponentSimulation)
 
 Returns the model state of a simulation as a `ClimaCore.FieldVector`.
 This is a template function that should be implemented for each component model.
 """
-get_model_prog_state(sim::Interfacer.ComponentModelSimulation) = nothing
+get_model_prog_state(sim::Interfacer.AbstractComponentSimulation) = nothing
 
 """
-    get_model_cache(sim::Interfacer.ComponentModelSimulation)
+    get_model_cache(sim::Interfacer.AbstractComponentSimulation)
 
 Returns the model cache of a simulation.
 This is a template function that should be implemented for each component model.
 """
-get_model_cache(sim::Interfacer.ComponentModelSimulation) = nothing
+get_model_cache(sim::Interfacer.AbstractComponentSimulation) = nothing
 
 """
     checkpoint_model_state(
-        sim::Interfacer.ComponentModelSimulation,
+        sim::Interfacer.AbstractComponentSimulation,
         comms_ctx::ClimaComms.AbstractCommsContext,
         t::Int,
         prev_checkpoint_t::Int;
@@ -49,7 +49,7 @@ many checkpoint files in the output directory. A value of -1 for `prev_checkpoin
 is used to indicate that there is no previous checkpoint to remove.
 """
 function checkpoint_model_state(
-    sim::Interfacer.ComponentModelSimulation,
+    sim::Interfacer.AbstractComponentSimulation,
     comms_ctx::ClimaComms.AbstractCommsContext,
     t::Int,
     prev_checkpoint_t::Int;
@@ -74,7 +74,7 @@ end
 
 """
     checkpoint_model_cache(
-        sim::Interfacer.ComponentModelSimulation,
+        sim::Interfacer.AbstractComponentSimulation,
         comms_ctx::ClimaComms.AbstractCommsContext,
         t::Int,
         prev_checkpoint_t::Int;
@@ -91,7 +91,7 @@ many checkpoint files in the output directory. A value of -1 for `prev_checkpoin
 is used to indicate that there is no previous checkpoint to remove.
 """
 function checkpoint_model_cache(
-    sim::Interfacer.ComponentModelSimulation,
+    sim::Interfacer.AbstractComponentSimulation,
     comms_ctx::ClimaComms.AbstractCommsContext,
     t::Int,
     prev_checkpoint_t::Int;
@@ -116,16 +116,16 @@ function checkpoint_model_cache(
 end
 
 """
-    get_model_cache_to_checkpoint(sim::Interfacer.ComponentModelSimulation)
+    get_model_cache_to_checkpoint(sim::Interfacer.AbstractComponentSimulation)
 
 Prepare the cache for checkpointing by moving the entire cache to CPU.
 """
-function get_model_cache_to_checkpoint(sim::Interfacer.ComponentModelSimulation)
+function get_model_cache_to_checkpoint(sim::Interfacer.AbstractComponentSimulation)
     return CC.Adapt.adapt(Array, get_model_cache(sim))
 end
 
 """
-    get_model_cache_to_checkpoint(sim::Interfacer.AtmosModelSimulation)
+    get_model_cache_to_checkpoint(sim::Interfacer.AbstractAtmosSimulation)
 
 Prepare the atmos cache for checkpoint by selectively moving parts of the atmos
 cache to CPU instead of moving the entire atmos cache to CPU, resulting in a
@@ -156,7 +156,7 @@ A vector of objects from the cache. Elements may reference the same underlying
 data if they share object IDs. The order of the objects in the vector is
 determined by `CacheIterator`.
 """
-function get_model_cache_to_checkpoint(sim::Interfacer.AtmosModelSimulation)
+function get_model_cache_to_checkpoint(sim::Interfacer.AbstractAtmosSimulation)
     atmos_cache_itr = CacheIterator(sim)
     cache_vec = [] # Elements of the vector can be any type
     # Keep track of the object ID and its index in the vector while iterating
@@ -201,13 +201,13 @@ function get_model_cache_to_checkpoint(sim::Interfacer.AtmosModelSimulation)
 end
 
 """
-    restore_cache!(sim::Interfacer.ComponentModelSimulation, new_cache)
+    restore_cache!(sim::Interfacer.AbstractComponentSimulation, new_cache)
 
 Replace the cache in `sim` with `new_cache`.
 
 Component models can define new methods for this to change how cache is restored.
 """
-function restore_cache!(sim::Interfacer.ComponentModelSimulation, new_cache)
+function restore_cache!(sim::Interfacer.AbstractComponentSimulation, new_cache)
     return nothing
 end
 
@@ -708,7 +708,7 @@ is_leaf(
 is_leaf(::Any) = false
 
 """
-    CacheIterator(sim::Interfacer.ComponentModelSimulation)
+    CacheIterator(sim::Interfacer.AbstractComponentSimulation)
 
 Create an iterator over the cache in `sim` of objects that should be
 saved.
@@ -717,18 +717,18 @@ To use this constructor, the function `get_cache_ignore` must be implemented
 for `sim` which takes in `sim` and returns a set of symbols to ignore while
 iterating through the fields of the cache.
 """
-function CacheIterator(sim::Interfacer.ComponentModelSimulation)
+function CacheIterator(sim::Interfacer.AbstractComponentSimulation)
     cache = get_model_cache(sim)
     return CacheIterator(cache, get_cache_ignore(sim))
 end
 
 """
-    get_cache_ignore(::Interfacer.AtmosModelSimulation)
+    get_cache_ignore(::Interfacer.AbstractAtmosSimulation)
 
 Return a set of symbols that should be ignored when iterating the fields of the
 atmos cache. These fields will not be saved when checkpointing.
 """
-function get_cache_ignore(::Interfacer.AtmosModelSimulation)
+function get_cache_ignore(::Interfacer.AbstractAtmosSimulation)
     return Set([
         :rc,
         :params,
@@ -740,7 +740,7 @@ function get_cache_ignore(::Interfacer.AtmosModelSimulation)
     ])
 end
 
-function get_cache_ignore(::Interfacer.ComponentModelSimulation)
+function get_cache_ignore(::Interfacer.AbstractComponentSimulation)
     return error("List of symbols to ignore when iterating the fields of the
     cache is not supported for this model. Checkpoint by saving the entire
     cache instead or define get_cache_ignore to use CacheIterator.")

--- a/src/ConservationChecker.jl
+++ b/src/ConservationChecker.jl
@@ -92,7 +92,7 @@ function check_conservation!(
     # save surfaces
     for sim in model_sims
         sim_name = Symbol(Base.nameof(sim))
-        if sim isa Interfacer.AtmosModelSimulation
+        if sim isa Interfacer.AbstractAtmosSimulation
             radiative_energy_flux_toa =
                 Interfacer.get_field(sim, Val(:radiative_energy_flux_toa))
 
@@ -116,7 +116,7 @@ function check_conservation!(
 
             push!(previous, current)
             total += current + radiation_sources_accum
-        elseif sim isa Interfacer.SurfaceModelSimulation
+        elseif sim isa Interfacer.AbstractSurfaceSimulation
             # save surfaces
             area_fraction = Interfacer.get_field(sim, Val(:area_fraction))
             if isnothing(Interfacer.get_field(sim, Val(:energy)))
@@ -183,7 +183,7 @@ function check_conservation!(
     # save surfaces
     for sim in model_sims
         sim_name = Symbol(Base.nameof(sim))
-        if sim isa Interfacer.AtmosModelSimulation
+        if sim isa Interfacer.AbstractAtmosSimulation
 
             # save atmos
             previous = getproperty(ccs, sim_name)
@@ -195,7 +195,7 @@ function check_conservation!(
             end
             push!(previous, current)
 
-        elseif sim isa Interfacer.SurfaceModelSimulation
+        elseif sim isa Interfacer.AbstractSurfaceSimulation
             # save surfaces
             area_fraction = Interfacer.get_field(sim, Val(:area_fraction))
             if isnothing(Interfacer.get_field(sim, Val(:water)))

--- a/src/surface_stub.jl
+++ b/src/surface_stub.jl
@@ -13,7 +13,7 @@ contains the necessary fields for the simulation, at minimum the following:
     - `phase` (phase of the water used to calculate surface humidity)
     - `thermo_params` (thermodynamic parameters)
 """
-abstract type AbstractSurfaceStub <: SurfaceModelSimulation end
+abstract type AbstractSurfaceStub <: AbstractSurfaceSimulation end
 
 """
     SurfaceStub

--- a/test/checkpointer_tests.jl
+++ b/test/checkpointer_tests.jl
@@ -14,7 +14,7 @@ const space_checkpointer = CC.CommonSpaces.CubedSphereSpace(
     h_elem = 4,
 )
 
-struct DummySimulation{S} <: Interfacer.AtmosModelSimulation
+struct DummySimulation{S} <: Interfacer.AbstractAtmosSimulation
     state::S
 end
 Checkpointer.get_model_prog_state(sim::DummySimulation) = sim.state

--- a/test/conservation_checker_tests.jl
+++ b/test/conservation_checker_tests.jl
@@ -12,7 +12,7 @@ get_slab_energy(slab_sim, T_sfc) =
     slab_sim.integrator.p.params.ρ .* slab_sim.integrator.p.params.c .* T_sfc .*
     slab_sim.integrator.p.params.h
 
-struct TestAtmos{I} <: Interfacer.AtmosModelSimulation
+struct TestAtmos{I} <: Interfacer.AbstractAtmosSimulation
     i::I
 end
 Interfacer.get_field(s::TestAtmos, ::Val{:radiative_energy_flux_toa}) =
@@ -20,7 +20,7 @@ Interfacer.get_field(s::TestAtmos, ::Val{:radiative_energy_flux_toa}) =
 Interfacer.get_field(s::TestAtmos, ::Val{:water}) = s.i.water
 Interfacer.get_field(s::TestAtmos, ::Val{:energy}) = s.i.energy
 
-struct TestOcean{I} <: Interfacer.SurfaceModelSimulation
+struct TestOcean{I} <: Interfacer.AbstractSurfaceSimulation
     i::I
 end
 Interfacer.get_field(s::TestOcean, ::Val{:water}) = zeros(s.i.space)
@@ -29,7 +29,7 @@ Interfacer.get_field(s::TestOcean, ::Val{:energy}) =
 Interfacer.get_field(s::TestOcean, ::Val{:area_fraction}) =
     ones(s.i.space) .* CC.Spaces.undertype(s.i.space)(0.25)
 
-struct TestLand{I} <: Interfacer.SurfaceModelSimulation
+struct TestLand{I} <: Interfacer.AbstractSurfaceSimulation
     i::I
 end
 Interfacer.get_field(s::TestLand, ::Val{:energy}) = zeros(s.i.space)

--- a/test/field_exchanger_tests.jl
+++ b/test/field_exchanger_tests.jl
@@ -5,10 +5,10 @@ import Thermodynamics.Parameters as TDP
 import ClimaParams # to load TDP extension
 
 # surface field exchange tests
-struct TestSurfaceSimulation1{C} <: Interfacer.SurfaceModelSimulation
+struct TestSurfaceSimulation1{C} <: Interfacer.AbstractSurfaceSimulation
     cache_field::C
 end
-struct TestSurfaceSimulation2{C} <: Interfacer.SurfaceModelSimulation
+struct TestSurfaceSimulation2{C} <: Interfacer.AbstractSurfaceSimulation
     cache_field::C
 end
 
@@ -40,10 +40,10 @@ Interfacer.get_field(sim::TestSurfaceSimulation2, ::Val{:area_fraction}) =
 
 Interfacer.step!(::TestSurfaceSimulation1, _) = nothing
 
-struct TestSurfaceSimulationA <: Interfacer.SurfaceModelSimulation end
-struct TestSurfaceSimulationB <: Interfacer.SurfaceModelSimulation end
-struct TestSurfaceSimulationC <: Interfacer.SurfaceModelSimulation end
-struct TestSurfaceSimulationD <: Interfacer.SurfaceModelSimulation end
+struct TestSurfaceSimulationA <: Interfacer.AbstractSurfaceSimulation end
+struct TestSurfaceSimulationB <: Interfacer.AbstractSurfaceSimulation end
+struct TestSurfaceSimulationC <: Interfacer.AbstractSurfaceSimulation end
+struct TestSurfaceSimulationD <: Interfacer.AbstractSurfaceSimulation end
 
 # Initialize weights (fractions) and initial values (fields)
 Interfacer.get_field(::TestSurfaceSimulationA, ::Val{:random}) = 1.0
@@ -56,7 +56,7 @@ Interfacer.get_field(::TestSurfaceSimulationB, ::Val{:area_fraction}) = 0.5
 Interfacer.get_field(::TestSurfaceSimulationC, ::Val{:area_fraction}) = 2.0
 Interfacer.get_field(::TestSurfaceSimulationD, ::Val{:area_fraction}) = -10.0
 
-struct DummyStub{C} <: Interfacer.SurfaceModelSimulation
+struct DummyStub{C} <: Interfacer.AbstractSurfaceSimulation
     cache::C
 end
 Interfacer.get_field(sim::DummyStub, ::Val{:area_fraction}) = sim.cache.area_fraction
@@ -69,7 +69,7 @@ function Interfacer.update_field!(
     sim.cache.area_fraction .= field
 end
 # atmos sim
-struct TestAtmosSimulation{C} <: Interfacer.AtmosModelSimulation
+struct TestAtmosSimulation{C} <: Interfacer.AbstractAtmosSimulation
     cache::C
 end
 
@@ -125,7 +125,7 @@ FluxCalculator.update_turbulent_fluxes!(sim::TestAtmosSimulation, fields) = noth
 Interfacer.step!(sim::TestAtmosSimulation, t) = nothing
 
 #surface sim
-struct TestSurfaceSimulationLand{C} <: Interfacer.SurfaceModelSimulation
+struct TestSurfaceSimulationLand{C} <: Interfacer.AbstractSurfaceSimulation
     cache::C
 end
 function Interfacer.get_field(sim::TestSurfaceSimulationLand, ::Val{:area_fraction})

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -10,22 +10,22 @@ import SurfaceFluxes.UniversalFunctions as UF
 import ClimaCoupler: FieldExchanger, FluxCalculator, Interfacer
 
 # simple generic atmos model
-struct DummySimulation{S, C} <: Interfacer.AtmosModelSimulation
+struct DummySimulation{S, C} <: Interfacer.AbstractAtmosSimulation
     state::S
     cache::C
 end
 
-struct DummySimulation2{C} <: Interfacer.AtmosModelSimulation
+struct DummySimulation2{C} <: Interfacer.AbstractAtmosSimulation
     cache::C
 end
 
 # atmos sim object and extensions
-struct TestAtmos{P, D, I} <: Interfacer.AtmosModelSimulation
+struct TestAtmos{P, D, I} <: Interfacer.AbstractAtmosSimulation
     params::P
     domain::D
     integrator::I
 end
-struct TestAtmos2 <: Interfacer.AtmosModelSimulation end
+struct TestAtmos2 <: Interfacer.AbstractAtmosSimulation end
 
 Interfacer.get_field(sim::TestAtmos, ::Val{:air_temperature}) = sim.integrator.T
 Interfacer.get_field(sim::TestAtmos, ::Val{:specific_humidity}) = sim.integrator.q
@@ -64,7 +64,7 @@ function FluxCalculator.get_surface_params(sim::TestAtmos)
 end
 
 # ocean sim object and extensions
-struct TestOcean{M, I} <: Interfacer.SurfaceModelSimulation
+struct TestOcean{M, I} <: Interfacer.AbstractSurfaceSimulation
     model::M
     integrator::I
 end
@@ -85,7 +85,7 @@ function FluxCalculator.update_turbulent_fluxes!(sim::TestOcean, fields::NamedTu
 end
 
 # simple surface sim object and extensions
-struct DummySurfaceSimulation3{M, I} <: Interfacer.SurfaceModelSimulation
+struct DummySurfaceSimulation3{M, I} <: Interfacer.AbstractSurfaceSimulation
     model::M
     integrator::I
 end

--- a/test/interfacer_tests.jl
+++ b/test/interfacer_tests.jl
@@ -13,21 +13,22 @@ function Interfacer.remap(::Nothing, field)
 end
 
 # test for a simple generic surface model
-struct DummySimulation{S} <: Interfacer.SeaIceModelSimulation
+struct DummySimulation{S} <: Interfacer.AbstractSeaIceSimulation
     space::S
 end
-struct DummySimulation2{S} <: Interfacer.OceanModelSimulation
+struct DummySimulation2{S} <: Interfacer.AbstractOceanSimulation
     space::S
 end
-struct DummySimulation3{S} <: Interfacer.LandModelSimulation
+struct DummySimulation3{S} <: Interfacer.AbstractLandSimulation
     space::S
 end
-struct DummySimulation4{S} <: Interfacer.AtmosModelSimulation
+struct DummySimulation4{S} <: Interfacer.AbstractAtmosSimulation
     space::S
 end
 
-Interfacer.get_field(sim::Interfacer.SurfaceModelSimulation, ::Val{:var}) = ones(sim.space)
-Interfacer.get_field(sim::Interfacer.SurfaceModelSimulation, ::Val{:var_float}) =
+Interfacer.get_field(sim::Interfacer.AbstractSurfaceSimulation, ::Val{:var}) =
+    ones(sim.space)
+Interfacer.get_field(sim::Interfacer.AbstractSurfaceSimulation, ::Val{:var_float}) =
     CC.Spaces.undertype(sim.space)(2)
 
 context = ClimaComms.context()
@@ -166,7 +167,7 @@ end
     )
 end
 
-@testset "undefined get_field for SurfaceModelSimulation" begin
+@testset "undefined get_field for AbstractSurfaceSimulation" begin
     FT = Float32
     space = CC.CommonSpaces.CubedSphereSpace(
         FT;
@@ -194,7 +195,7 @@ end
     end
 end
 
-@testset "undefined get_field for AtmosModelSimulation" begin
+@testset "undefined get_field for AbstractAtmosSimulation" begin
     FT = Float32
     space = CC.CommonSpaces.CubedSphereSpace(
         FT;
@@ -225,7 +226,7 @@ end
     end
 end
 
-@testset "update_field! warnings for SurfaceModelSimulation" begin
+@testset "update_field! warnings for AbstractSurfaceSimulation" begin
     FT = Float32
     space = CC.CommonSpaces.CubedSphereSpace(
         FT;
@@ -259,7 +260,7 @@ end
     end
 end
 
-@testset "undefined update_field! warnings for AtmosModelSimulation" begin
+@testset "undefined update_field! warnings for AbstractAtmosSimulation" begin
     FT = Float32
     space = CC.CommonSpaces.CubedSphereSpace(
         FT;


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
#1683 adds generic component constructors with names like `LandSimulation`. This PR renames abstract types to make it more clear they're abstract types and to distinguish from the new constructors. This is only renaming so there shouldn't be any results changes.

## Content
- ComponentModelSimulation -> AbstractComponentSimulation
- SurfaceModelSimulation -> AbstractSurfaceSimulation
- LandModelSimulation -> AbstractLandSimulation
- OceanModelSimulation -> AbstractOceanSimulation
- SeaIceModelSimulation -> AbstractSeaIceSimulation
- AtmosModelSimulation -> AbstractAtmosSimulation
- ImplicitFluxModelSimulation -> AbstractImplicitFluxSimulation


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
