### PR TITLE
Add ClimaCouplerClimaAtmosExt extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,6 +40,7 @@ Poppler_jll = "759029c8-65f6-5f13-b93f-2d7e0a4cb77c"
 Printf = "366bfd08-7218-5ad0-9036-d27ba1f5fe54"
 
 [extensions]
+ClimaCouplerClimaAtmosExt = ["ClimaAtmos"]
 ClimaCouplerCMIPExt = ["ClimaOcean", "ClimaSeaIce", "KernelAbstractions", "Oceananigans"]
 ClimaCouplerClimaLandExt = ["ClimaLand", "NCDatasets"]
 ClimaCouplerMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Poppler_jll", "Printf"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+ClimaAtmos = "b2c96348-7fb7-4fe0-8da9-78d88439e717"
 ClimaCoreMakie = "908f55d8-4145-4867-9c14-5dad1a479e4d"
 ClimaCoupler = "4ade58fe-a8da-486c-bd89-46df092ec0c7"
 ClimaLand = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,8 @@ import CairoMakie, ClimaCoreMakie, GeoMakie, Makie, Poppler_jll, Printf, Oceanan
 import ClimaOcean, ClimaSeaIce, KernelAbstractions
 # Import packages for ClimaCouplerClimaLandExt
 import ClimaLand, NCDatasets
+# Import packages for ClimaCouplerClimaAtmosExt
+import ClimaAtmos
 
 const COUPLER_DIR = joinpath(@__DIR__, "..")
 const EXPERIMENTS_DIR = joinpath(@__DIR__, "..", "experiments")
@@ -104,6 +106,7 @@ makedocs(
         Base.get_extension(ClimaCoupler, :ClimaCouplerOceananigansMakieExt),
         Base.get_extension(ClimaCoupler, :ClimaCouplerCMIPExt),
         Base.get_extension(ClimaCoupler, :ClimaCouplerClimaLandExt),
+        Base.get_extension(ClimaCoupler, :ClimaCouplerClimaAtmosExt),
     ],
     authors = "Climate Modelling Alliance",
     sitename = "ClimaCoupler.jl",

--- a/experiments/ClimaCore/Manifest-v1.11.toml
+++ b/experiments/ClimaCore/Manifest-v1.11.toml
@@ -414,6 +414,7 @@ version = "0.1.2"
 
     [deps.ClimaCoupler.extensions]
     ClimaCouplerCMIPExt = ["ClimaOcean", "ClimaSeaIce", "KernelAbstractions", "Oceananigans"]
+    ClimaCouplerClimaAtmosExt = ["ClimaAtmos"]
     ClimaCouplerClimaLandExt = ["ClimaLand", "NCDatasets"]
     ClimaCouplerMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Poppler_jll", "Printf"]
     ClimaCouplerOceananigansMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Oceananigans", "Poppler_jll", "Printf"]

--- a/experiments/ClimaCore/Manifest.toml
+++ b/experiments/ClimaCore/Manifest.toml
@@ -411,6 +411,7 @@ version = "0.1.2"
 
     [deps.ClimaCoupler.extensions]
     ClimaCouplerCMIPExt = ["ClimaOcean", "ClimaSeaIce", "KernelAbstractions", "Oceananigans"]
+    ClimaCouplerClimaAtmosExt = ["ClimaAtmos"]
     ClimaCouplerClimaLandExt = ["ClimaLand", "NCDatasets"]
     ClimaCouplerMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Poppler_jll", "Printf"]
     ClimaCouplerOceananigansMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Oceananigans", "Poppler_jll", "Printf"]

