### PR TITLE
Fix if condition for code coverage upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - name: Submit coverage
-        if: ${{ matrix.version == '1.12' }} && ${{ matrix.os == 'ubuntu-latest' }}
+        if: matrix.version == '1.12' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v5
         with:
           token: ${{secrets.CODECOV_TOKEN}}


### PR DESCRIPTION
From what I understand, `${{ matrix.version == '1.12' }} && ${{ matrix.os == 'ubuntu-latest' }}` is interpolated to `true && false` as an example. Unexpectedly, this is treated as a string instead of an expression. A non-empty string is treated as true so this if condition always evaluate to true.

I saw this error at https://github.com/CliMA/ClimaCoupler.jl/actions/runs/22928949697.