### PR TITLE
Use spatially varying canopy height

### DIFF
--- a/experiments/ClimaEarth/components/land/climaland_integrated.jl
+++ b/experiments/ClimaEarth/components/land/climaland_integrated.jl
@@ -161,6 +161,15 @@ function ClimaLandSimulation(
     # Use the soil moisture stress function based on soil moisture only
     soil_moisture_stress = CL.Canopy.PiecewiseMoistureStressModel{FT}(domain, toml_dict)
     surface_domain = CL.Domains.obtain_surface_domain(domain)
+    biomass = CL.Canopy.PrescribedBiomassModel{FT}(
+        domain,
+        LAI,
+        toml_dict;
+        height = CL.Canopy.clm_canopy_height(
+            domain.space.surface;
+            max_height = minimum(atmos_h) * FT(0.9),
+        ),
+    )
     canopy = CL.Canopy.CanopyModel{FT}(
         surface_domain,
         canopy_forcing,
@@ -170,6 +179,7 @@ function ClimaLandSimulation(
         photosynthesis,
         conductance,
         soil_moisture_stress,
+        biomass,
     )
 
     # Snow model setup


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
To align with ClimaLand and default parameters, use spatially varying canopy height

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
