### PR TITLE
use default hyperdiffusion for wxquest

### DIFF
--- a/config/atmos_configs/climaatmos_wx_diagedmf.yml
+++ b/config/atmos_configs/climaatmos_wx_diagedmf.yml
@@ -7,7 +7,6 @@ topo_smoothing: true
 topography: "Earth"
 rayleigh_sponge: true
 viscous_sponge: true
-hyperdiff: ClimaHyperdiffusion
 divergence_damping_factor: 50.0
 scalar_hyperdiffusion_coefficient: 0.929738
 vorticity_hyperdiffusion_coefficient: 0.1857

--- a/config/atmos_configs/climaatmos_wx_progedmf.yml
+++ b/config/atmos_configs/climaatmos_wx_progedmf.yml
@@ -7,7 +7,6 @@ topo_smoothing: true
 topography: "Earth"
 rayleigh_sponge: true
 viscous_sponge: true
-hyperdiff: ClimaHyperdiffusion
 divergence_damping_factor: 50.0
 scalar_hyperdiffusion_coefficient: 0.929738
 vorticity_hyperdiffusion_coefficient: 0.1857


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In ClimaAtmos v0.35.2, `ClimaHyperdiffusion` was renamed to `Hyperdiffusion`. These are both the default options, so this PR just removes `hyperdiff` from the configs it appears in. This should not be behavior-changing and will work with ClimaAtmos < 0.35.2 and 0.35.2.
