### PR TITLE
start using LandSimulation constructor

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,7 +109,7 @@ steps:
           slurm_ntasks: 2
           slurm_mem: 32GB
 
-      - label: "GPU restarts"
+      - label: "GPU restarts (state and cache)"
         command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/restart.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -118,7 +118,7 @@ steps:
           slurm_gres: "gpu:1"
           slurm_mem: 32GB
 
-      - label: "GPU restarts"
+      - label: "GPU restarts (state only)"
         command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/restart_state_only.jl"
         env:
           CLIMACOMMS_DEVICE: "CUDA"

--- a/experiments/ClimaEarth/test/fluxes_test.jl
+++ b/experiments/ClimaEarth/test/fluxes_test.jl
@@ -27,11 +27,55 @@ include(joinpath("..", "code_loading.jl"))
 
     # Construct coupled simulation and run one coupling step
     cs = CoupledSimulation(config_dict)
-    step!(cs)
     boundary_space = Interfacer.boundary_space(cs)
 
     # Unpack component models
     (; atmos_sim, land_sim, ocean_sim, ice_sim) = cs.model_sims
+    land_fraction = Interfacer.get_field(land_sim, Val(:area_fraction))
+
+    # Check SWD, LWD, albedo, temp, emissivity between atmos and land before flux calculation
+    atmos_swd = Interfacer.get_field(boundary_space, atmos_sim, Val(:SW_d))
+    land_swd = Interfacer.remap(boundary_space, land_sim.integrator.p.drivers.SW_d)
+    err_swd = @. atmos_swd - land_swd
+    err_swd = @. ifelse(land_fraction ≈ 0, zero(err_swd), err_swd)
+    @test maximum(abs.(err_swd)) < 1e-10
+
+    atmos_lwd = Interfacer.get_field(boundary_space, atmos_sim, Val(:LW_d))
+    land_lwd = Interfacer.remap(boundary_space, land_sim.integrator.p.drivers.LW_d)
+    err_lwd = @. atmos_lwd - land_lwd
+    err_lwd = @. ifelse(land_fraction ≈ 0, zero(err_lwd), err_lwd)
+    @test maximum(abs.(err_lwd)) < 1e-10
+
+    atmos_albedo = CC.Fields.array2field(
+        atmos_sim.integrator.p.radiation.rrtmgp_model.direct_sw_surface_albedo,
+        boundary_space,
+    )
+    land_albedo =
+        Interfacer.get_field(boundary_space, land_sim, Val(:surface_direct_albedo))
+    err_albedo = @. atmos_albedo - land_albedo
+    err_albedo = @. ifelse(land_fraction ≈ 0, zero(err_albedo), err_albedo)
+    @test maximum(abs.(err_albedo)) < 1e-10
+
+    atmos_temp = Interfacer.remap(
+        boundary_space,
+        atmos_sim.integrator.p.precomputed.sfc_conditions.T_sfc,
+    )
+    land_temp = Interfacer.get_field(boundary_space, land_sim, Val(:surface_temperature))
+    err_temp = @. atmos_temp - land_temp
+    err_temp = @. ifelse(land_fraction ≈ 0, zero(err_temp), err_temp)
+    @test maximum(abs.(err_temp)) < 1e-6
+
+    atmos_emissivity = CC.Fields.array2field(
+        atmos_sim.integrator.p.radiation.rrtmgp_model.surface_emissivity,
+        boundary_space,
+    )
+    land_emissivity = Interfacer.get_field(boundary_space, land_sim, Val(:emissivity))
+    err_emissivity = @. atmos_emissivity - land_emissivity
+    err_emissivity = @. ifelse(land_fraction ≈ 0, zero(err_emissivity), err_emissivity)
+    @test maximum(abs.(err_emissivity)) < 1e-10
+
+    step!(cs)
+    boundary_space = Interfacer.boundary_space(cs)
 
     # Atmosphere: radiative flux on the surface interface
     # Convention: positive downward to the surface

