### PR TITLE
Add CALIPSO/CloudSat dataloader

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -65,3 +65,9 @@ git-tree-sha1 = "ce2b3b1f113f88956db112c81f8d48a62d9f57ae"
     [[modis_lwp_iwp.download]]
     sha256 = "ca0dce6450a4cb101bd4581b9dfb50164ad6518ffe96f617471d2f23f2b46367"
     url = "https://caltech.box.com/shared/static/bl0efc6st1i0sdmxx8bs70qof0xov4d9.gz"
+
+[calipso_cloudsat]
+git-tree-sha1 = "dae77bc4ff79194ee6e794c1181bec1bebd67ea9"
+
+[calipso_cloudsat_lowres]
+git-tree-sha1 = "c1c0a16127bd547124cdf7288140002d74846efe"

--- a/src/CalibrationTools.jl
+++ b/src/CalibrationTools.jl
@@ -12,6 +12,9 @@ import ClimaAnalysis
 import ClimaAnalysis: NCCatalog
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
 
+# TODO: Remove this once the name is added to ClimaAnalysis
+push!(ClimaAnalysis.Var.ALTITUDE_NAMES, "height")
+
 """
     struct CalibrateConfig{SPINUP <: Dates.Period, EXTEND <: Dates.Period}
 
@@ -212,7 +215,7 @@ const STANDARD_UNITS = Dict(
 """
     ERA5DataLoader(; era5_to_clima_names = ERA5_TO_CLIMA_NAMES)
 
-Construct a data loader which you can load preprocessed ERA5 monthly
+Construct a data loader which you can used to load preprocessed ERA5 monthly
 time-averaged data in `OutputVar`, where
 - the short name, sign of the data, and units match CliMA conventions
 - the latitudes are shifted to be -180 to 180 degrees,
@@ -312,7 +315,7 @@ const CERES_DERIVED_VARS = Set(["swcre", "lwcre"])
 """
     CERESDataLoader(; ceres_to_clima_names = CERES_TO_CLIMA_NAMES)
 
-Construct a data loader which you can load preprocessed CERES monthly
+Construct a data loader which you can used to load preprocessed CERES monthly
 time-averaged TOA radiation data in `OutputVar`, where
 - the short name and units match CliMA conventions,
 - the latitudes are shifted to be -180 to 180 degrees,
@@ -409,7 +412,7 @@ const GPCP_TO_CLIMA_NAMES = ["precip" => "pr"]
 """
     GPCPDataLoader(; gpcp_to_clima_names = GPCP_TO_CLIMA_NAMES)
 
-Construct a data loader which you can load preprocessed GPCP monthly
+Construct a data loader which you can used to load preprocessed GPCP monthly
 time-averaged precipitation data in `OutputVar`, where
 - the short name and sign of the data match CliMA conventions
 - the latitudes are shifted to be -180 to 180 degrees,
@@ -469,7 +472,7 @@ const ERA5_PRESSURE_LEVEL_TO_CLIMA_NAMES = ["t" => "ta", "q" => "hus", "r" => "h
     ERA5PressureLevelDataLoader(;
         era5_pressure_level_to_clima_names = ERA5_PRESSURE_LEVEL_TO_CLIMA_NAMES)
 
-Construct a data loader which you can load preprocessed monthly
+Construct a data loader which you can used to load preprocessed monthly
 time-averaged ERA5 data on pressure levels in `OutputVar`, where
 - the short name and sign of the data match CliMA conventions,
 - the latitudes are shifted to be -180 to 180 degrees,
@@ -543,7 +546,7 @@ const MODIS_TO_CLIMA_NAMES = ["lwp" => "lwp", "iwp" => "clivi"]
         modis_to_clima_names = MODIS_TO_CLIMA_NAMES,
     )
 
-Construct a data loader which you can load preprocessed monthly time-averaged
+Construct a data loader which you can used to load preprocessed monthly time-averaged
 MODIS data on single levels in `OutputVar`, where
 - the short name and sign of the data match CliMA conventions,
 - the latitudes are shifted to be -180 to 180 degrees,
@@ -588,9 +591,158 @@ function preprocess(::ModisDataLoader, var, ::Union{Val{:clivi}, Val{:lwp}})
     var = _preprocess_var(var)
     not_nans = filter(!isnan, var.data)
     global_mean = sum(not_nans) / length(not_nans)
-    @info "$(ClimaAnalysis.short_name(var)): Imputting $global_mean for NaNs"
+    @info "$(ClimaAnalysis.short_name(var)): Imputing global mean $global_mean for NaNs"
     replace!(x -> isnan(x) ? global_mean : x, var)
     return var
