### PR TITLE
Add infrastructure for testing calibration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -324,6 +324,21 @@ steps:
           slurm_mem: 20GB
           slurm_gpus: 1
 
+      - label: "AMIP calibration pipeline with emulated diagnostics"
+        key: "amip_test_calibration"
+        command:
+          - "julia -O0 --color=yes --project=experiments/AMIP/ experiments/calibration/amip/generate_observations.jl"
+          - "julia -O0 --color=yes --project=experiments/AMIP/ experiments/calibration/amip/run_calibration.jl"
+        artifact_paths: "amip_calibration/*"
+        env:
+          CLIMACOMMS_DEVICE: "CPU"
+          CLIMACOMMS_CONTEXT: "SINGLETON"
+          TEST_CALIBRATION: ""
+        agents:
+          slurm_mem: 64GB
+          slurm_ntasks: 3
+          slurm_cpus_per_task: 4
+
   - wait
 
   # plot job performance history

--- a/config/amip_configs/amip_calibration.yml
+++ b/config/amip_configs/amip_calibration.yml
@@ -10,7 +10,6 @@ dt_rad: "1hours"
 dt_seaice: "150secs"
 dt: "150secs"
 energy_check: false
-era5_initial_condition_dir: "/glade/campaign/univ/ucit0011/cchristo/wxquest_data/initial_conditions/initial_conditions_v1_dev"
 extra_atmos_diagnostics:
   - short_name: [tas, pr, mslp, rsut, rsutcs, rlut, rlutcs, rsdt]
     period: monthly
@@ -34,7 +33,7 @@ non_orographic_gravity_wave: true
 ode_algo: "ARS232"
 output_default_diagnostics: false
 radiation_reset_rng_seed: true
-start_date: "20100924"
+start_date: "20100101"
 strict_params: false
 surface_setup: "PrescribedSurface"
 t_end: "39days"

--- a/experiments/calibration/amip/model_interface.jl
+++ b/experiments/calibration/amip/model_interface.jl
@@ -1,5 +1,3 @@
-ENV["CLIMACOMMS_DEVICE"] = "CUDA"
-ENV["CLIMACOMMS_CONTEXT"] = "SINGLETON"
 import ClimaCoupler
 import ClimaCalibrate
 using Pkg
@@ -8,6 +6,11 @@ using Pkg
 # This allows other pipelines to include their own run_calibration.jl first
 if !@isdefined(CALIBRATE_CONFIG)
     include(joinpath(@__DIR__, "run_calibration.jl"))
+end
+
+if !TEST_CALIBRATION
+    ENV["CLIMACOMMS_DEVICE"] = "CUDA"
+    ENV["CLIMACOMMS_CONTEXT"] = "SINGLETON"
 end
 
 function ClimaCalibrate.forward_model(iter, member)
@@ -31,7 +34,12 @@ function ClimaCalibrate.forward_model(iter, member)
 
     @info "Simulation dates" start_date end_date
 
-    ClimaCoupler.SimCoordinator.setup_and_run(config_dict)
+    if !TEST_CALIBRATION
+        ClimaCoupler.SimCoordinator.setup_and_run(config_dict)
+    else
+        @info "Emulating diagnostics for test calibration"
+        CalibrationTools.setup_and_emulate_diagnostics(config_dict)
+    end
     @info "Completed member $member"
     return nothing
 end

--- a/experiments/calibration/amip/preprocessing.jl
+++ b/experiments/calibration/amip/preprocessing.jl
@@ -128,7 +128,6 @@ end
     apply_normalization!(normalization_stats, var::ClimaAnalysis.OutputVar)
 
 Apply normalization using the statistics saved in `normalization_stats`.
