### PR TITLE
Added and enabled GW flags in AMIP run files

### DIFF
--- a/config/atmos_configs/climaatmos_diagedmf.yml
+++ b/config/atmos_configs/climaatmos_diagedmf.yml
@@ -30,3 +30,5 @@ viscous_sponge: true
 z_elem: 63
 z_max: 60000.0
 microphysics_model: "0M"
+non_orographic_gravity_wave: true
+orographic_gravity_wave: "raw_topo"

--- a/config/atmos_configs/climaatmos_edonly.yml
+++ b/config/atmos_configs/climaatmos_edonly.yml
@@ -23,3 +23,5 @@ viscous_sponge: true
 z_elem: 63
 z_max: 60000.0
 microphysics_model: "0M"
+non_orographic_gravity_wave: true
+orographic_gravity_wave: "raw_topo"

--- a/config/atmos_configs/climaatmos_progedmf.yml
+++ b/config/atmos_configs/climaatmos_progedmf.yml
@@ -37,3 +37,5 @@ viscous_sponge: true
 z_elem: 63
 z_max: 60000.0
 microphysics_model: "0M"
+non_orographic_gravity_wave: true
+orographic_gravity_wave: "raw_topo"

--- a/config/atmos_configs/climaatmos_progedmf_1m.yml
+++ b/config/atmos_configs/climaatmos_progedmf_1m.yml
@@ -38,3 +38,5 @@ viscous_sponge: true
 z_elem: 63
 z_max: 60000.0
 microphysics_model: "1M"
+non_orographic_gravity_wave: true
+orographic_gravity_wave: "raw_topo"

--- a/config/atmos_configs/climaatmos_wx_diagedmf.yml
+++ b/config/atmos_configs/climaatmos_wx_diagedmf.yml
@@ -43,3 +43,7 @@ toml: [toml/diagnostic_edmfx_era5_ic.toml]
 cloud_model: "quadrature"
 use_itime: true
 deep_atmosphere: true
+
+### Gravity waves ###
+non_orographic_gravity_wave: true
+orographic_gravity_wave: "raw_topo"

--- a/config/atmos_configs/climaatmos_wx_progedmf.yml
+++ b/config/atmos_configs/climaatmos_wx_progedmf.yml
@@ -47,3 +47,7 @@ microphysics_model: "0M"
 cloud_model: "quadrature"
 use_itime: true
 deep_atmosphere: true
+
+### Gravity waves ###
+non_orographic_gravity_wave: true
+orographic_gravity_wave: "raw_topo"

--- a/experiments/test/restart.jl
+++ b/experiments/test/restart.jl
@@ -116,6 +116,7 @@ cs_two_steps2 = setup_and_run(two_steps)
             :face_clear_sw_direct_flux_dn,      # Not filled by RRTGMP
             :face_sw_direct_flux_dn,            # Not filled by RRTGMP
             :rc,                                # CUDA internal object
+            :non_orographic_gravity_wave,       # Recomputed every timestep; sensitive to FP accumulation
         ],
     )
 


### PR DESCRIPTION
CI of this PR depends on the following PRs to pass:
https://github.com/CliMA/ClimaArtifacts/pull/150
https://github.com/CliMA/ClimaAtmos.jl/pull/4346

<!--- THESE LINES ARE COMMENTED -->
## Purpose and Content
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
As the gravity wave schemes have been added to ClimaAtmos, we now enable gravity wave parameterization in all AMIP runs with non-trivial orographic.

Note that `nogw_dc` was increased from the default 0.8 to reduce the number of spectral components from 250 to 50 for GPU compatibility. This is necessary to avoid memory issues on the P100s.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
