### PR TITLE
improve debug plots

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -99,15 +99,17 @@ pages = Any[
 ]
 
 
+extensions = [
+    Base.get_extension(ClimaCoupler, :ClimaCouplerMakieExt),
+    Base.get_extension(ClimaCoupler, :ClimaCouplerCMIPMakieExt),
+    Base.get_extension(ClimaCoupler, :ClimaCouplerCMIPExt),
+    Base.get_extension(ClimaCoupler, :ClimaCouplerClimaLandExt),
+    Base.get_extension(ClimaCoupler, :ClimaCouplerClimaAtmosExt),
+]
+@assert all(!isnothing, extensions) "Some extensions failed to load: $extensions"
+
 makedocs(
-    modules = [
-        ClimaCoupler,
-        Base.get_extension(ClimaCoupler, :ClimaCouplerMakieExt),
-        Base.get_extension(ClimaCoupler, :ClimaCouplerCMIPMakieExt),
-        Base.get_extension(ClimaCoupler, :ClimaCouplerCMIPExt),
-        Base.get_extension(ClimaCoupler, :ClimaCouplerClimaLandExt),
-        Base.get_extension(ClimaCoupler, :ClimaCouplerClimaAtmosExt),
-    ],
+    modules = [ClimaCoupler, extensions...],
     authors = "Climate Modelling Alliance",
     sitename = "ClimaCoupler.jl",
     format = Documenter.HTML(),

--- a/experiments/ClimaEarth/test/debug_plots_tests.jl
+++ b/experiments/ClimaEarth/test/debug_plots_tests.jl
@@ -6,7 +6,7 @@ import ClimaCoupler: Interfacer, Plotting
 import ClimaComms
 ClimaComms.@import_required_backends
 
-using Makie, GeoMakie, CairoMakie, ClimaCoreMakie # trigger ClimaCouplerMakieExt extension
+using Makie, GeoMakie, CairoMakie, ClimaCoreMakie, Poppler_jll, Printf # trigger ClimaCouplerMakieExt extension
 
 # Prevent GKS headless operation mode warning
 ENV["GKSwstype"] = "nul"

--- a/ext/ClimaCouplerCMIPExt.jl
+++ b/ext/ClimaCouplerCMIPExt.jl
@@ -10,7 +10,8 @@ and KernelAbstractions are loaded with either `import` or `using`.
 module ClimaCouplerCMIPExt
 
 import ClimaCoupler
-import ClimaCoupler: Checkpointer, FieldExchanger, FluxCalculator, Interfacer, Utilities
+import ClimaCoupler:
+    Checkpointer, FieldExchanger, FluxCalculator, Interfacer, Utilities, Plotting
 import Oceananigans as OC
 import ClimaOcean as CO
 import ClimaSeaIce as CSI

--- a/ext/ClimaCouplerCMIPExt/clima_seaice.jl
+++ b/ext/ClimaCouplerCMIPExt/clima_seaice.jl
@@ -553,3 +553,17 @@ TODO extend this for non-ClimaCore states.
 function Checkpointer.get_model_prog_state(sim::ClimaSeaIceSimulation)
     @warn "get_model_prog_state not implemented for ClimaSeaIceSimulation"
 end
+
+# Additional ClimaSeaIceSimulation getter methods for plotting debug fields
+Interfacer.get_field(sim::ClimaSeaIceSimulation, ::Val{:ice_thickness}) =
+    sim.ice.model.ice_thickness
+
+"""
+    Plotting.debug_plot_fields(sim::ClimaSeaIceSimulation)
+
+Return the fields to include in debug plots for a ClimaSeaIce simulation.
+This includes the area fraction, surface temperature, ice concentration, and ice thickness.
+These plots are not polished, and are intended for debugging.
+"""
+Plotting.debug_plot_fields(sim::ClimaSeaIceSimulation) =
+    (:area_fraction, :surface_temperature, :ice_concentration, :ice_thickness)

--- a/ext/ClimaCouplerCMIPExt/climaocean_helpers.jl
+++ b/ext/ClimaCouplerCMIPExt/climaocean_helpers.jl
@@ -165,7 +165,7 @@ function contravariant_to_cartesian!(ρτ_flux_uv, ρτxz, ρτyz)
     yz = @. CT12(CT2(unit_basis_vector_data(CT2, local_geometry)), local_geometry)
 
     # Convert the vector components to a UVVector on the Cartesian basis
-    @. ρτ_flux_uv = @. CC.Geometry.UVVector(ρτxz * xz + ρτyz * yz, local_geometry)
+    @. ρτ_flux_uv = CC.Geometry.UVVector(ρτxz * xz + ρτyz * yz, local_geometry)
     return nothing
 end
 

--- a/ext/ClimaCouplerCMIPExt/oceananigans.jl
+++ b/ext/ClimaCouplerCMIPExt/oceananigans.jl
@@ -541,3 +541,21 @@ TODO extend this for non-ClimaCore states.
 function Checkpointer.get_model_prog_state(sim::OceananigansSimulation)
     @warn "get_model_prog_state not implemented for OceananigansSimulation"
 end
+
+# Additional OceananigansSimulation getter methods for plotting debug fields
+Interfacer.get_field(sim::OceananigansSimulation, ::Val{:salinity}) =
+    sim.ocean.model.tracers.S
+Interfacer.get_field(sim::OceananigansSimulation, ::Val{:u}) = sim.ocean.model.velocities.u
+Interfacer.get_field(sim::OceananigansSimulation, ::Val{:v}) = sim.ocean.model.velocities.v
+Interfacer.get_field(sim::OceananigansSimulation, ::Val{:free_surface_displacement}) =
+    sim.ocean.model.free_surface.displacement
+
+"""
+    Plotting.debug_plot_fields(sim::OceananigansSimulation)
+
+Return the fields to include in debug plots for an Oceananigans simulation.
+This includes the area fraction, surface temperature, salinity, velocity, and
+free surface displacement. These plots are not polished, and are intended for debugging.
+"""
+Plotting.debug_plot_fields(sim::OceananigansSimulation) =
+    (:area_fraction, :surface_temperature, :salinity, :u, :v, :free_surface_displacement)

--- a/ext/ClimaCouplerCMIPMakieExt.jl
+++ b/ext/ClimaCouplerCMIPMakieExt.jl
@@ -26,8 +26,7 @@ Plot a heatmap of the provided Oceananigans field or operation.
 This is intended to be used as part of the debug plotting system.
 """
 function Plotting.debug_plot!(ax, fig, field::OC.Field, i, j)
-    grid = field.grid
-    hm = CairoMakie.heatmap!(ax, view(field, :, :, grid.Nz))
+    hm = CairoMakie.heatmap!(ax, Array(OC.interior(field, :, :, size(field, 3))))
     Makie.Colorbar(fig[i, j * 2], hm)
     return nothing
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

## Content
- [x] rotate contravariant vectors to cartesian basis (atmos u_int, atmos v_int, momentum fluxes)
- [x] plot more fields for ocean (T, salinity, free surface, u, v)
- [x] plot more fields for sea ice (ice thickness, ice concentration)

## Updated plots
From CMIP runs in [this build](https://buildkite.com/clima/climacoupler-ci/builds/8172#_)
#### Oceananigans debug plots
<img width="1494" height="771" alt="Screenshot 2026-02-27 at 11 32 41 AM" src="https://github.com/user-attachments/assets/14239dbe-3f44-4cf9-877f-100671884bf6" />

#### ClimaSeaIce debug plots
<img width="1494" height="771" alt="Screenshot 2026-02-27 at 11 33 08 AM" src="https://github.com/user-attachments/assets/0945a24a-294e-4191-942c-0c0c3f565075" />

#### Coupler fields _before_ this PR (on unphysical basis)
<img width="750" height="180" alt="Screenshot 2026-02-27 at 11 35 47 AM" src="https://github.com/user-attachments/assets/4f6940a4-d121-4621-ad69-acddf7237296" />

<img width="1037" height="256" alt="Screenshot 2026-02-27 at 11 36 01 AM" src="https://github.com/user-attachments/assets/8e2eee1a-90dc-4174-b01c-9735e1afc5cc" />

#### Coupler fields _after_ this PR (on Cartesian basis)
<img width="1084" height="256" alt="Screenshot 2026-02-27 at 11 37 59 AM" src="https://github.com/user-attachments/assets/b5012147-e540-409a-bb4c-f09e75c3e6d8" />

<img width="1084" height="256" alt="Screenshot 2026-02-27 at 11 37 46 AM" src="https://github.com/user-attachments/assets/f3ee505f-7bc7-4fb5-9dd6-60780a1c02d5" />