--- a/experiments/ClimaEarth/Manifest-v1.11.toml
+++ b/experiments/ClimaEarth/Manifest-v1.11.toml
@@ -505,6 +505,7 @@ weakdeps = ["CairoMakie", "ClimaCoreMakie", "ClimaLand", "ClimaOcean", "ClimaSea
 
     [deps.ClimaCoupler.extensions]
     ClimaCouplerCMIPExt = ["ClimaOcean", "ClimaSeaIce", "KernelAbstractions", "Oceananigans"]
+    ClimaCouplerClimaAtmosExt = ["ClimaAtmos"]
     ClimaCouplerClimaLandExt = ["ClimaLand", "NCDatasets"]
     ClimaCouplerMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Poppler_jll", "Printf"]
     ClimaCouplerOceananigansMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Oceananigans", "Poppler_jll", "Printf"]

--- a/experiments/ClimaEarth/Manifest.toml
+++ b/experiments/ClimaEarth/Manifest.toml
@@ -502,6 +502,7 @@ weakdeps = ["CairoMakie", "ClimaCoreMakie", "ClimaLand", "ClimaOcean", "ClimaSea
 
     [deps.ClimaCoupler.extensions]
     ClimaCouplerCMIPExt = ["ClimaOcean", "ClimaSeaIce", "KernelAbstractions", "Oceananigans"]
+    ClimaCouplerClimaAtmosExt = ["ClimaAtmos"]
     ClimaCouplerClimaLandExt = ["ClimaLand", "NCDatasets"]
     ClimaCouplerMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Poppler_jll", "Printf"]
     ClimaCouplerOceananigansMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Oceananigans", "Poppler_jll", "Printf"]

--- a/experiments/ClimaEarth/setup_run.jl
+++ b/experiments/ClimaEarth/setup_run.jl
@@ -60,19 +60,11 @@ using Makie, GeoMakie, CairoMakie, ClimaCoreMakie, NCDatasets, Poppler_jll
 # Note we only need these if running CMIP, but for now we share one environment for all experiments
 import Oceananigans, ClimaOcean, ClimaSeaIce, KernelAbstractions
 
-#  Trigger ClimaCouplerClimaLandExt extension
+# Trigger ClimaCouplerClimaLandExt extension
 import ClimaLand, NCDatasets
 
-pkg_dir = pkgdir(ClimaCoupler)
-
-#=
-### Helper Functions
-These will be eventually moved to their respective component model and utility packages, and so they should not
-contain any internals of the ClimaCoupler source code, except extensions to the Interfacer functions.
-=#
-
-## helpers for component models
-include("components/atmosphere/climaatmos.jl")
+# Trigger ClimaCouplerClimaAtmosExt
+import ClimaAtmos
 
 #=
 ### Configuration Dictionaries
@@ -160,43 +152,12 @@ function CoupledSimulation(config_dict::AbstractDict)
         comms_ctx = comms_ctx,
     )
 
-    ## get component model dictionaries (if applicable)
-    ## Note this step must come after parsing the coupler config dictionary, since
-    ##  some parameters are passed from the coupler config to the component model configs
-    atmos_config_dict = get_atmos_config_dict(
-        config_dict,
-        dir_paths.atmos_output_dir,
-        coupled_param_dict,
-        comms_ctx,
-    )
-
     ## set unique random seed if desired, otherwise use default
     Random.seed!(random_seed)
     @info "Random seed set to $(random_seed)"
 
-    if detect_restart_files
-        isnothing(restart_t) &&
-            (restart_t = Checkpointer.t_start_from_checkpoint(dir_paths.checkpoints_dir))
-        isnothing(restart_dir) && (restart_dir = dir_paths.checkpoints_dir)
-    end
-    should_restart = !isnothing(restart_t) && !isnothing(restart_dir)
-    if should_restart
-        if t_start isa ITime
-            t_start, _ = promote(ITime(restart_t), t_start)
-        else
-            t_start = restart_t
-        end
-
-        # We only support a round number of seconds
-        isinteger(float(t_start)) ||
-            error("Cannot restart from a non integer number of seconds")
-        t_start_int = Int(float(t_start))
-        atmos_config_dict.parsed_args["t_start"] = "$(t_start_int)secs"
-
-        @info "Starting from t_start $(t_start)"
-    end
-
     tspan = (t_start, t_end)
+    @info "Starting from t_start $(t_start)"
 
     #=
     ## Component Model Initialization
@@ -210,8 +171,15 @@ function CoupledSimulation(config_dict::AbstractDict)
     =#
 
     ## init atmos model component
-    atmos_sim =
-        Interfacer.AtmosSimulation(Val(:climaatmos); atmos_config = atmos_config_dict)
+    ## Note this step must come after parsing the coupler config dictionary, since
+    ## some parameters are passed from the coupler config to the component model configs
+    atmos_sim = Interfacer.AtmosSimulation(
+        Val(:climaatmos);
+        config_dict,
+        atmos_output_dir = dir_paths.atmos_output_dir,
+        coupled_param_dict,
+        comms_ctx,
+    )
 
     #=
     ### Boundary Space
@@ -471,6 +439,12 @@ function CoupledSimulation(config_dict::AbstractDict)
     When the caches are not read from the restart file, we have to perform the initial component
     model exchange so that `set_caches!` can be called to initialize the caches.
     =#
+    if detect_restart_files
+        isnothing(restart_t) &&
+            (restart_t = Checkpointer.t_start_from_checkpoint(dir_paths.checkpoints_dir))
+        isnothing(restart_dir) && (restart_dir = dir_paths.checkpoints_dir)
+    end
+    should_restart = !isnothing(restart_t) && !isnothing(restart_dir)
     should_restart && Checkpointer.restart!(cs, restart_dir, restart_t, restart_cache)
 
     # Make sure surface model area fractions sum to 1 everywhere.

--- a/experiments/ClimaEarth/test/component_model_tests/climaatmos_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/climaatmos_tests.jl
@@ -2,7 +2,11 @@ import Test: @test, @testset
 import ClimaCore as CC
 import ClimaCoupler
 
-include(joinpath("..", "..", "components", "atmosphere", "climaatmos.jl"))
+import ClimaAtmos
+import ClimaParams as CP
+
+# Needed to construct ClimaAtmosSimulation
+ClimaAtmosExt = Base.get_extension(ClimaCoupler, :ClimaCouplerClimaAtmosExt)
 
 for FT in (Float32, Float64)
     @testset "dss_state! ClimaAtmosSimulation for FT=$FT" begin
@@ -23,7 +27,7 @@ for FT in (Float32, Float64)
             ),
             p = (; cache_field = CC.Fields.zeros(boundary_space)),
         )
