### PR TITLE
COARE3 Roughness parameters over oceans

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ ClimaCoupler.jl Release Notes
 
 ### ClimaCoupler features
 
+#### Enable COARE3 roughness parameterization PR[#1689](https://github.com/CliMA/ClimaCoupler.jl/pull/1689) Allows :constant (land, ice) or :coare3 (ocean) aerodynamic roughness parameterization. 
+
 #### Rename abstract component types PR[#1688](https://github.com/CliMA/ClimaCoupler.jl/pull/1688)
 To follow abstract type naming convention. For example, `XModelSimulation` is now
 `AbstractXSimulation`.

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -279,10 +279,15 @@ properties needed by a component model.
 For some quantities, default `get_field` functions are provided, which may be
 overwritten or used as-is. These currently include the following:
 
-| Coupler name  | Description                                                               | Units | Default value |
-|---------------|---------------------------------------------------------------------------|-------|---------------|
-| `emissivity`  | measure of how much energy a surface radiates                             |       |             1 |
-| `height_disp` | displacement height relative to the surface                               | m     |             0 |
+| Coupler name             | Description                                                                 | Units | Default value |
+|--------------------------|-----------------------------------------------------------------------------|-------|---------------|
+| `emissivity`             | measure of how much energy a surface radiates                              |       |             1 |
+| `height_disp`            | displacement height relative to the surface                                | m     |             0 |
+| `roughness_model`        | roughness parameterization for surface flux calculations                    |       | `:constant`   |
+| `coare3_roughness_params`| COARE3 roughness params Field on exchange grid (when `roughness_model` is `:coare3`) |       | -             |
+
+!!! note "Roughness model option"
+    Default is `:constant`. Use `:coare3` for dynamic ocean roughness; then provide `coare3_roughness_params` via `get_field`.
 
 
 - `update_turbulent_fluxes!(::AbstractComponentSimulation, fields::NamedTuple)`:

--- a/experiments/ClimaEarth/components/land/climaland_bucket.jl
+++ b/experiments/ClimaEarth/components/land/climaland_bucket.jl
@@ -289,6 +289,7 @@ Interfacer.get_field(sim::BucketSimulation, ::Val{:surface_diffuse_albedo}) =
     CL.surface_albedo(sim.model, sim.integrator.u, sim.integrator.p)
 Interfacer.get_field(sim::BucketSimulation, ::Val{:surface_temperature}) =
     CL.component_temperature(sim.model, sim.integrator.u, sim.integrator.p)
