### PR TITLE
Fix make_diagnostics_plot when there are pressure diagnostics

### DIFF
--- a/ext/ClimaCouplerMakieExt/diagnostics_plots.jl
+++ b/ext/ClimaCouplerMakieExt/diagnostics_plots.jl
@@ -27,7 +27,9 @@ short_name(var) = var.attributes["short_name"]
     )
 Create plots for diagnostics. The plots are saved to `plot_path`.
 This function will plot all variables that have been saved in `output_path`.
-The `reduction` keyword argument should be consistent with the reduction used to save the diagnostics.
+
+When plotting diagnostics, diagnostics that are daily averages in z coordinates
+(if available) are prioritized first.
 """
 function Plotting.make_diagnostics_plots(
     output_path::AbstractString,
@@ -45,18 +47,20 @@ function Plotting.make_diagnostics_plots(
     for (i, short_name) in enumerate(short_names)
         # Use "average" if available, otherwise use the first reduction
         reductions = CAN.available_reductions(simdir; short_name)
-        "average" in reductions ? (reduction = "average") : (reduction = first(reductions))
+        reduction = "average" in reductions ? "average" : first(reductions)
         periods = CAN.available_periods(simdir; short_name, reduction)
-        "1d" in periods ? (period = "1d") : (period = first(periods))
-        vars[i] = get(simdir; short_name, reduction, period)
+        period = "1d" in periods ? "1d" : first(periods)
+        coord_types = CAN.available_coord_types(simdir; short_name, reduction, period)
+        coord_type = nothing in coord_types ? nothing : first(coord_types)
+        vars[i] = get(simdir; short_name, reduction, period, coord_type)
     end
 
     # Filter vars into 2D and 3D variable diagnostics vectors
     # 3D fields are zonally averaged platted on the lat-z plane
     # 2D fields are plotted on the lon-lat plane
-    vars_3D =
-        map(var_3D -> CAN.average_lon(var_3D), filter(var -> CAN.has_altitude(var), vars))
-    vars_2D = filter(var -> !CAN.has_altitude(var), vars)
+    is_3d = var -> CAN.has_altitude(var) || CAN.has_pressure(var)
+    vars_3D = map(var_3D -> CAN.average_lon(var_3D), filter(is_3d, vars))
+    vars_2D = filter(var -> !is_3d(var), vars)
 
     # Generate plots and save in `plot_path`
     !isempty(vars_3D) && make_plots_generic(

--- a/src/SimOutput/sim_obs_data.jl
+++ b/src/SimOutput/sim_obs_data.jl
@@ -73,6 +73,7 @@ function get_sim_var_dict(diagnostics_folder_path)
                     short_name = "pr",
                     reduction = "average",
                     period = "1M",
+                    coord_type = nothing,
                 )
                 sim_var = ClimaAnalysis.convert_units(
                     sim_var,
@@ -97,6 +98,7 @@ function get_sim_var_dict(diagnostics_folder_path)
                         short_name = short_name,
                         reduction = "average",
                         period = "1M",
+                        coord_type = nothing,
                     )
                     # For ClimaDiagnostics v0.3 and later, the dates are saved at
                     # the start of the reduction period


### PR DESCRIPTION
This PR makes `make_diagnostics_plot`  compatible with pressure diagnostics. This is done by preferring diagnostics with z coordinates when making the diagnostics plots.