### PR TITLE
dont use pmodel

### DIFF
--- a/ext/climaland/climaland_integrated.jl
+++ b/ext/climaland/climaland_integrated.jl
@@ -134,12 +134,6 @@ function ClimaLandSimulation(
     ground = CL.PrognosticGroundConditions{FT}()
     canopy_forcing = (; forcing.atmos, forcing.radiation, ground)
     prognostic_land_components = (:canopy, :snow, :soil, :soilco2)
-
-    # Construct the P model manually since it is not a default
-    photosynthesis = CL.Canopy.PModel{FT}(domain, toml_dict)
-    conductance = CL.Canopy.PModelConductance{FT}(toml_dict)
-    # Use the soil moisture stress function based on soil moisture only
-    soil_moisture_stress = CL.Canopy.PiecewiseMoistureStressModel{FT}(domain, toml_dict)
     surface_domain = CL.Domains.obtain_surface_domain(domain)
     biomass = CL.Canopy.PrescribedBiomassModel{FT}(
         domain,
@@ -156,9 +150,6 @@ function ClimaLandSimulation(
         LAI,
         toml_dict;
         prognostic_land_components,
-        photosynthesis,
-        conductance,
-        soil_moisture_stress,
         biomass,
     )
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Dont use Pmodel, but use some other parameterizations that correspond to what we run weekly in land:
- snow albedo and snow cover fraction
- spatially varying canopy height (required biomass model to be defined to override the default), because the parameters in the land toml file were calibrated with spatially varying canopy height.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