+Interfacer.get_field(sim::BucketSimulation, ::Val{:roughness_model}) = :constant
 
 """
     Interfacer.get_field(sim::BucketSimulation, ::Val{:energy})

--- a/experiments/ClimaEarth/components/land/climaland_integrated.jl
+++ b/experiments/ClimaEarth/components/land/climaland_integrated.jl
@@ -380,6 +380,7 @@ Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:water}) =
     CL.total_water(sim.integrator.u, sim.integrator.p)
 Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:surface_temperature}) =
     sim.integrator.p.T_sfc
+Interfacer.get_field(sim::ClimaLandSimulation, ::Val{:roughness_model}) = :constant
 
 # Update fields stored in land drivers
 function Interfacer.update_field!(sim::ClimaLandSimulation, ::Val{:diffuse_fraction}, field)

--- a/experiments/ClimaEarth/components/ocean/clima_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/clima_seaice.jl
@@ -286,6 +286,7 @@ Interfacer.get_field(sim::ClimaSeaIceSimulation, ::Val{:ice_concentration}) =
     sim.ice.model.ice_concentration
 
 # TODO better values for this
+Interfacer.get_field(sim::ClimaSeaIceSimulation, ::Val{:roughness_model}) = :constant
 Interfacer.get_field(sim::ClimaSeaIceSimulation, ::Val{:roughness_buoyancy}) =
     eltype(sim.ice.model)(5.8e-5)
 Interfacer.get_field(sim::ClimaSeaIceSimulation, ::Val{:roughness_momentum}) =

--- a/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
+++ b/experiments/ClimaEarth/components/ocean/prescr_seaice.jl
@@ -248,6 +248,7 @@ Interfacer.get_field(
     sim::PrescribedIceSimulation,
     ::Union{Val{:surface_direct_albedo}, Val{:surface_diffuse_albedo}},
 ) = sim.integrator.p.params.α
+Interfacer.get_field(sim::PrescribedIceSimulation, ::Val{:roughness_model}) = :constant
 Interfacer.get_field(sim::PrescribedIceSimulation, ::Val{:surface_temperature}) =
     ice_surface_temperature.(sim.integrator.u.T_bulk, sim.integrator.p.params.T_base)
 

--- a/experiments/ClimaEarth/test/component_model_tests/slab_ocean_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/slab_ocean_tests.jl
@@ -2,6 +2,7 @@ import Test: @test, @testset
 import ClimaCore as CC
 import ClimaParams as CP
 import ClimaCoupler
+import SurfaceFluxes as SF
 
 include(joinpath("..", "..", "components", "ocean", "slab_ocean.jl"))
 
@@ -24,9 +25,13 @@ for FT in (Float32, Float64)
             state_field1 = CC.Fields.ones(boundary_space),
             state_field2 = CC.Fields.zeros(boundary_space),
         )
+        coare3_roughness_params =
+            CC.Fields.Field(SF.COARE3RoughnessParams{FT}, boundary_space)
+        coare3_roughness_params .= SF.COARE3RoughnessParams{FT}()
         p = (;
             cache_field = CC.Fields.zeros(boundary_space),
             dss_buffer = CC.Spaces.create_dss_buffer(u),
+            coare3_roughness_params,
         )
         integrator = (; u, p)
         sim = SlabOceanSimulation(nothing, integrator)

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -266,6 +266,21 @@ get_field(sim::AbstractSurfaceSimulation, ::Val{:emissivity}) =
 get_field(sim::AbstractSurfaceSimulation, ::Val{:height_disp}) =
     convert(eltype(sim.integrator.u), 0.0)
 
+"""
+    get_field(sim::AbstractSurfaceSimulation, ::Val{:roughness_model})
+
+Return the roughness model to be used for surface flux calculations.
+Returns `:constant` by default. Ocean models should override this to return
+`:coare3` to use COARE3 roughness parameterization, which accounts for the
+dynamic response of ocean surface roughness to wind speed and wave state.
+The `:constant` roughness model uses fixed roughness lengths for momentum
+and buoyancy specified by the component model.
+
+This ensures COARE3 is applied over ocean surfaces where the area_fraction > 0,
+while land and sea ice surfaces use constant roughness parameterization.
+"""
+get_field(::AbstractSurfaceSimulation, ::Val{:roughness_model}) = :constant
+
 
 """
     get_field(target_space, sim, quantity)

--- a/src/surface_stub.jl
+++ b/src/surface_stub.jl
@@ -40,6 +40,19 @@ get_field(sim::AbstractSurfaceStub, ::Val{:surface_diffuse_albedo}) = sim.cache.
 get_field(sim::AbstractSurfaceStub, ::Val{:surface_temperature}) = sim.cache.T_sfc
 
 """
+    get_field(::AbstractSurfaceStub, ::Val{:coare3_roughness_params})
+
+Return cached COARE3 roughness params when present in the stub's cache (e.g. PrescribedOceanSimulation).
+"""
+function get_field(sim::AbstractSurfaceStub, ::Val{:coare3_roughness_params})
+    if :coare3_roughness_params in propertynames(sim.cache)
+        return getproperty(sim.cache, :coare3_roughness_params)
+    else
+        return get_field_error(sim, Val(:coare3_roughness_params))
+    end
+end
+
+"""
     update_field!(sim::AbstractSurfaceStub, ::Val{:area_fraction}, field::CC.Fields.Field)
 
 Updates the specified value in the cache of `SurfaceStub`.


### PR DESCRIPTION
Modifies FluxCalculator so that `roughness_model` can be passed and conditionally
assigned based on the surface type. 

Low-res build test: https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/776

Closes #1687 
