### PR TITLE
Fix runaway eta (free sfc displacement) at high latitudes

### DIFF
--- a/ext/ClimaCouplerCMIPExt/clima_seaice.jl
+++ b/ext/ClimaCouplerCMIPExt/clima_seaice.jl
@@ -340,8 +340,8 @@ function FluxCalculator.update_turbulent_fluxes!(sim::ClimaSeaIceSimulation, fie
     OC.set!(sim.remapping.scratch_cc2, sim.remapping.scratch_arr2) # meridional momentum flux
 
     # Rename for clarity; these are now Center, Center Oceananigans fields
-    F_turb_ρτxz_cc = sim.remapping.scratch_cc1
-    F_turb_ρτyz_cc = sim.remapping.scratch_cc2
+    F_turb_ρτxz_cell = sim.remapping.scratch_cc1
+    F_turb_ρτyz_cell = sim.remapping.scratch_cc2
 
     # Set the momentum flux BCs at the correct locations using the remapped scratch fields
     # Note that this requires the sea ice model to always be run with dynamics turned on
@@ -350,8 +350,8 @@ function FluxCalculator.update_turbulent_fluxes!(sim::ClimaSeaIceSimulation, fie
     set_from_extrinsic_vector!(
         (; u = si_flux_u, v = si_flux_v),
         grid,
-        F_turb_ρτxz_cc,
-        F_turb_ρτyz_cc,
+        F_turb_ρτxz_cell,
+        F_turb_ρτyz_cell,
     )
 
     # Remap the latent and sensible heat fluxes using scratch arrays
@@ -446,6 +446,7 @@ function FluxCalculator.ocean_seaice_fluxes!(
     ocean_sim::OceananigansSimulation,
     ice_sim::ClimaSeaIceSimulation,
 )
+    grid = ocean_sim.ocean.model.grid
     ocean_properties = ocean_sim.ocean_properties
     ice_concentration = Interfacer.get_field(ice_sim, Val(:ice_concentration))
 
@@ -475,12 +476,15 @@ function FluxCalculator.ocean_seaice_fluxes!(
     # Compute fluxes for u, v, T, and S from momentum, heat, and freshwater fluxes
     oc_flux_u = surface_flux(ocean_sim.ocean.model.velocities.u)
     oc_flux_v = surface_flux(ocean_sim.ocean.model.velocities.v)
+    # polar-exclusion mask
+    polar_excl_centers = ocean_sim.remapping.polar_exclusion_flux_mask_centers
+    polar_excl_u = ocean_sim.remapping.polar_exclusion_flux_mask_u
+    polar_excl_v = ocean_sim.remapping.polar_exclusion_flux_mask_v
 
     ρτxio = ice_sim.ocean_ice_interface.fluxes.x_momentum # sea_ice - ocean zonal momentum flux
     ρτyio = ice_sim.ocean_ice_interface.fluxes.y_momentum # sea_ice - ocean meridional momentum flux
 
     # Update the momentum flux contributions from ocean/sea ice fluxes
-    grid = ocean_sim.ocean.model.grid
     arch = OC.Architectures.architecture(grid)
     OC.Utils.launch!(
         arch,
@@ -495,15 +499,26 @@ function FluxCalculator.ocean_seaice_fluxes!(
         ρₒ⁻¹,
         ice_concentration,
     )
+    # polar-exclusion mask
+    flux_u = OC.interior(oc_flux_u, :, :, 1)
+    flux_v = OC.interior(oc_flux_v, :, :, 1)
+    flux_u .= ifelse.(polar_excl_u .≈ 0, zero(flux_u), flux_u)
+    flux_v .= ifelse.(polar_excl_v .≈ 0, zero(flux_v), flux_v)
 
     oc_flux_T = surface_flux(ocean_sim.ocean.model.tracers.T)
-    OC.interior(oc_flux_T, :, :, 1) .+=
+    qi_masked = OC.interior(ocean_sim.remapping.scratch_cc1, :, :, 1)
+    qi_masked .=
         OC.interior(ice_concentration, :, :, 1) .* OC.interior(Qi, :, :, 1) .* ρₒ⁻¹ ./ cₒ
+    qi_masked .= ifelse.(polar_excl_centers .≈ 0, zero(qi_masked), qi_masked)
+    OC.interior(oc_flux_T, :, :, 1) .+= qi_masked
 
     oc_flux_S = surface_flux(ocean_sim.ocean.model.tracers.S)
-    OC.interior(oc_flux_S, :, :, 1) .+=
+    salt_contrib = OC.interior(ocean_sim.remapping.scratch_cc2, :, :, 1)
+    salt_contrib .=
         OC.interior(ice_concentration, :, :, 1) .*
         OC.interior(ice_sim.ocean_ice_interface.fluxes.salt, :, :, 1)
+    salt_contrib .= ifelse.(polar_excl_centers .≈ 0, zero(salt_contrib), salt_contrib)
+    OC.interior(oc_flux_S, :, :, 1) .+= salt_contrib
 
     return nothing
 end

--- a/ext/ClimaCouplerCMIPExt/oceananigans.jl
+++ b/ext/ClimaCouplerCMIPExt/oceananigans.jl
@@ -101,7 +101,7 @@ function OceananigansSimulation(
         arch;
         size = resolution_points,
         longitude = (-180, 180),
-        latitude = (-80, 80),   # NOTE: Don't goo to high up when using LatLongGrid, or the cells will be too small
+        latitude = (-80, 80),   # NOTE: Don't go too high up when using LatLongGrid, or the cells will be too small
         z,
         halo = (7, 7, 7),
     )
@@ -198,6 +198,16 @@ function OceananigansSimulation(
     # Allocate space for a Field of UVVectors, which we need for remapping momentum fluxes
     temp_uv_vec = CC.Fields.Field(CC.Geometry.UVVector{FT}, boundary_space)
 
+    # polar-exclusion mask
+    # Precompute polar-exclusion flux masks once (zeros ocean surface fluxes where |lat| ≥ 80° to avoid instability).
+    # _centers = cell-centered (T, S); _u = Face/Center (u); _v = Center/Face (v).
+    polar_exclusion_flux_mask_centers =
+        ocean_flux_highlat_mask(grid; location = (OC.Center(), OC.Center(), OC.Center()))
+    polar_exclusion_flux_mask_u =
+        ocean_flux_highlat_mask(grid; location = (OC.Face(), OC.Center(), OC.Center()))
+    polar_exclusion_flux_mask_v =
+        ocean_flux_highlat_mask(grid; location = (OC.Center(), OC.Face(), OC.Center()))
+
     remapping = (;
         remapper_cc,
         scratch_cc1,
@@ -206,6 +216,10 @@ function OceananigansSimulation(
         scratch_arr2,
         scratch_arr3,
         temp_uv_vec,
+        # polar-exclusion mask
+        polar_exclusion_flux_mask_centers,
+        polar_exclusion_flux_mask_u,
+        polar_exclusion_flux_mask_v,
     )
 
     # COARE3 roughness params (allocated once, reused each timestep)
@@ -280,11 +294,9 @@ end
     FieldExchanger.resolve_area_fractions!(ocean_sim, ice_sim, land_fraction)
 
 Ensure the ocean and ice area fractions are consistent with each other.
-This matters in the case of a LatitudeLongitudeGrid, which is only
-defined between -80 and 80 degrees latitude. In this case, we set the ice
-and ocean area fractions to 0 and the land fraction to 1 on [78°S, 90°S]
-and on [78°N, 90°N]. Note the overlap between 78° and 80° to avoid any gaps
-introduced by the cubed sphere not aligning with latitude lines.
+This matters in the case of a LatitudeLongitudeGrid, which only extends to
+±80° latitude. We set ice and ocean area fractions to 0 and land to 1 where
+|lat| ≥ 80° (same band used to zero ocean surface fluxes).
 
 This function also updates the ice concentration field in the ocean simulation
 so that it can be used for weighting flux updates.
@@ -298,7 +310,7 @@ function FieldExchanger.resolve_area_fractions!(
         ocean_fraction = Interfacer.get_field(ocean_sim, Val(:area_fraction))
         ice_fraction = Interfacer.get_field(ice_sim, Val(:area_fraction))
 
-        # Create a "polar" mask that's 1 at latitudes in [-90, -80] and [80, 90] degrees
+        # Polar mask: 1 where |lat| ≥ 80° (same band used to zero ocean fluxes)
         boundary_space = axes(ocean_fraction)
         FT = CC.Spaces.undertype(boundary_space)
         lat = CC.Fields.coordinate_field(boundary_space).lat
@@ -349,6 +361,26 @@ Interfacer.get_field(sim::OceananigansSimulation, ::Val{:surface_temperature}) =
     sim.ocean.model.tracers.T + sim.ocean_properties.C_to_K # convert from Celsius to Kelvin
 
 """
+    ocean_flux_highlat_mask(grid; location)
+
+Build the ocean flux high latitude mask once at setup.
+Currently we define ocean between 80degS to 80degN with 2 degree overlap in the coupler mask.
+Returns a 2D mask (1.0 where |lat| < 80°, 0.0 elsewhere). This mask is on the ocean grid (
+unlike the polar mask which is defined on the boundary_space)
+"""
+# polar-exclusion mask
+function ocean_flux_highlat_mask(grid; location = (OC.Center(), OC.Center(), OC.Center()))
+    polar_flux_lat_deg = 78.0  # zero fluxes where |lat| ≥ this (same band as polar_mask)
+    φ = OC.φnodes(grid, location[1], location[2], location[3])
+    φ_2D = Array(φ[:, :, 1])
+    lat_deg = abs.(rad2deg.(φ_2D))
+    mask = ifelse.(lat_deg .< polar_flux_lat_deg, 1.0, 0.0)
+    mask = reshape(mask[1, :], 1, :)
+    arch = OC.Architectures.architecture(grid)
+    return OC.Architectures.on_architecture(arch, mask)
+end
+
+"""
     FluxCalculator.update_turbulent_fluxes!(sim::OceananigansSimulation, fields)
 
 Update the turbulent fluxes in the simulation using the values computed at this time step.
@@ -371,7 +403,9 @@ function FluxCalculator.update_turbulent_fluxes!(sim::OceananigansSimulation, fi
     (; F_lh, F_sh, F_turb_ρτxz, F_turb_ρτyz, F_turb_moisture) = fields
     (; reference_density, heat_capacity) = sim.ocean_properties
     grid = sim.ocean.model.grid
-    ice_concentration = sim.ice_concentration
+    ice_concentration_field = sim.ice_concentration
+    # polar-exclusion mask
+    polar_excl_centers = sim.remapping.polar_exclusion_flux_mask_centers
 
     # Convert the momentum fluxes from contravariant to Cartesian basis
     contravariant_to_cartesian!(sim.remapping.temp_uv_vec, F_turb_ρτxz, F_turb_ρτyz)
@@ -392,16 +426,17 @@ function FluxCalculator.update_turbulent_fluxes!(sim::OceananigansSimulation, fi
     )
     OC.set!(sim.remapping.scratch_cc2, sim.remapping.scratch_arr2) # meridional momentum flux
 
-    # Rename for clarity; these are now Center, Center Oceananigans fields
-    F_turb_ρτxz_cc = sim.remapping.scratch_cc1
-    F_turb_ρτyz_cc = sim.remapping.scratch_cc2
+    # Rename for clarity; these are now cell-centered (Center, Center) Oceananigans fields
+    F_turb_ρτxz_cell = sim.remapping.scratch_cc1
+    F_turb_ρτyz_cell = sim.remapping.scratch_cc2
 
-    # Weight by (1 - sea ice concentration)
-    OC.interior(F_turb_ρτxz_cc, :, :, 1) .=
-        OC.interior(F_turb_ρτxz_cc, :, :, 1) .* (1.0 .- ice_concentration) ./
+    # Weight by (1 - sea ice concentration); polar-exclusion mask applied via ifelse below
+    ice_concentration = OC.interior(ice_concentration_field, :, :, 1)
+    OC.interior(F_turb_ρτxz_cell, :, :, 1) .=
+        OC.interior(F_turb_ρτxz_cell, :, :, 1) .* (1.0 .- ice_concentration) ./
         reference_density
-    OC.interior(F_turb_ρτyz_cc, :, :, 1) .=
-        OC.interior(F_turb_ρτyz_cc, :, :, 1) .* (1.0 .- ice_concentration) ./
+    OC.interior(F_turb_ρτyz_cell, :, :, 1) .=
+        OC.interior(F_turb_ρτyz_cell, :, :, 1) .* (1.0 .- ice_concentration) ./
         reference_density
 
     # Set the momentum flux BCs at the correct locations using the remapped scratch fields
@@ -410,9 +445,16 @@ function FluxCalculator.update_turbulent_fluxes!(sim::OceananigansSimulation, fi
     set_from_extrinsic_vector!(
         (; u = oc_flux_u, v = oc_flux_v),
         grid,
-        F_turb_ρτxz_cc,
-        F_turb_ρτyz_cc,
+        F_turb_ρτxz_cell,
+        F_turb_ρτyz_cell,
     )
+    # polar-exclusion mask
+    polar_excl_u = sim.remapping.polar_exclusion_flux_mask_u
+    polar_excl_v = sim.remapping.polar_exclusion_flux_mask_v
+    flux_u = OC.interior(oc_flux_u, :, :, 1)
+    flux_v = OC.interior(oc_flux_v, :, :, 1)
+    flux_u .= ifelse.(polar_excl_u .≈ 0, zero(flux_u), flux_u)
+    flux_v .= ifelse.(polar_excl_v .≈ 0, zero(flux_v), flux_v)
 
     # Remap the latent and sensible heat fluxes using scratch arrays
     CC.Remapping.interpolate!(sim.remapping.scratch_arr1, sim.remapping.remapper_cc, F_lh) # latent heat flux
@@ -426,6 +468,9 @@ function FluxCalculator.update_turbulent_fluxes!(sim::OceananigansSimulation, fi
     # everything on the surface, but later we will need to account for this.
     # One way we can do this is using directly ClimaOcean
     oc_flux_T = surface_flux(sim.ocean.model.tracers.T)
+    # polar-exclusion mask
+    @. remapped_F_lh = ifelse(polar_excl_centers .≈ 0, zero(remapped_F_lh), remapped_F_lh)
+    @. remapped_F_sh = ifelse(polar_excl_centers .≈ 0, zero(remapped_F_sh), remapped_F_sh)
     OC.interior(oc_flux_T, :, :, 1) .=
         OC.interior(oc_flux_T, :, :, 1) .+
         (1.0 .- ice_concentration) .* (remapped_F_lh .+ remapped_F_sh) ./
@@ -441,6 +486,12 @@ function FluxCalculator.update_turbulent_fluxes!(sim::OceananigansSimulation, fi
     moisture_fresh_water_flux = sim.remapping.scratch_arr1 ./ reference_density
     oc_flux_S = surface_flux(sim.ocean.model.tracers.S)
     surface_salinity = OC.interior(sim.ocean.model.tracers.S, :, :, grid.Nz)
+    # polar-exclusion mask
+    @. moisture_fresh_water_flux = ifelse(
+        polar_excl_centers .≈ 0,
+        zero(moisture_fresh_water_flux),
+        moisture_fresh_water_flux,
+    )
     OC.interior(oc_flux_S, :, :, 1) .=
         OC.interior(oc_flux_S, :, :, 1) .-
         (1.0 .- ice_concentration) .* surface_salinity .* moisture_fresh_water_flux
@@ -473,8 +524,12 @@ so a sign change is needed when we convert from precipitation to salinity flux.
 """
 function FieldExchanger.update_sim!(sim::OceananigansSimulation, csf)
     (; reference_density, heat_capacity) = sim.ocean_properties
-    ice_concentration = sim.ice_concentration
-    Nz = sim.ocean.model.grid.Nz
+    grid = sim.ocean.model.grid
+    Nz = grid.Nz
+    ice_concentration = OC.interior(sim.ice_concentration, :, :, 1)
+    oc_flux_T = surface_flux(sim.ocean.model.tracers.T)
+    # polar-exclusion mask
+    polar_excl_centers = sim.remapping.polar_exclusion_flux_mask_centers
 
     # Remap radiative flux onto scratch array; rename for clarity
     CC.Remapping.interpolate!(
@@ -493,11 +548,13 @@ function FieldExchanger.update_sim!(sim::OceananigansSimulation, csf)
 
     # Update only the part due to radiative fluxes. For the full update, the component due
     # to latent and sensible heat is missing and will be updated in update_turbulent_fluxes.
-    oc_flux_T = surface_flux(sim.ocean.model.tracers.T)
     (; σ, C_to_K) = sim.ocean_properties
     α = Interfacer.get_field(sim, Val(:surface_direct_albedo)) # scalar
     ϵ = Interfacer.get_field(sim, Val(:emissivity)) # scalar
-    OC.interior(oc_flux_T, :, :, 1) .=
+
+    # Compute radiative contribution; polar-exclusion mask applied via ifelse
+    rad_T_flux = sim.remapping.scratch_arr3
+    rad_T_flux .=
         (1.0 .- ice_concentration) .* (
             -(1 - α) .* remapped_SW_d .-
             ϵ * (
@@ -505,6 +562,8 @@ function FieldExchanger.update_sim!(sim::OceananigansSimulation, csf)
                 σ .* (C_to_K .+ OC.interior(sim.ocean.model.tracers.T, :, :, Nz)) .^ 4
             )
         ) ./ (reference_density * heat_capacity)
+    @. rad_T_flux = ifelse(polar_excl_centers .≈ 0, zero(rad_T_flux), rad_T_flux)
+    OC.interior(oc_flux_T, :, :, 1) .= rad_T_flux
 
     # Remap precipitation fields onto scratch arrays; rename for clarity
     CC.Remapping.interpolate!(
@@ -517,11 +576,22 @@ function FieldExchanger.update_sim!(sim::OceananigansSimulation, csf)
         sim.remapping.remapper_cc,
         csf.P_snow,
     )
-    remapped_P_liq = sim.remapping.scratch_arr1
-    remapped_P_snow = sim.remapping.scratch_arr2
+    remapped_P_liq =
+        ifelse.(
+            polar_excl_centers .≈ 0,
+            zero(sim.remapping.scratch_arr1),
+            sim.remapping.scratch_arr1,
+        )
+    remapped_P_snow =
+        ifelse.(
+            polar_excl_centers .≈ 0,
+            zero(sim.remapping.scratch_arr2),
+            sim.remapping.scratch_arr2,
+        )
 
     # Virtual salt flux
     oc_flux_S = surface_flux(sim.ocean.model.tracers.S)
+    # polar-exclusion mask
     OC.interior(oc_flux_S, :, :, 1) .=
         OC.interior(oc_flux_S, :, :, 1) .-
         OC.interior(sim.ocean.model.tracers.S, :, :, Nz) .* (1.0 .- ice_concentration) .*


### PR DESCRIPTION
Current main branch simulations fail with runaway eta values at high latitudes - e.g. (Longrun; 16 horizontal elements in atmos cubed-sphere mesh) 

<img width="788" height="526" alt="free_sfc_displacement_2657" src="https://github.com/user-attachments/assets/74c96cb9-5d1d-4e1a-92a5-fe440ee9b86d" />

This PR introduces an ocean flux high-lat mask which zeros all ocean surface flux updates where |lat| ≥ 78° (user defined polar mask latitude), so the ocean is not forced in that band. This fixes an issue with inconsistent flux balances in the overlap area and stabilizes simulations for up to 2 weeks. 

<img width="782" height="523" alt="Screenshot 2026-02-26 at 11 45 01 AM" src="https://github.com/user-attachments/assets/3cead1e9-98ca-4444-a2ae-3a9d0f23725d" />

<img width="3000" height="1600" alt="debug_coupler" src="https://github.com/user-attachments/assets/b88f1829-5b95-42a8-bdef-7bfd671a77b8" />
