### PR TITLE
add simple ocean option and use Float32 for CMIP in CI

### DIFF
--- a/config/ci_configs/cmip_oceananigans_climaseaice.yml
+++ b/config/ci_configs/cmip_oceananigans_climaseaice.yml
@@ -19,6 +19,7 @@ ocean_model: "oceananigans"
 output_default_diagnostics: true
 radiation_reset_rng_seed: true
 rayleigh_sponge: true
+simple_ocean: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "1days"

--- a/config/ci_configs/cmip_oceananigans_climaseaice_bucket.yml
+++ b/config/ci_configs/cmip_oceananigans_climaseaice_bucket.yml
@@ -18,6 +18,7 @@ ocean_model: "oceananigans"
 output_default_diagnostics: true
 radiation_reset_rng_seed: true
 rayleigh_sponge: true
+simple_ocean: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "1days"

--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -1,4 +1,4 @@
-FLOAT_TYPE: "Float32"
+FLOAT_TYPE: "Float64"
 atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 bucket_albedo_type: "map_temporal"
 checkpoint_dt: "720hours"

--- a/config/longrun_configs/cmip_edonly_land.yml
+++ b/config/longrun_configs/cmip_edonly_land.yml
@@ -1,4 +1,4 @@
-FLOAT_TYPE: "Float32"
+FLOAT_TYPE: "Float64"
 atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 checkpoint_dt: "720hours"
 dt_atmos: "120secs" # 2 minutes

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -114,6 +114,8 @@ function CoupledSimulation(config_dict::AbstractDict)
         Δt_cpl,
         component_dt_dict,
         share_surface_space,
+        nh_poly,
+        h_elem,
         saveat,
         checkpoint_dt,
         detect_restart_files,
@@ -135,6 +137,7 @@ function CoupledSimulation(config_dict::AbstractDict)
         parameter_files,
         era5_initial_condition_dir,
         ocean_model,
+        simple_ocean,
         ice_model,
         land_fraction_source,
         binary_area_fraction,
@@ -228,8 +231,7 @@ function CoupledSimulation(config_dict::AbstractDict)
     if share_surface_space
         boundary_space = CC.Spaces.horizontal_space(atmos_sim.domain.face_space)
     else
-        h_elem = config_dict["h_elem"]
-        n_quad_points = 4
+        n_quad_points = nh_poly + 1
         radius = coupled_param_dict["planet_radius"] # in meters
         boundary_space = CC.CommonSpaces.CubedSphereSpace(FT; radius, n_quad_points, h_elem)
     end
@@ -324,7 +326,7 @@ function CoupledSimulation(config_dict::AbstractDict)
         boundary_space,
         # Arguments used by Oceananigans
         output_dir = dir_paths.ocean_output_dir,
-        ice_model,
+        simple_ocean,
         # Arguments used by prescribed ocean
         sst_path = subseasonal_sst,
         # Arguments used by slab ocean

--- a/src/Input.jl
+++ b/src/Input.jl
@@ -120,6 +120,10 @@ function argparse_settings()
         help = "Number of horizontal elements to use for the boundary space [16 (default)]"
         arg_type = Int
         default = 16
+        "--nh_poly"
+        help = "Polynomial order to use for the boundary space [3 (default)]"
+        arg_type = Int
+        default = 3
         "--share_surface_space"
         help = "Boolean flag indicating whether to share the surface space between the surface models, atmosphere, and boundary [`true` (default), `false`]"
         arg_type = Bool
@@ -229,6 +233,10 @@ function argparse_settings()
         help = "Ocean model to use. [`prescribed` (default), `oceananigans`, `slab`, `nothing`]"
         arg_type = String
         default = "prescribed"
+        "--simple_ocean"
+        help = "Boolean flag indicating whether to use a simpler ocean model setup with Oceananigans [`false` (default), `true`]"
+        arg_type = Bool
+        default = false
         # Ice model specific
         "--ice_model"
         help = "Sea ice model to use. [`prescribed` (default), `clima_seaice`, `nothing`]"
@@ -384,6 +392,8 @@ function get_coupler_args(config_dict::Dict)
 
     # Space information
     share_surface_space = config_dict["share_surface_space"]
+    nh_poly = config_dict["nh_poly"]
+    h_elem = config_dict["h_elem"]
 
     # Checkpointing information
     checkpoint_dt = config_dict["checkpoint_dt"]
@@ -424,6 +434,7 @@ function get_coupler_args(config_dict::Dict)
 
     # Ocean model-specific information
     ocean_model = Val(Symbol(config_dict["ocean_model"]))
+    simple_ocean = config_dict["simple_ocean"]
 
     # Ice model-specific information
     ice_model = Val(Symbol(config_dict["ice_model"]))
@@ -449,6 +460,8 @@ function get_coupler_args(config_dict::Dict)
         Δt_cpl,
         component_dt_dict,
         share_surface_space,
+        nh_poly,
+        h_elem,
         saveat,
         checkpoint_dt,
         detect_restart_files,
@@ -472,6 +485,7 @@ function get_coupler_args(config_dict::Dict)
         parameter_files,
         era5_initial_condition_dir,
         ocean_model,
+        simple_ocean,
         ice_model,
         land_fraction_source,
         binary_area_fraction,

--- a/test/input_tests.jl
+++ b/test/input_tests.jl
@@ -68,6 +68,8 @@ end
         "dt_cpl" => "400secs",
         "dt" => "400secs",
         "share_surface_space" => true,
+        "nh_poly" => 2,
+        "h_elem" => 8,
         "checkpoint_dt" => "90days",
         "detect_restart_files" => false,
         "restart_dir" => nothing,
@@ -90,6 +92,7 @@ end
         "era5_initial_condition_dir" => nothing,
         "ocean_model" => "prescribed",
         "ice_model" => "prescribed",
+        "simple_ocean" => false,
         "land_fraction_source" => "etopo",
         "binary_area_fraction" => true,
         "component_dt_dict" => Dict(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
updated from #1679

I'm planning to split that PR into two pieces, this PR to add the simple ocean option and use Float32 for regular CI, and another to update to the TripolarGrid and conservative regridding. I'd rather do this than rebase because it became pretty large and the CMIP code has been moved into an extension.

## Content
- [x] update to ClimaSeaIce 0.4.3 so we can correctly use Float32 in CMIP
- [x] use Float64 for CMIP longruns
- [x] add `simple_ocean` setup and use it for short CI runs
- [x] make non-simple ocean setup more complex

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
