### PR TITLE
Fix bug with missing imports

### DIFF
--- a/ext/ClimaCouplerMakieExt/leaderboard/data_sources.jl
+++ b/ext/ClimaCouplerMakieExt/leaderboard/data_sources.jl
@@ -1,5 +1,6 @@
 import ClimaAnalysis
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
+import ClimaDiagnostics as CD
 
 """
     get_compare_vars_biases_groups()
@@ -156,7 +157,7 @@ function get_sim_var_in_pfull_dict(diagnostics_folder_path)
                     )
                     # For ClimaDiagnostics v0.3 and later, the dates are saved at
                     # the start of the reduction period
-                    pkgversion(ClimaDiagnostics) < v"0.3" && (
+                    pkgversion(CD) < v"0.3" && (
                         sim_in_pfull_var =
                             ClimaAnalysis.shift_to_start_of_previous_month(
                                 sim_in_pfull_var,

--- a/src/SimOutput/sim_obs_data.jl
+++ b/src/SimOutput/sim_obs_data.jl
@@ -81,7 +81,7 @@ function get_sim_var_dict(diagnostics_folder_path)
                 )
                 # For ClimaDiagnostics v0.3 and later, the dates are saved at
                 # the start of the reduction period
-                pkgversion(ClimaDiagnostics) < v"0.3" && (
+                pkgversion(CD) < v"0.3" && (
                     sim_var = ClimaAnalysis.shift_to_start_of_previous_month(sim_var)
                 )
                 return sim_var
@@ -100,7 +100,7 @@ function get_sim_var_dict(diagnostics_folder_path)
                     )
                     # For ClimaDiagnostics v0.3 and later, the dates are saved at
                     # the start of the reduction period
-                    pkgversion(ClimaDiagnostics) < v"0.3" && (
+                    pkgversion(CD) < v"0.3" && (
                         sim_var =
                             ClimaAnalysis.shift_to_start_of_previous_month(sim_var)
                     )


### PR DESCRIPTION
Nightly AMIP is currently failing because `ClimaDiagnostics` is not imported when using `pkgversion` to check the version of ClimaDiagnostics. This PR adds the necessary imports and rename `ClimaDiagnostics` to `CD` in some cases.