-        sim = ClimaAtmosSimulation(nothing, nothing, integrator, nothing)
+        sim = ClimaAtmosExt.ClimaAtmosSimulation(nothing, nothing, integrator, nothing)
 
         # make field non-constant to check the impact of the dss step
         coords_lat = CC.Fields.coordinate_field(sim.integrator.u.state_field2).lat
@@ -31,7 +35,7 @@ for FT in (Float32, Float64)
 
         integrator_copy = deepcopy(integrator)
         # apply DSS
-        dss_state!(sim)
+        ClimaAtmosExt.dss_state!(sim)
 
         # test that uniform field and cache are unchanged, non-constant is changed
         # note: uniform field is changed slightly by dss

--- a/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
+++ b/experiments/ClimaEarth/test/component_model_tests/climaland_tests.jl
@@ -2,7 +2,7 @@ using Test
 import ClimaCore as CC
 import ClimaAtmos as CA
 import ClimaCoupler
-import ClimaCoupler: FluxCalculator, Interfacer
+import ClimaCoupler: FieldExchanger, FluxCalculator, Interfacer
 import Dates
 import Thermodynamics.Parameters as TDP
 import ClimaParams as CP # to load TDP extension
@@ -11,7 +11,9 @@ ClimaComms.@import_required_backends
 
 exp_dir = joinpath(pkgdir(ClimaCoupler), "experiments", "ClimaEarth")
 
-include(joinpath(exp_dir, "components", "atmosphere", "climaatmos.jl"))
+import ClimaAtmos
+# Needed to construct ClimaAtmosSimulation
+ClimaAtmosExt = Base.get_extension(ClimaCoupler, :ClimaCouplerClimaAtmosExt)
 
 # To load ClimaCouplerClimaLandExt
 import ClimaLand as CL
@@ -97,7 +99,7 @@ end
     atmos_config_file =
         joinpath(exp_dir, "test", "component_model_tests", "climaatmos_coarse_short.yml")
     atmos_config = CA.AtmosConfig(atmos_config_file; job_id = "atmos_land_flux_test")
-    atmos_sim = ClimaAtmosSimulation(; atmos_config)
+    atmos_sim = ClimaAtmosExt.ClimaAtmosSimulation(atmos_config)
 
     boundary_space = CC.Spaces.horizontal_space(atmos_sim.domain.face_space)
     area_fraction = CC.Fields.ones(boundary_space)

--- a/experiments/ClimaEarth/test/restart.jl
+++ b/experiments/ClimaEarth/test/restart.jl
@@ -62,6 +62,7 @@ four_steps_reading["detect_restart_files"] = true
 four_steps_reading["restart_dir"] = cs_four_steps.dir_paths.checkpoints_dir
 four_steps_reading["restart_t"] = 720
 four_steps_reading["job_id"] = "four_steps_reading"
