### PR TITLE
run macOS tests on merge instead of push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 on:
   push:
+    branches: [main]
     tags: '*'
   pull_request:
 
@@ -28,8 +29,15 @@ jobs:
           - '1.11'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
+          # There is a concurrency limit for MacOS runners across the
+          # entire organization.
+          # (see https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners)
+          # To help with this, MacOS runners are only run when PRs are merged
+          # into the main branch.
+          - ${{ github.event_name == 'push' && 'macos-latest' || '' }}
+        exclude:
+          - os: ''
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Same changes as https://github.com/CliMA/ClimaAtmos.jl/pull/4287

From that PR description:
> From https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners, the concurrency limit for MacOS is 5 across the entire organization. This PR limits CI testing for MacOS to only PR merges.

The MacOS tests should now run on PR merges rather than on every push