### PR TITLE
Use ERA5 for default atmosphere initial conditions in Coarse AMIP; Update deps

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -48,3 +48,6 @@ git-tree-sha1 = "7f7b6d4ae6055c4c2b6a6dfba5be8b4e6ca1b0be"
     [[historical_sst_sic_lowres.download]]
     sha256 = "b68c0ce6ea682c38e29cb87c9c6ced6736ecac32d0d32dbaba78beb66046a06c"
     url = "https://caltech.box.com/shared/static/ufnesb00zkvlc3sxzhnnmqc3zbatxkb9.gz"
+
+[era5_inst_model_levels]
+git-tree-sha1 = "8aae2d7330f90a029a4891be658a691e4e3362dc"

--- a/config/nightly_configs/amip_coarse_diagedmf.yml
+++ b/config/nightly_configs/amip_coarse_diagedmf.yml
@@ -15,6 +15,7 @@ netcdf_output_at_levels: true
 output_default_diagnostics: true
 radiation_reset_rng_seed: true
 start_date: "20100101"
+initial_condition: "AMIPFromERA5"
 surface_setup: "PrescribedSurface"
 t_end: "465days"
 topo_smoothing: true

--- a/experiments/ClimaCore/Manifest-v1.11.toml
+++ b/experiments/ClimaCore/Manifest-v1.11.toml
@@ -367,9 +367,9 @@ version = "0.5.20"
 
 [[deps.ClimaAtmos]]
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Flux", "ForwardDiff", "Insolation", "Interpolations", "JLD2", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SciMLBase", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
-git-tree-sha1 = "69332bb7b1c2d4d1809fecaba8f6a1abdb774984"
+git-tree-sha1 = "2211b885dce3957d316bfcfe0061d96f08180ee6"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.35.1"
+version = "0.35.2"
 
 [[deps.ClimaComms]]
 deps = ["Adapt", "Logging", "LoggingExtras"]

--- a/experiments/ClimaEarth/Artifacts.toml
+++ b/experiments/ClimaEarth/Artifacts.toml
@@ -42,3 +42,6 @@ git-tree-sha1 = "6cddb07eeee2dd46dc5a19e9b2f706302ddba2c9"
     [[era5_monthly_averages_surface_single_level_1979_2024.download]]
     sha256 = "46b422722d98c89c6bc0b8641bff259db1caee253f45389ddf9eb9c2d31ed605"
     url = "https://caltech.box.com/shared/static/jbgtyt6oq9lxvk8il5zzck6k581q7f3k.gz"
+
+[era5_inst_model_levels]
+git-tree-sha1 = "8aae2d7330f90a029a4891be658a691e4e3362dc"

--- a/experiments/ClimaEarth/Manifest-v1.11.toml
+++ b/experiments/ClimaEarth/Manifest-v1.11.toml
@@ -447,9 +447,9 @@ weakdeps = ["GeoMakie", "Makie"]
 
 [[deps.ClimaAtmos]]
 deps = ["Adapt", "ArgParse", "Artifacts", "AtmosphericProfilesLibrary", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaInterpolations", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "CloudMicrophysics", "Dates", "Flux", "ForwardDiff", "Insolation", "Interpolations", "JLD2", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "Logging", "NCDatasets", "NVTX", "NullBroadcasts", "RRTMGP", "Random", "SciMLBase", "SparseMatrixColorings", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "UnrolledUtilities", "YAML"]
-git-tree-sha1 = "69332bb7b1c2d4d1809fecaba8f6a1abdb774984"
+git-tree-sha1 = "2211b885dce3957d316bfcfe0061d96f08180ee6"
 uuid = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
-version = "0.35.1"
+version = "0.35.2"
 
 [[deps.ClimaCalibrate]]
 deps = ["Dates", "Distributed", "Distributions", "EnsembleKalmanProcesses", "JLD2", "Logging", "Random", "TOML", "YAML"]


### PR DESCRIPTION
Modify atmosphere IC to use ERA5 IC for default start date (Jan 1, 2010). Update dependencies. 