-
 """
 function apply_normalization!(normalization_stats, var::ClimaAnalysis.OutputVar)
     if ClimaAnalysis.has_pressure(var)

--- a/experiments/calibration/amip/run_calibration.jl
+++ b/experiments/calibration/amip/run_calibration.jl
@@ -8,6 +8,8 @@ import EnsembleKalmanProcesses as EKP
 import EnsembleKalmanProcesses.ParameterDistributions as PD
 import JLD2
 
+using Distributed
+
 include(
     joinpath(
         pkgdir(ClimaCoupler),
@@ -28,16 +30,40 @@ model_interface = joinpath(
 
 # CALIBRATION CONFIGURATION
 
+# To test a calibration, set `export TEST_CALIBRATION=` in the terminal or
+# `ENV["TEST_CALIBRATION"]=""` in the REPL. A test calibration differs from a
+# full calibration in three ways: it runs for only a single iteration, uses only
+# one prior, and emulates the production of the diagnostics. The diagnostics
+# produced will have the correct metadata, but the values may be nonsensical.
+const TEST_CALIBRATION = haskey(ENV, "TEST_CALIBRATION")
+
 config_file =
     joinpath(pkgdir(ClimaCoupler), "config", "amip_configs", "amip_calibration.yml")
 
 # Calibrate only on Jan 1 2010
 sample_date_ranges =
     [(Dates.DateTime(2010, 10, 1), Dates.DateTime(2010, 10, 1)) for _ in 1:6]
+
 # On Derecho, it is preferable to save the calibration output to the scratch
 # directory (e.g. "/glade/derecho/scratch")
 output_dir = joinpath(pkgdir(ClimaCoupler), "amip_calibration")
 isdir(output_dir) || mkdir(output_dir)
+
+n_iterations = 6
+spinup = Dates.Day(7)
+
+# For the test calibration, we only care whether a single iteration can be
+# completed. Since each iteration follows the same structure, successfully
+# completing one iteration will catch most errors with the full calibration
+# pipeline
+if TEST_CALIBRATION
+    n_iterations = 1
+    # spinup and sample_date_ranges are chosen to match the only dates
+    # available in the wxquest_initial_conditions artifact
+    spinup = Dates.Day(0)
+    sample_date_ranges =
+        [(Dates.DateTime(2010, 10, 1), Dates.DateTime(2010, 10, 1)) for _ in 1:6]
+end
 
 const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
     config_file,
@@ -45,10 +71,10 @@ const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
     # pressure_coordinates: true in config
     short_names = ["ta", "hur"],
     minibatch_size = 1,
-    n_iterations = 6,
+    n_iterations,
     sample_date_ranges,
     extend = Dates.Month(1),
-    spinup = Dates.Day(7),
+    spinup,
     output_dir,
     rng_seed = 42,
 )
@@ -70,7 +96,23 @@ const CALIBRATION_PRIORS = [
     PD.constrained_gaussian("mixing_length_tke_surf_flux_coeff", 8.0, 4.0, 0, 100.0),
 ]
 
+if TEST_CALIBRATION
+    # For testing a calibration, the number of priors should be small to
+    # minimize the number of ensemble members.
+    resize!(CALIBRATION_PRIORS, 1)
+end
+
 const PRIORS = EKP.combine_distributions(CALIBRATION_PRIORS)
+
+
+# Commit type piracy to overwrite module_load_string because an old version of
+# climacommon is being used
+function ClimaCalibrate.module_load_string(::ClimaCalibrate.CaltechHPCBackend)
+    return """export MODULEPATH="/resnick/groups/esm/modules:\$MODULEPATH"
+    module purge
+    module load climacommon/2025_05_15"""
+end
+
 
 if abspath(PROGRAM_FILE) == @__FILE__
 
@@ -112,7 +154,19 @@ if abspath(PROGRAM_FILE) == @__FILE__
         scheduler = EKP.DataMisfitController(terminate_at = 1000000),
     )
 
-    if ClimaCalibrate.get_backend() == ClimaCalibrate.DerechoBackend
+    if TEST_CALIBRATION
+        addprocs(ClimaCalibrate.SlurmManager())
+        @everywhere include($model_interface)
+        (; n_iterations, output_dir) = CALIBRATE_CONFIG
+        ClimaCalibrate.calibrate(
+            ClimaCalibrate.WorkerBackend(),
+            ekp,
+            n_iterations,
+            PRIORS,
+            output_dir,
+        )
+        return nothing
+    elseif ClimaCalibrate.get_backend() == ClimaCalibrate.DerechoBackend
         backend = ClimaCalibrate.DerechoBackend(;
             model_interface,
             verbose = true,

--- a/src/CalibrationTools.jl
+++ b/src/CalibrationTools.jl
@@ -931,15 +931,20 @@ end
     emulate_diagnostics!(sim, t_end)
 
 Emulate producing diagnostics for the component model `sim`.
+
+There is only support for emulating diagnostics of the `ClimaAtmosSimulation`.
 """
 function emulate_diagnostics!(sim, t_end)