--- a/ext/ClimaCouplerClimaLandExt/climaland_bucket.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_bucket.jl
@@ -49,12 +49,10 @@ function BucketSimulation(
     depth::FT = FT(3.5),
     dz_tuple::Tuple{FT, FT} = FT.((1, 0.05)),
     shared_surface_space = nothing,
-    saveat::Vector{TT} = [tspan[1], tspan[2]],
     surface_elevation = nothing,
     atmos_h,
     land_temperature_anomaly::String = "amip",
     use_land_diagnostics::Bool = true,
-    stepper = CTS.RK4(),
     albedo_type::String = "map_static",
     bucket_initial_condition::String = "",
     era5_albedo_file_path::Union{Nothing, String} = nothing,
@@ -80,7 +78,6 @@ function BucketSimulation(
         )
     end
     surface_space = domain.space.surface
-    subsurface_space = domain.space.subsurface
 
     # If provided, interpolate surface elevation field to surface space; otherwise use zero elevation
     if isnothing(surface_elevation)
@@ -142,9 +139,6 @@ function BucketSimulation(
     )
     model = CL.Bucket.BucketModel{FT, typeof.(args)...}(args...)
 
-    # Initial conditions with no moisture
-    Y, p, coords = CL.initialize(model)
-
     if land_temperature_anomaly != "nothing"
         T_functions =
             Dict("aquaplanet" => temp_anomaly_aquaplanet, "amip" => temp_anomaly_amip)
@@ -155,117 +149,75 @@ function BucketSimulation(
         # Set temperature IC including anomaly, based on atmospheric setup
         # Bucket surface temperature is in `p.bucket.T_sfc` (ClimaLand.jl)
         lapse_rate = FT(6.5e-3)
-        T_sfc_0 = FT(271)
-        @. Y.bucket.T = T_sfc_0 + temp_anomaly(coords.subsurface)
+        T_base = FT(271)
+        coords = CL.Domains.coordinates(model)
+        T_sfc_0 = T_base .+ temp_anomaly.(coords.subsurface)
         # `surface_elevation` is a ClimaCore.Fields.Field(`half` level)
         orog_adjusted_T_data =
-            CC.Fields.field_values(Y.bucket.T) .-
+            CC.Fields.field_values(T_sfc_0) .-
             lapse_rate .* CC.Fields.field_values(surface_elevation)
-        orog_adjusted_T = CC.Fields.Field(orog_adjusted_T_data, domain.space.subsurface)
-        # Adjust T based on surface elevation (p.bucket.T_sfc is then set using the
-        # set_initial_cache! function)
-        Y.bucket.T .= orog_adjusted_T
+        orog_adjusted_T_surface =
+            CC.Fields.Field(CC.Fields.level(orog_adjusted_T_data, 1), surface_space)
     end
 
-    Y.bucket.W .= 0.15
-    Y.bucket.Ws .= 0.0
-    Y.bucket.σS .= 0.0
-
-    # Overwrite initial conditions with interpolated values from a netcdf file using
-    # the `SpaceVaryingInputs` tool. We expect the file to contain the following variables:
+    # Overwrite initial conditions with interpolated values from a netcdf file if provided.
+    # We expect the file to contain the following variables:
     # - `W`, for subsurface water storage (2D),
     # - `Ws`, for surface water content (2D),
     # - `T`, for soil temperature (3D),
     # - `S`, for snow water equivalent (2D).
-
     if !isempty(bucket_initial_condition)
         @info "ClimaLand Bucket using land IC file" bucket_initial_condition
-        ds = NCDataset(bucket_initial_condition)
-        has_all_variables = all(key -> haskey(ds, key), ["W", "Ws", "T", "S"])
-        @assert has_all_variables "The land iniital condition file is expected to contain the variables W, Ws, T, and S (read documentation about requirements)."
-        close(ds)
-
-        surface_space = domain.space.surface
-        subsurface_space = domain.space.subsurface
-        regridder_type = :InterpolationsRegridder
-        extrapolation_bc =
-            (Interpolations.Periodic(), Interpolations.Flat(), Interpolations.Flat())
-
-        Y.bucket.W .= SpaceVaryingInput(
-            bucket_initial_condition,
-            "W",
-            surface_space;
-            regridder_type,
-            regridder_kwargs = (; extrapolation_bc,),
-        )
-        Y.bucket.Ws .= SpaceVaryingInput(
-            bucket_initial_condition,
-            "Ws",
-            surface_space;
-            regridder_type,
-            regridder_kwargs = (; extrapolation_bc,),
-        )
-        Y.bucket.T .= SpaceVaryingInput(
-            bucket_initial_condition,
-            "T",
-            subsurface_space;
-            regridder_type,
-            regridder_kwargs = (; extrapolation_bc,),
-        )
-        Y.bucket.σS .= SpaceVaryingInput(
-            bucket_initial_condition,
-            "S",
-            surface_space;
-            regridder_type,
-            regridder_kwargs = (; extrapolation_bc,),
-        )
-        # clip negative values from horizontal regridding
-        Y.bucket.σS .= max.(Y.bucket.σS, FT(0))
-        Y.bucket.W .= max.(Y.bucket.W, FT(0))
-        Y.bucket.Ws .= max.(Y.bucket.Ws, FT(0))
+        set_ic! =
+            CL.Simulations.make_set_initial_state_from_file(bucket_initial_condition, model)
+    else
+        set_ic! =
+            (Y, p, t, model) -> _coupler_set_ic!(
+                Y,
+                p,
+                t,
+                model,
+                orog_adjusted_T_surface,
+                CL.Simulations.make_set_initial_state_from_atmos_and_parameters(model),
+            )
     end
-
-    # ensure initial storage < bucket capacity
-    Y.bucket.W .= min.(Y.bucket.W, params.W_f)
-
-    # Set initial aux variable values
-    set_initial_cache! = CL.make_set_initial_cache(model)
-    set_initial_cache!(p, Y, tspan[1])
-
-    exp_tendency! = CL.make_exp_tendency(model)
-    ode_algo = CTS.ExplicitAlgorithm(stepper)
-    bucket_ode_function = CTS.ClimaODEFunction(T_exp! = exp_tendency!)
-    prob = SciMLBase.ODEProblem(bucket_ode_function, Y, tspan, p)
 
     # Add diagnostics
     if use_land_diagnostics
         output_writer =
             CD.Writers.NetCDFWriter(domain.space.subsurface, output_dir; start_date)
-        scheduled_diagnostics = CL.default_diagnostics(
+        diagnostics = CL.default_diagnostics(
             model,
             start_date,
             output_writer = output_writer,
             reduction_period = :monthly,
         )
-
-        diagnostic_handler =
-            CD.DiagnosticsHandler(scheduled_diagnostics, Y, p, tspan[1]; dt = dt)
-        diag_cb = CD.DiagnosticsCallback(diagnostic_handler)
     else
-        output_writer = nothing
-        diag_cb = nothing
+        diagnostics = nothing
     end
 
-    integrator = SciMLBase.init(
-        prob,
-        ode_algo;
-        dt = dt,
-        saveat = saveat,
-        adaptive = false,
-        callback = SciMLBase.CallbackSet(diag_cb),
+    stop_date = start_date + Dates.Second(float(tspan[2] - tspan[1]))
+    # Convert start_date and stop_date to ITime if using ITime
+    if dt isa ITime
+        start_date = tspan[1]
+        stop_date = tspan[2]
+    end
+
+    # Choose the timestepping algorithm
+    timestepper = CTS.ExplicitAlgorithm(CTS.RK4())
+    simulation = CL.Simulations.LandSimulation(
+        start_date,
+        stop_date,
+        dt,
+        model;
+        outdir = output_dir,
+        set_ic!,
+        user_callbacks = (),
+        diagnostics,
+        timestepper,
     )
 
-    return BucketSimulation(model, integrator, area_fraction, output_writer)
+    return BucketSimulation(model, simulation._integrator, area_fraction, output_writer)
 end
 
 # extensions required by Interfacer
@@ -363,8 +315,12 @@ function Interfacer.update_field!(
     Interfacer.remap!(sim.integrator.p.bucket.turbulent_fluxes.vapor_flux, field ./ ρ_liq) # TODO: account for sublimation
 end
 
-Interfacer.step!(sim::BucketSimulation, t) =
-    Interfacer.step!(sim.integrator, t - sim.integrator.t, true)
+function Interfacer.step!(sim::BucketSimulation, t)
+    while float(sim.integrator.t) < float(t)
+        Interfacer.step!(sim.integrator)
+    end
+    return nothing
+end
 Interfacer.close_output_writers(sim::BucketSimulation) =
     isnothing(sim.output_writer) || close(sim.output_writer)
 

--- a/ext/ClimaCouplerClimaLandExt/climaland_integrated.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_integrated.jl
@@ -43,7 +43,6 @@ end
         dz_tuple::Tuple{FT, FT} = FT.((3.0, 0.05)),
         shared_surface_space = nothing,
         land_spun_up_ic::Bool = true,
-        saveat::Vector{TT} = [tspan[1], tspan[2]],
         surface_elevation = nothing,
         atmos_h,
         land_temperature_anomaly::String = "amip",
@@ -78,7 +77,6 @@ function ClimaLandSimulation(
     dz_tuple::Tuple{FT, FT} = FT.((3.0, 0.05)),
     shared_surface_space = nothing,
     land_spun_up_ic::Bool = true,
-    saveat::Vector{TT} = [tspan[1], tspan[2]],
     surface_elevation = nothing,
     atmos_h,
     land_temperature_anomaly::String = "amip",
@@ -93,7 +91,6 @@ function ClimaLandSimulation(
     land_toml_dict = LP.create_toml_dict(FT)
     # Override land parameters with coupled parameters
     toml_dict = CP.merge_override_default_values(coupled_param_dict, land_toml_dict)
-    earth_param_set = CL.Parameters.LandParameters(toml_dict)
 
     # Note that this does not take into account topography of the surface, which is OK for this land model.
     # But it must be taken into account when computing surface fluxes, for Δz.
@@ -209,9 +206,20 @@ function ClimaLandSimulation(
         canopy,
     )
 
-    Y, p, coords = CL.initialize(model)
-
-    # Set initial conditions
+    # Set up diagnostics
+    if use_land_diagnostics
+        output_writer = CD.Writers.NetCDFWriter(subsurface_space, output_dir; start_date)
+        diagnostics = CL.default_diagnostics(
+            model,
+            start_date,
+            output_writer = output_writer,
+            output_vars = :short,
+            reduction_period = :monthly,
+        )
+    else
+        output_writer = nothing
+        diagnostics = nothing
+    end
 
     # Apply temperature anomaly function to initial temperature only if specified
     T_base = FT(276.85)
@@ -221,6 +229,7 @@ function ClimaLandSimulation(
         haskey(T_functions, land_temperature_anomaly) ||
             error("land temp anomaly function $land_temperature_anomaly not supported")
         temp_anomaly = T_functions[land_temperature_anomaly]
+        coords = CL.Domains.coordinates(model)
         T_sfc0 = T_base .+ temp_anomaly.(coords.subsurface)
     else
         # constant field on subsurface space
@@ -232,185 +241,73 @@ function ClimaLandSimulation(
     orog_adjusted_T_data =
         CC.Fields.field_values(T_sfc0) .-
         lapse_rate .* CC.Fields.field_values(surface_elevation)
-    orog_adjusted_T = CC.Fields.Field(orog_adjusted_T_data, subsurface_space)
     orog_adjusted_T_surface =
         CC.Fields.Field(CC.Fields.level(orog_adjusted_T_data, 1), surface_space)
 
-    # Read in initial conditions for snow and soil from file, if requested
+    # Define functions to set initial conditions
     if !land_spun_up_ic && !isnothing(land_ic_path)
-        # Set initial conditions that aren't read in from file
-        Y.soilco2.CO2 .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
-        Y.soilco2.O2_f .= FT(0.21)    # atmospheric O2 volumetric fraction
-        Y.soilco2.SOC .= FT(5.0)      # default SOC concentration (kg C/m³)
-
-        Y.canopy.hydraulics.ϑ_l.:1 .= model.canopy.hydraulics.parameters.ν
-        @. Y.canopy.energy.T = orog_adjusted_T_surface
-        # Subseasonal setup: land_spun_up_ic false, but a land_ic_path is provided
-        ic_path = land_ic_path
-        @info "ClimaLand: using land IC file" ic_path
-
-        regridder_type = :InterpolationsRegridder
-        extrapolation_bc =
-            (Interpolations.Periodic(), Interpolations.Flat(), Interpolations.Flat())
-        interpolation_method = Interpolations.Linear()
-
-        # Set snow T first to use in computing snow internal energy from IC file
-        p.snow.T .= SpaceVaryingInput(
-            ic_path,
-            "tsn",
-            surface_space;
-            regridder_type,
-            regridder_kwargs = (; extrapolation_bc, interpolation_method),
-        )
-        # Set canopy temperature to skin temperature
-        Y.canopy.energy.T .= SpaceVaryingInput(
-            ic_path,
-            "skt",
-            surface_space;
-            regridder_type,
-            regridder_kwargs = (; extrapolation_bc, interpolation_method),
-        )
-
-        # Initialize the surface temperature so the atmosphere can compute radiation.
-        # Set surface temperature to skin temperature
-        p.T_sfc .= SpaceVaryingInput(
-            ic_path,
-            "skt",
-            surface_space;
-            regridder_type,
-            regridder_kwargs = (; extrapolation_bc, interpolation_method),
-        )
-
-        CL.Simulations.set_snow_initial_conditions!(
-            Y,
-            p,
-            surface_space,
-            ic_path,
-            model.snow.parameters;
-            regridder_type = regridder_type,
-            extrapolation_bc = extrapolation_bc,
-            interpolation_method = interpolation_method,
-        )
-
-        CL.Simulations.set_soil_initial_conditions_from_temperature_and_total_water!(
-            Y,
-            subsurface_space,
-            ic_path,
-            model.soil;
-            regridder_type = regridder_type,
-            extrapolation_bc = extrapolation_bc,
-            interpolation_method = interpolation_method,
-        )
+        @info "ClimaLand: using land IC file" land_ic_path
+        # Note: This `set_ic!` function does not require `p.drivers.T` to be set,
+        # so we do not need to use `_coupler_set_ic!` here.
+        set_ic! = CL.make_set_subseasonal_initial_conditions(land_ic_path)
     elseif land_spun_up_ic
         # Use artifact spun-up initial conditions
         ic_path = CL.Artifacts.soil_ic_2008_50m_path()
         @info "ClimaLand: using land IC file" ic_path
-        set_ic! = CL.Simulations.make_set_initial_state_from_file(
+
+        # Set initial conditions from file, and set air temperature to the input atmospheric temperature
+        spun_up_set_ic! = CL.Simulations.make_set_initial_state_from_file(
             ic_path,
             model;
             enforce_constraints = true,
         )
-        p.drivers.T .= orog_adjusted_T_surface
-        t0 = tspan[1]
-        set_ic!(Y, p, t0, model)
-        # Initialize the surface temperature so the atmosphere can compute radiation.
-        @. p.T_sfc = orog_adjusted_T_surface
+        set_ic! =
+            (Y, p, t, model) ->
+                _coupler_set_ic!(Y, p, t, model, orog_adjusted_T_surface, spun_up_set_ic!)
+
     else
-        (; θ_r, ν, ρc_ds) = model.soil.parameters
-        # Set initial conditions that aren't read in from file
-        Y.soilco2.CO2 .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
-        Y.soilco2.O2_f .= FT(0.21)    # atmospheric O2 volumetric fraction
-        Y.soilco2.SOC .= FT(5.0)      # default SOC concentration (kg C/m³)
-
-        Y.canopy.hydraulics.ϑ_l.:1 .= model.canopy.hydraulics.parameters.ν
-        @. Y.canopy.energy.T = orog_adjusted_T_surface
-        # Set initial conditions for the state
-        @. Y.soil.ϑ_l = θ_r + (ν - θ_r) / 2
-        Y.soil.θ_i .= FT(0.0)
-        ρc_s =
-            CL.Soil.volumetric_heat_capacity.(
-                Y.soil.ϑ_l,
-                Y.soil.θ_i,
-                ρc_ds,
-                earth_param_set,
+        set_ic_from_atmos_and_parameters! =
+            CL.Simulations.make_set_initial_state_from_atmos_and_parameters(model)
+        set_ic! =
+            (Y, p, t, model) -> _coupler_set_ic!(
+                Y,
+                p,
+                t,
+                model,
+                orog_adjusted_T_surface,
+                set_ic_from_atmos_and_parameters!,
             )
-        Y.soil.ρe_int .=
-            CL.Soil.volumetric_internal_energy.(
-                Y.soil.θ_i,
-                ρc_s,
-                orog_adjusted_T,
-                earth_param_set,
-            )
-
-        Y.snow.S .= FT(0)
-        Y.snow.S_l .= FT(0)
-        Y.snow.U .= FT(0)
-        # Initialize the surface temperature so the atmosphere can compute radiation.
-        @. p.T_sfc = orog_adjusted_T_surface
     end
+
+    # Convert start_date and stop_date to ITime if using ITime
+    if dt isa ITime
+        start_date = tspan[1]
+        stop_date = tspan[2]
+    end
+    simulation = CL.Simulations.LandSimulation(
+        start_date,
+        stop_date,
+        dt,
+        model;
+        outdir = output_dir,
+        set_ic!,
+        user_callbacks = (),
+        diagnostics,
+    )
+
     # Initialize the surface emissivity so the atmosphere can compute radiation.
     # Otherwise, it's initialized to 0 which causes NaNs in the radiation calculation.
-    @. p.ϵ_sfc = FT(1)
+    @. simulation._integrator.p.ϵ_sfc = FT(1)
 
-    # Update cos(zenith angle) within land model every hour
-    update_dt = dt isa ITime ? ITime(3600) : 3600
-    updatefunc = CL.make_update_drivers(CL.get_drivers(model))
-    driver_cb = CL.DriverUpdateCallback(updatefunc, update_dt, tspan[1])
+    # Initialize the surface temperature so the atmosphere can compute radiation.
+    @. simulation._integrator.p.T_sfc = simulation._integrator.u.canopy.energy.T
 
-    exp_tendency! = CL.make_exp_tendency(model)
-    imp_tendency! = CL.make_imp_tendency(model)
-    jacobian! = CL.make_jacobian(model)
-
-    # set up jacobian info
-    jac_kwargs = (; jac_prototype = CL.initialize_jacobian(Y), Wfact = jacobian!)
-
-    prob = SciMLBase.ODEProblem(
-        CTS.ClimaODEFunction(
-            T_exp! = exp_tendency!,
-            T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
-        ),
-        Y,
-        tspan,
-        p,
+    return ClimaLandSimulation(
+        simulation.model,
+        simulation._integrator,
+        area_fraction,
+        output_writer,
     )
-
-    # Set up diagnostics
-    if use_land_diagnostics
-        output_writer = CD.Writers.NetCDFWriter(subsurface_space, output_dir; start_date)
-        scheduled_diagnostics = CL.default_diagnostics(
-            model,
-            start_date,
-            output_writer = output_writer,
-            output_vars = :short,
-            reduction_period = :monthly,
-        )
-        diagnostic_handler =
-            CD.DiagnosticsHandler(scheduled_diagnostics, Y, p, tspan[1]; dt = dt)
-        diag_cb = CD.DiagnosticsCallback(diagnostic_handler)
-    else
-        output_writer = nothing
-        diag_cb = nothing
-    end
-
-    # Set up time stepper and integrator
-    stepper = CTS.ARS111()
-    ode_algo = CTS.IMEXAlgorithm(
-        stepper,
-        CTS.NewtonsMethod(
-            max_iters = 3,
-            update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
-        ),
-    )
-    integrator = SciMLBase.init(
-        prob,
-        ode_algo;
-        dt,
-        saveat,
-        adaptive = false,
-        callback = SciMLBase.CallbackSet(driver_cb, diag_cb),
-    )
-
-    return ClimaLandSimulation(model, integrator, area_fraction, output_writer)
 end
 
 ###############################################################################

--- a/src/SimCoordinator.jl
+++ b/src/SimCoordinator.jl
@@ -24,6 +24,7 @@ import ClimaParams as CP
 import Thermodynamics.Parameters as TDP
 import Random
 
+import ClimaCoupler
 import ..Interfacer
 import ..ConservationChecker
 import ..FieldExchanger
@@ -321,7 +322,6 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
         output_dir = dir_paths.land_output_dir,
         area_fraction = land_fraction,
         shared_surface_space,
-        saveat,
         surface_elevation,
         atmos_h,
         land_temperature_anomaly,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We can use ClimaLand's LandSimulation constructor to simplify the setup of our bucket and integrated land components. We hadn't used this previously because it initialized the cache in the constructor, but we need to initialize the land cache after a first exchange in coupled runs. ClimaLand has been changed so the cache isn't initialized in the coupled case.

This PR also uses functions from ClimaLand to simplify how we set ICs of the land models.

AMIP runs with the bucket look unchanged in buildkite. AMIP + integrated land has slight changes in momentum fluxes, and CMIP has slight changes in multiple fluxes

## Content
- [x] use LandSimulation constructor for bucket
- [x] use LandSimulation constructor for integrated land
- [x] use new IC function for bucket
- [x] use new IC functions x2 for integrated land

## Content that is less-related to the LandSimulation change
- [x] improve fluxes tests for bucket case
- [x] set everything needed to compute radiation (T, albedo, emissivity) in bucket/land model initialization. Now we should be able to remove the extra method of `set_surface_albedo!` for the coupled case in ClimaAtmos

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
