### PR TITLE
update docstrings to reflect polar mask extent

### DIFF
--- a/ext/ClimaCouplerCMIPExt/oceananigans.jl
+++ b/ext/ClimaCouplerCMIPExt/oceananigans.jl
@@ -199,7 +199,7 @@ function OceananigansSimulation(
     temp_uv_vec = CC.Fields.Field(CC.Geometry.UVVector{FT}, boundary_space)
 
     # polar-exclusion mask
-    # Precompute polar-exclusion flux masks once (zeros ocean surface fluxes where |lat| ≥ 80° to avoid instability).
+    # Precompute polar-exclusion flux masks once (zeros ocean surface fluxes where |lat| ≥ 78° to avoid instability).
     # _centers = cell-centered (T, S); _u = Face/Center (u); _v = Center/Face (v).
     polar_exclusion_flux_mask_centers =
         ocean_flux_highlat_mask(grid; location = (OC.Center(), OC.Center(), OC.Center()))
@@ -296,7 +296,7 @@ end
 Ensure the ocean and ice area fractions are consistent with each other.
 This matters in the case of a LatitudeLongitudeGrid, which only extends to
 ±80° latitude. We set ice and ocean area fractions to 0 and land to 1 where
-|lat| ≥ 80° (same band used to zero ocean surface fluxes).
+|lat| ≥ 78° (same band used to zero ocean surface fluxes).
 
 This function also updates the ice concentration field in the ocean simulation
 so that it can be used for weighting flux updates.
@@ -310,7 +310,7 @@ function FieldExchanger.resolve_area_fractions!(
         ocean_fraction = Interfacer.get_field(ocean_sim, Val(:area_fraction))
         ice_fraction = Interfacer.get_field(ice_sim, Val(:area_fraction))
 
-        # Polar mask: 1 where |lat| ≥ 80° (same band used to zero ocean fluxes)
+        # Polar mask: 1 where |lat| ≥ 78° (same band used to zero ocean fluxes)
         boundary_space = axes(ocean_fraction)
         FT = CC.Spaces.undertype(boundary_space)
         lat = CC.Fields.coordinate_field(boundary_space).lat
@@ -365,7 +365,7 @@ Interfacer.get_field(sim::OceananigansSimulation, ::Val{:surface_temperature}) =
 
 Build the ocean flux high latitude mask once at setup.
 Currently we define ocean between 80degS to 80degN with 2 degree overlap in the coupler mask.
-Returns a 2D mask (1.0 where |lat| < 80°, 0.0 elsewhere). This mask is on the ocean grid (
+Returns a 2D mask (1.0 where |lat| < 78°, 0.0 elsewhere). This mask is on the ocean grid (
 unlike the polar mask which is defined on the boundary_space)
 """
 # polar-exclusion mask


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
#1763 updated docstrings and comments to suggest that we no longer had an ocean-sea ice/land overlap between 78 and 80 degrees latitude, but we do still have it. When that overlap is removed, CMIP fails immediately after initialization ([see here](https://buildkite.com/clima/climacoupler-longruns/builds/1068)).


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