-    (; integrator) = sim
+    (; integrator, output_writers) = sim
     diagnostics_handler =
         integrator.callback.discrete_callbacks[end].affect!.diagnostics_handler
     while sim.integrator.t < t_end
         sim.integrator.t += integrator.dt
         ClimaDiagnostics.orchestrate_diagnostics(integrator, diagnostics_handler)
     end
+    # Since the simulation never actually ran, we need to manually close the
+    # writers ourselves
+    foreach(close, output_writers)
     return nothing
 end
 

--- a/src/CalibrationTools.jl
+++ b/src/CalibrationTools.jl
@@ -10,7 +10,10 @@ import Dates
 
 import ClimaAnalysis
 import ClimaAnalysis: NCCatalog
+import ClimaCoupler
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
+import ClimaDiagnostics
+import ClimaUtilities.TimeManager: ITime
 
 # TODO: Remove this once the name is added to ClimaAnalysis
 push!(ClimaAnalysis.Var.ALTITUDE_NAMES, "height")
@@ -880,6 +883,63 @@ Add the parameter toml file at `parameter_filepath` to `config_dict`.
 function add_parameter_filepath!(config_dict, parameter_filepath)
     parameter_filepaths = get!(config_dict, "coupler_toml", String[])
     push!(parameter_filepaths, parameter_filepath)
+    return nothing
+end
+
+"""
+    setup_and_emulate_diagnostics(config_dict::AbstractDict; dt = "86400secs")
+
+Set up and emulate producing the diagnostics of the coupled model simulation
+specified by the `config_dict`. Returns the `CoupledSimulation` after simulating
+the diagnostics.
+
+This is analogous to [`SimCoordinator.setup_and_run`](@ref) and is meant a
+drop-in replacement for starting a simulation that will produce only
+diagnostics. Note this function is primarily intended for testing, not running
+or viewing meaningful simulations.
+
+By default, the size of the time step will be set to one day.
+
+!!! note "Atmos diagnostics"
+    This only supports simulating the creation of atmos diagnostics.
+
+!!! note "Emulation"
+    Since no actual time steps are taken, the values in the `CoupledSimulation`
+    might be nonsensical.
+"""
+function setup_and_emulate_diagnostics(config_dict::AbstractDict; dt = "86400secs")
+    config_dict["dt"] = dt
+    cs = ClimaCoupler.Interfacer.CoupledSimulation(config_dict)
+    emulate_diagnostics!(cs)
+    return cs
+end
+
+"""
+    emulate_diagnostics!(cs::ClimaCoupler.Interfacer.CoupledSimulation)
+
+Emulate producing diagnostics for `cs`.
+
+This only produces diagnostics for the atmos model because the calibration of
+the coupled model currently uses only atmos variables.
+"""
+function emulate_diagnostics!(cs::ClimaCoupler.Interfacer.CoupledSimulation)
+    t_end = cs.tspan[end]
+    emulate_diagnostics!(cs.model_sims.atmos_sim, t_end)
+end
+
+"""
+    emulate_diagnostics!(sim, t_end)
+
+Emulate producing diagnostics for the component model `sim`.
+"""
+function emulate_diagnostics!(sim, t_end)
+    (; integrator) = sim
+    diagnostics_handler =
+        integrator.callback.discrete_callbacks[end].affect!.diagnostics_handler
+    while sim.integrator.t < t_end
+        sim.integrator.t += integrator.dt
+        ClimaDiagnostics.orchestrate_diagnostics(integrator, diagnostics_handler)
+    end
     return nothing
 end
 

--- a/toml/amip_diagedmf.toml
+++ b/toml/amip_diagedmf.toml
@@ -1,62 +1,83 @@
 [zd_rayleigh]
 value = 40000.0
+type = "float"
 
 [zd_viscous]
 value = 40000.0
+type = "float"
 
 [alpha_rayleigh_w]
 value = 10.0
+type = "float"
 
 [EDMF_surface_area]
 value = 0.06399178163606391
+type = "float"
 
 [min_area_limiter_scale]
 value = 0