+Input.update_t_start_for_restarts!(four_steps_reading)
 
 cs_four_steps_reading = setup_and_run(four_steps_reading)
 @testset "Restarts from command line arguments" begin
@@ -87,6 +88,7 @@ println("Reading and simulating last two steps")
 # Two additional steps
 two_steps["t_end"] = "720secs"
 two_steps["detect_restart_files"] = true
+Input.update_t_start_for_restarts!(two_steps)
 cs_two_steps2 = setup_and_run(two_steps)
 
 @testset "Restarts" begin

--- a/experiments/ClimaEarth/test/restart_state_only.jl
+++ b/experiments/ClimaEarth/test/restart_state_only.jl
@@ -72,6 +72,9 @@ two_steps_reading["restart_t"] = 360
 two_steps_reading["restart_cache"] = false
 two_steps_reading["job_id"] = "two_steps_reading"
 two_steps_reading["save_cache"] = false
+# calling setup_and_run bypass get_coupler_config_dict which modifies the
+# t_start
+Input.update_t_start_for_restarts!(two_steps_reading)
 
 cs_two_steps_reading = setup_and_run(two_steps_reading)
 @testset "Restarts from command line arguments" begin

--- a/src/Input.jl
+++ b/src/Input.jl
@@ -14,6 +14,7 @@ import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
 import ClimaCore as CC
 import ClimaCoupler
+import ..Checkpointer
 import ..Interfacer
 import ..Utilities
 
@@ -334,8 +335,43 @@ function get_coupler_config_dict(config_file)
 
     # Select the correct timestep for each component model based on which are available
     parse_component_dts!(config_dict)
+    update_t_start_for_restarts!(config_dict)
 
     return config_dict
+end
+
+"""
+    update_t_start_for_restarts!(config_dict)
+
+Update `t_start` in `config_dict` for restarts.
+
+If the user specifies to restart via `detect_restart_files` but a restart time
+`restart_t` isn't specified, the restart time is inferred from the checkpointed
+files. Otherwise, the provided `restart_t` is used.
+
+If the simulation is not restarting, the input `config_dict` is unchanged.
+"""
+function update_t_start_for_restarts!(config_dict)
+    # Update t_start for restarts
+    (; detect_restart_files, output_dir_root, restart_dir, restart_t) =
+        get_coupler_args(config_dict)
+    # Checkpoint directory is hardcoded and can be wrong if
+    # Utilities.setup_output_dirs is updated
+    checkpoints_dir = joinpath(output_dir_root, "checkpoints")
+    if detect_restart_files
+        isnothing(restart_t) &&
+            (restart_t = Checkpointer.t_start_from_checkpoint(checkpoints_dir))
+        isnothing(restart_dir) && (restart_dir = checkpoints_dir)
+    end
+    should_restart = !isnothing(restart_t) && !isnothing(restart_dir)
+    if should_restart
+        # We only support a round number of seconds
+        isinteger(float(restart_t)) ||
+            error("Cannot restart from a non integer number of seconds")
+        restart_t_int = Int(float(restart_t))
+        config_dict["t_start"] = "$(restart_t_int)secs"
+    end
+    return nothing
 end
 
 """
@@ -380,7 +416,12 @@ function get_coupler_args(config_dict::Dict)
     if use_itime
         t_end = ITime(t_end, epoch = start_date)
         t_start = ITime(t_start, epoch = start_date)
-        Δt_cpl = ITime(Δt_cpl, epoch = start_date)
+        # A period of Dates.Second(1) is passed when initializing Δt_cpl to
+        # ensure consistent Δt_cpl for when restarting a simulation. ITime
+        # automatically choose the appropriate period based on time value. For
+        # example, the result ITime(0) gives a period of 1 second, but
+        # ITime(120) gives a period of 1 minute.
+        Δt_cpl = ITime(Int64(Δt_cpl), period = Dates.Second(1), epoch = start_date)
         times = promote(
             t_end,
             t_start,


### PR DESCRIPTION
This PR makes an extension for ClimaAtmos which involves moving all the files in `experiments/ClimaEarth/components/atmosphere` to ext.