+end
+
+"""
+    CalipsoDataLoader
+
+A struct for loading preprocessed CALIPSO/CloudSat cloud fraction data on altitude
+levels as `OutputVar`s.
+"""
+struct CalipsoDataLoader <: AbstractDataLoader
+    catalog::NCCatalog
+    available_vars::Set{String}
+end
+
+const CALIPSO_TO_CLIMA_NAMES = ["cloud_fraction_on_levels" => "cl"]
+
+"""
+    CalipsoDataLoader(; calipso_to_clima_names = CALIPSO_TO_CLIMA_NAMES)
+
+Construct a data loader which you can used to load preprocessed monthly CALIPSO/CloudSat
+cloud fraction on altitude levels in `OutputVar`, where
+- the short name and units match CliMA conventions,
+- the latitudes are shifted to be -180 to 180 degrees,
+- the times are at the start of the time period (e.g. the time average of
+  January is on the first of January instead of January 15th),
+- values are fractions in [0, 1]
+
+The CALIPSO/CloudSat data comes from the `calipso_cloudsat` artifact, which
+repackages the 3S-GEOPROF-COMB dataset. See
+[ClimaArtifacts](https://github.com/CliMA/ClimaArtifacts/tree/main/calipso_cloudsat)
+for more information about this artifact.
+
+The keyword argument `calipso_to_clima_names` is a vector of pairs mapping
+CALIPSO/CloudSat variable name to CliMA name.
+"""
+function CalipsoDataLoader(; calipso_to_clima_names = CALIPSO_TO_CLIMA_NAMES)
+    artifact_dir = @clima_artifact("calipso_cloudsat")
+    monthly_file = joinpath(artifact_dir, "radarlidar_monthly_2.5x2.5.nc")
+
+    catalog = NCCatalog()
+    ClimaAnalysis.add_file!(catalog, monthly_file, calipso_to_clima_names...)
+    return CalipsoDataLoader(catalog, Set(last.(calipso_to_clima_names)))
+end
+
+"""
+    get(loader::CalipsoDataLoader, short_name::String)
+
+Get the preprocessed `OutputVar` with the name `short_name` from the
+CALIPSO/CloudSat dataset.
+"""
+function Base.get(loader::CalipsoDataLoader, short_name::String)
+    (; catalog, available_vars) = loader
+    short_name in available_vars || error(
+        "$short_name is not available to load. To add this variable, pass it to calipso_to_clima_names as a pair mapping CALIPSO/CloudSat name to CliMA name and create a new CalipsoDataLoader",
+    )
+    var = get(catalog, short_name; var_kwargs = (shift_by = Dates.firstdayofmonth,))
+    return preprocess(loader, var, Val(Symbol(short_name)))
+end
+
+"""
+    preprocess(::CalipsoDataLoader, var, ::Val{varname}) where {varname}
+
+Preprocess `var` with short name `varname`.
+"""
+function preprocess(::CalipsoDataLoader, var, ::Val{:cl})
+    # Select "All cases" doop (first index)
+    var = ClimaAnalysis.slice(var; doop = 1, by = ClimaAnalysis.Index())
+    var = _preprocess_var(var)
+    # Convert from percentage (0–100) to fraction (0–1)
+    var = ClimaAnalysis.convert_units(var, "unitless"; conversion_function = x -> x / 100)
+    # Impute missing and NaN values with the global mean in one pass
+    T = nonmissingtype(eltype(var.data))
+    valid = filter(x -> !ismissing(x) && !isnan(x), vec(var.data))
+    global_mean = T(sum(valid) / length(valid))
+    @info "$(ClimaAnalysis.short_name(var)): Imputing global mean $global_mean for missing/NaN values"
+    return ClimaAnalysis.remake(
+        var;
+        data = map(x -> (ismissing(x) || isnan(x)) ? global_mean : T(x), var.data),
+    )
+end
+
+"""
+    regrid_to_model_levels(obs_var, model_altitudes)
+
+Regrid `obs_var` from dataset altitude levels to `model_altitudes` using a
+Gaussian-weighted average along the altitude dimension.
+
+For each model level `k` with altitude `z_k`, the regridded value is:
+
+    obs(z_k) = sum_i w_i(k) * obs(z_i)
+
+where the sum is over all dataset levels `i` with altitude `z_i`, and the
+normalized weight is:
+
+    w_i(k) = exp(-(z_i - z_k)^2 / (2 * sigma_k^2)) / Z_k
+    Z_k     = sum_j exp(-(z_j - z_k)^2 / (2 * sigma_k^2))
+
+The bandwidth `sigma_k` is half the spacing between neighboring model levels:
+
+    sigma_k = 0.5 * (z_{k+1} - z_{k-1})   (interior levels)
+    sigma_1 = 0.5 * (z_2 - z_1)            (lower boundary)
+    sigma_K = 0.5 * (z_K - z_{K-1})        (upper boundary)
+
+All other dimensions (lon, lat, time, …) are left unchanged; only the altitude
+axis is replaced by `model_altitudes`.
+
+`obs_var` must have an altitude dimension. `model_altitudes` should be in the
+same units as the altitude coordinate of `obs_var` (meters above mean sea
+level for the CALIPSO/CloudSat dataset).
+"""
+function regrid_to_model_levels(obs_var::ClimaAnalysis.OutputVar, model_altitudes)
+    ClimaAnalysis.has_altitude(obs_var) || error(
+        "obs_var with short name $(short_name(obs_var)) is missing the altitude dimension",
+    )
+    alt_name = ClimaAnalysis.altitude_name(obs_var)
+    alt_axis = obs_var.dim2index[alt_name]
+    z_i = ClimaAnalysis.altitudes(obs_var)
+    z_k = model_altitudes
+    K = length(z_k)
+
+    # Compute sigma for each model level (half the central finite difference)
+    sigmas = map(1:K) do k
+        if k == 1
+            0.5 * (z_k[2] - z_k[1])
+        elseif k == K
+            0.5 * (z_k[K] - z_k[K - 1])
+        else
+            0.5 * (z_k[k + 1] - z_k[k - 1])
+        end
+    end
+
+    # Allocate output array with model altitude size along alt_axis
+    out_shape = ntuple(i -> i == alt_axis ? K : size(obs_var.data, i), ndims(obs_var.data))
+    out_data = zeros(eltype(obs_var.data), out_shape)
+
+    # For each model level k, compute normalized Gaussian weights over all
+    # dataset levels and accumulate the weighted sum into the corresponding
+    # slice of out_data
+    for k in 1:K
+        weights = @. exp(-(z_i - z_k[k])^2 / (2 * sigmas[k]^2))
+        weights ./= sum(weights)
+        out_k = selectdim(out_data, alt_axis, k)
+        for (i, w) in enumerate(weights)
+            out_k .+= w .* selectdim(obs_var.data, alt_axis, i)
+        end
+    end
+
+    new_dims = copy(obs_var.dims)
+    new_dims[alt_name] = model_altitudes
+    return ClimaAnalysis.remake(obs_var; dims = new_dims, data = out_data)
 end
 
 """

--- a/test/calibration_tools_tests.jl
+++ b/test/calibration_tools_tests.jl
@@ -5,6 +5,9 @@ import ClimaCoupler
 import ClimaCoupler: CalibrationTools
 import ClimaAnalysis
 
+# TODO: Remove this once the name is added to ClimaAnalysis
+push!(ClimaAnalysis.Var.ALTITUDE_NAMES, "height")
+
 @testset "Calibrate config" begin
     config_file =
         joinpath(pkgdir(ClimaCoupler), "experiments", "ClimaEarth", "test", "amip_test.jl")
@@ -158,6 +161,60 @@ end
     @test lwcre.data ≈ rlutcs.data .- rlut.data
 
     @test_throws ErrorException get(data_loader, "idk")
+end
+
+@testset "Calipso data loader" begin
+    artifact_on_disk("calipso_cloudsat") || return
+    data_loader = CalibrationTools.CalipsoDataLoader()
+
+    varnames = last.(CalibrationTools.CALIPSO_TO_CLIMA_NAMES)
+    @test CalibrationTools.available_vars(data_loader) == Set(varnames)
+
+    for varname in varnames
+        var = get(data_loader, varname)
+        check_conventions(var, varname)
+        @test ClimaAnalysis.units(var) == "unitless"
+        @test all(0 .<= var.data .<= 1)
+        @test !haskey(var.dims, "doop")
+    end
+
+    @test_throws ErrorException get(data_loader, "idk")
+end
+
+@testset "regrid_to_model_levels" begin
+
+    # Construct a simple synthetic OutputVar with an altitude dimension
+    # dims: (altitude=5, lon=2)
+    lons = [0.0, 1.0]
+    z_i = [0.0, 1000.0, 2000.0, 3000.0, 4000.0]
+    # data: cloud fraction = 0.5 everywhere
+    data = fill(0.5f0, length(lons), length(z_i))
+    dims = Dict("z" => z_i, "longitude" => lons)
+    dim_attribs = Dict("z" => Dict{String, Any}(), "longitude" => Dict{String, Any}())
+    attribs = Dict{String, Any}("short_name" => "cl", "units" => "unitless")
+    obs_var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
+
+    # Regrid to 3 model levels
+    model_alts = [500.0, 2000.0, 3500.0]
+    result = CalibrationTools.regrid_to_model_levels(obs_var, model_alts)
+
+    @test size(result.data, 1) == length(lons)
+    @test size(result.data, 2) == 3
+    @test ClimaAnalysis.altitudes(result) == model_alts
+    # Since data is constant 0.5, weighted average should also be 0.5
+    @test all(result.data .≈ 0.5f0)
+
+    # Test with real CALIPSO data
+    if artifact_on_disk("calipso_cloudsat")
+        cl_var = get(CalibrationTools.CalipsoDataLoader(), "cl")
+        z_obs = ClimaAnalysis.altitudes(cl_var)
+        # Pick 5 evenly-spaced model levels within the observed altitude range
+        model_alts = collect(range(first(z_obs), last(z_obs), length = 5))
+        result_calipso = CalibrationTools.regrid_to_model_levels(cl_var, model_alts)
+        @test length(ClimaAnalysis.altitudes(result_calipso)) == 5
+        @test ClimaAnalysis.altitudes(result_calipso) ≈ model_alts
+        @test all(0 .<= result_calipso.data .<= 1)
+    end
 end
 
 @testset "Other data loaders" begin


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Adds a DataLoader for the CALIPSO/CloudSat dataset and a smooth weighting function `regrid_to_model_levels` to map the dataset to model vertical levels.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