+type = "float"
 
 [max_area_limiter_scale]
 value = 0
+type = "float"
 
 [entr_coeff]
 value = 0
+type = "float"
 
 [entr_param_vec]
 value = [0, -20.29437694493032, -22.269204417686513, 0, 0, -0.8]
+type = "float"
 
 [entr_mult_limiter_coeff]
 value = 0.4641383877134538
+type = "float"
 
 [entr_inv_tau]
 value = 0.008362201402729065
+type = "float"
 
 [detr_inv_tau]
 value = 0
+type = "float"
 
 [detr_vertdiv_coeff]
 value = 0.6
+type = "float"
 
 [detr_buoy_coeff]
 value = 0.12
+type = "float"
 
 [mixing_length_Prandtl_maximum]
 value = 4.2
+type = "float"
 
 [mixing_length_eddy_viscosity_coefficient]
 value = 0.5892594727125273
+type = "float"
 
 [mixing_length_tke_surf_flux_coeff]
 value = 0.3331950998157493
+type = "float"
 
 [mixing_length_diss_coeff]
 value = 0.04640288100600733
+type = "float"
 
 [mixing_length_Prandtl_number_0]
 value = 2.909243754318121
+type = "float"
 
 [mixing_length_static_stab_coeff]
 value = 0.29736273245468714
+type = "float"
 
 [precipitation_timescale]
 value = 1200
+type = "float"
 
 [Tq_correlation_coefficient]
 value = -1
+type = "float"

--- a/toml/amip_diagedmf_1m.toml
+++ b/toml/amip_diagedmf_1m.toml
@@ -1,74 +1,99 @@
 [zd_rayleigh]
 value = 40000.0
+type = "float"
 
 [zd_viscous]
 value = 40000.0
+type = "float"
 
 [alpha_rayleigh_w]
 value = 10.0
+type = "float"
 
 [EDMF_surface_area]
 value = 0.06399178163606391
+type = "float"
 
 [min_area_limiter_scale]
 value = 0
+type = "float"
 
 [max_area_limiter_scale]
 value = 0
+type = "float"
 
 [entr_coeff]
 value = 0
+type = "float"
 
 [entr_param_vec]
 value = [0, -20.29437694493032, -22.269204417686513, 0, 0, -0.8]
+type = "float"
 
 [entr_mult_limiter_coeff]
 value = 0.4641383877134538
+type = "float"
 
 [entr_inv_tau]
 value = 0.008362201402729065
+type = "float"
 
 [detr_inv_tau]
 value = 0
+type = "float"
 
 [detr_vertdiv_coeff]
 value = 0.6
+type = "float"
 
 [detr_buoy_coeff]
 value = 0.12
+type = "float"
 
 [mixing_length_Prandtl_maximum]
 value = 4.2
+type = "float"
 
 [mixing_length_eddy_viscosity_coefficient]
 value = 0.5892594727125273
+type = "float"
 
 [mixing_length_tke_surf_flux_coeff]
 value = 0.3331950998157493
+type = "float"
 
 [mixing_length_diss_coeff]
 value = 0.04640288100600733
+type = "float"
 
 [mixing_length_Prandtl_number_0]
 value = 2.909243754318121
+type = "float"
 
 [mixing_length_static_stab_coeff]
 value = 0.29736273245468714
+type = "float"
 
 [Tq_correlation_coefficient]
 value = -1
+type = "float"
 
 [tracer_vertical_diffusion_factor]
 value = 0
+type = "float"
 
 [condensation_evaporation_timescale]
 value = 150
+type = "float"
 
 [sublimation_deposition_timescale]
 value = 150
+type = "float"
 
 [snow_autoconversion_timescale]
 value = 1e3
+type = "float"
 
 [rain_autoconversion_timescale]
 value = 150
+type = "float"

--- a/toml/amip_edonly.toml
+++ b/toml/amip_edonly.toml
@@ -1,32 +1,43 @@
 [alpha_rayleigh_w]
 value = 10.0
+type = "float"
 
 [zd_rayleigh]
 value = 40000.0
+type = "float"
 
 [zd_viscous]
 value = 40000.0
+type = "float"
 
 [mixing_length_Prandtl_maximum]
 value = 4.2
+type = "float"
 
 [mixing_length_eddy_viscosity_coefficient]
 value = 0.5892594727125273
+type = "float"
 
 [mixing_length_tke_surf_flux_coeff]
 value = 0.3331950998157493
+type = "float"
 
 [mixing_length_diss_coeff]
 value = 0.04640288100600733
+type = "float"
 
 [mixing_length_Prandtl_number_0]
 value = 2.909243754318121
+type = "float"
 
 [mixing_length_static_stab_coeff]
 value = 0.29736273245468714
+type = "float"
 
 [precipitation_timescale]
 value = 1200
+type = "float"
 
 [Tq_correlation_coefficient]
 value = -1
+type = "float"

--- a/toml/amip_progedmf.toml
+++ b/toml/amip_progedmf.toml
@@ -1,80 +1,107 @@
 [zd_rayleigh]
 value = 40000.0
+type = "float"
 
 [zd_viscous]
 value = 40000.0
+type = "float"
 
 [alpha_rayleigh_sgs_tracer]
 value = 1e-3
+type = "float"
 
 [EDMF_surface_area]
 value = 0.06399178163606391
+type = "float"
 
 [min_area_limiter_scale]
 value = 0
+type = "float"
 
 [max_area_limiter_scale]
 value = 0
+type = "float"
 
 [EDMF_min_area]
 value = 1.0e-5
+type = "float"
 
 [EDMF_max_area]
 value = 0.7
+type = "float"
 
 [entr_coeff]
 value = 0
+type = "float"
 
 [entr_param_vec]
 value = [0, 0.1759425797637972, -4.15529994350738, 0, 0, 0.23034829797200007]
+type = "float"
 
 [entr_mult_limiter_coeff]
 value = 0.6022681998170195
+type = "float"
 
 [entr_inv_tau]
 value = 1.0e-5
+type = "float"
 
 [detr_inv_tau]
 value = 0.001
+type = "float"
 
 [detr_coeff]
 value = 0
+type = "float"
 
 [detr_buoy_coeff]
 value = 0
+type = "float"
 
 [detr_vertdiv_coeff]
 value = 0
+type = "float"
 
 [detr_massflux_vertdiv_coeff]
 value = 1
+type = "float"
 
 [entr_detr_limit_inv_tau]
 value = 0.01
+type = "float"
 
 [pressure_normalmode_drag_coeff]
 value = 8.002319316450539
+type = "float"
 
 [pressure_normalmode_buoy_coeff1]
 value = 0.04592259632544556
+type = "float"
 
 [mixing_length_tke_surf_flux_coeff]
 value = 0.3331950998157493
+type = "float"
 
 [mixing_length_diss_coeff]
 value = 0.04640288100600733
+type = "float"
 
 [mixing_length_eddy_viscosity_coefficient]
 value = 1.497382613786804
+type = "float"
 
 [mixing_length_Prandtl_number_0]
 value = 0.5168130504404477
+type = "float"
 
 [mixing_length_static_stab_coeff]
 value = 0.35509778819311516
+type = "float"
 
 [precipitation_timescale]
 value = 1200
+type = "float"
 
 [Tq_correlation_coefficient]
 value = -1
+type = "float"

--- a/toml/amip_progedmf_1m.toml
+++ b/toml/amip_progedmf_1m.toml
@@ -1,86 +1,115 @@
 [zd_rayleigh]
 value = 40000.0
+type = "float"
 
 [zd_viscous]
 value = 40000.0
+type = "float"
 
 [alpha_rayleigh_sgs_tracer]
 value = 1e-3
+type = "float"
 
 [EDMF_surface_area]
 value = 0.06399178163606391
+type = "float"
 
 [min_area_limiter_scale]
 value = 0
+type = "float"
 
 [max_area_limiter_scale]
 value = 0
+type = "float"
 
 [EDMF_min_area]
 value = 1.0e-5
+type = "float"
 
 [EDMF_max_area]
 value = 0.7
+type = "float"
 
 [entr_coeff]
 value = 0
+type = "float"
 
 [entr_param_vec]
 value = [0, 0.1759425797637972, -4.15529994350738, 0, 0, 0.23034829797200007]
+type = "float"
 
 [entr_mult_limiter_coeff]
 value = 0.6022681998170195
+type = "float"
 
 [entr_inv_tau]
 value = 1.0e-5
+type = "float"
 
 [detr_inv_tau]
 value = 0.001
+type = "float"
 
 [detr_coeff]
 value = 0
+type = "float"
 
 [detr_buoy_coeff]
 value = 0
+type = "float"
 
 [detr_vertdiv_coeff]
 value = 0
+type = "float"
 
 [detr_massflux_vertdiv_coeff]
 value = 1
+type = "float"
 
 [entr_detr_limit_inv_tau]
 value = 0.01
+type = "float"
 
 [pressure_normalmode_drag_coeff]
 value = 8.002319316450539
+type = "float"
 
 [pressure_normalmode_buoy_coeff1]
 value = 0.04592259632544556
+type = "float"
 
 [mixing_length_tke_surf_flux_coeff]
 value = 0.3331950998157493
+type = "float"
 
 [mixing_length_diss_coeff]
 value = 0.04640288100600733
+type = "float"
 
 [mixing_length_eddy_viscosity_coefficient]
 value = 1.497382613786804
+type = "float"
 
 [mixing_length_Prandtl_number_0]
 value = 0.5168130504404477
+type = "float"
 
 [mixing_length_static_stab_coeff]
 value = 0.35509778819311516
+type = "float"
 
 [Tq_correlation_coefficient]
 value = -1
+type = "float"
 
 [tracer_vertical_diffusion_factor]
 value = 0
+type = "float"
 
 [condensation_evaporation_timescale]
 value = 100
+type = "float"
 
 [sublimation_deposition_timescale]
 value = 100
+type = "float"

--- a/toml/microphysics_0M_no_precip.toml
+++ b/toml/microphysics_0M_no_precip.toml
@@ -1,5 +1,7 @@
 [specific_humidity_precipitation_threshold]
 value = 1
+type = "float"
 
 [precipitation_timescale]
 value = 1e10
+type = "float"

--- a/toml/wxquest_diagedmf.toml
+++ b/toml/wxquest_diagedmf.toml
@@ -1,44 +1,59 @@
 [alpha_rayleigh_w]
 value = 10.0
+type = "float"
 
 [zd_rayleigh]
 value = 45000.0
+type = "float"
 
 [zd_viscous]
 value = 45000.0
+type = "float"
 
 [precipitation_timescale]
 value = 1200
+type = "float"
 
 [entr_inv_tau]
 value = 0.0015
+type = "float"
 
 [entr_param_vec]
 value = [0, -20.29437694493032, -22.269204417686513, 0, 0, -0.8]
+type = "float"
 
 [entr_coeff]
 value = 0
+type = "float"
 
 [detr_inv_tau]
 value = 0
+type = "float"
 
 [detr_buoy_coeff]
 value = 0.12
+type = "float"
 
 [detr_vertdiv_coeff]
 value = 1.0
+type = "float"
 
 [diagnostic_covariance_coeff]
 value = 2.1
+type = "float"
 
 [min_area_limiter_scale]
 value = 0
+type = "float"
 
 [max_area_limiter_scale]
 value = 0
+type = "float"
 
 [mixing_length_Prandtl_maximum]
 value = 4.2
+type = "float"
 
 [land_bucket_capacity]
 value = 0.8
+type = "float"


### PR DESCRIPTION
closes [#1570](https://github.com/CliMA/ClimaCoupler.jl/issues/1750)

This PR adds infrastructure for testing whether a calibration can run or not. A calibration involves

1. Generating observations
2. Running an ensemble of simulations to produce diagnostics
3. Computing the observation map (data from diagnostics to G ensemble matrix)
4. Run post iteration analysis (plotting of parameters, bias, and RMSE)

The main computational cost is running the ensemble of simulations and the amount of mistakes/typos that can happen in this step is minimal compared to the other steps. This PR adds the function `setup_and_emulate_diagnostics` which repeatedly call the diagnostics handler of the atmos simulation with a default time step of one day. This forces all the diagnostics of the atmos simulation to be produced with data that is probably not correct. Beside that, the diagnostics are exactly what would be produced from the atmos simulation.

When running a test calibration on `clima` with precompilation finished with a simulation lasting for a month, the first iteration takes ~20 minutes (most of the time is spent creating the simulation). 