### PR TITLE
Support coupled single-column runs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,7 +127,44 @@ steps:
           slurm_gpus: 1
           slurm_mem: 32GB
 
-  - group: "Integration Tests"
+  - group: "Integration Tests (single column)"
+    steps:
+      - label: "SCM: slabplanet aqua (atmos + slab ocean column)"
+        key: "scm_slabplanet_aqua"
+        command: "julia -O0 --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/scm_slabplanet_aqua.yml --job_id scm_slabplanet_aqua"
+        artifact_paths: "output/scm_slabplanet_aqua/artifacts/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: "SCM: slabplanet terra bucket (atmos + bucket land column)"
+        key: "scm_slabplanet_terra_bucket"
+        command: "julia -O0 --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/scm_slabplanet_terra_bucket.yml --job_id scm_slabplanet_terra_bucket"
+        artifact_paths: "output/scm_slabplanet_terra_bucket/artifacts/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: "SCM: slabplanet terra land (atmos + integrated land column)"
+        key: "scm_slabplanet_terra_land"
+        command: "julia -O0 --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/scm_slabplanet_terra_land.yml --job_id scm_slabplanet_terra_land"
+        artifact_paths: "output/scm_slabplanet_terra_land/artifacts/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: "SCM: AMIP ocean (atmos + prescribed ocean column)"
+        key: "scm_amip_ocean"
+        command: "julia -O0 --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/scm_amip_ocean.yml --job_id scm_amip_ocean"
+        artifact_paths: "output/scm_amip_ocean/artifacts/*"
+        agents:
+          slurm_mem: 20GB
+
+      - label: "SCM: AMIP sea ice (atmos + prescribed sea ice column)"
+        key: "scm_amip_ice"
+        command: "julia -O0 --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/scm_amip_ice.yml --job_id scm_amip_ice"
+        artifact_paths: "output/scm_amip_ice/artifacts/*"
+        agents:
+          slurm_mem: 20GB
+
+  - group: "Integration Tests (global)"
     steps:
       # SLABPLANET EXPERIMENTS
 

--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SurfaceFluxes = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
@@ -42,10 +43,10 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [extensions]
 ClimaCouplerCMIPExt = ["ClimaOcean", "ClimaSeaIce", "KernelAbstractions", "Oceananigans"]
+ClimaCouplerCMIPMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Oceananigans", "Poppler_jll", "Printf"]
 ClimaCouplerClimaAtmosExt = ["ClimaAtmos"]
 ClimaCouplerClimaLandExt = ["ClimaLand"]
 ClimaCouplerMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Poppler_jll", "Printf"]
-ClimaCouplerCMIPMakieExt = ["CairoMakie", "ClimaCoreMakie", "GeoMakie", "Makie", "Oceananigans", "Poppler_jll", "Printf"]
 
 [compat]
 ArgParse = "1"
@@ -78,6 +79,7 @@ Printf = "1"
 Random = "1"
 SciMLBase = "~2.110, ~2.111, ~2.112"
 StaticArrays = "1.9.8"
+Statistics = "1"
 SurfaceFluxes = "0.15.0, 1"
 Thermodynamics = "0.15.3, ~1.0, ~1.1, ~1.2"
 YAML = "0.4"

--- a/config/ci_configs/scm_amip_ice.yml
+++ b/config/ci_configs/scm_amip_ice.yml
@@ -1,0 +1,15 @@
+domain_type: "column"
+column_latlon: [70.0, -10.0]
+scm_surface_type: "sea_ice"
+mode_name: "amip"
+dt: "120secs"
+dt_cpl: "120secs"
+t_end: "480secs"
+start_date: "20100101"
+rad: "gray"
+microphysics_model: "0M"
+surface_setup: "PrescribedSurface"
+vert_diff: "DecayWithHeightDiffusion"
+z_elem: 30
+z_max: 30000.0
+z_stretch: false

--- a/config/ci_configs/scm_amip_ocean.yml
+++ b/config/ci_configs/scm_amip_ocean.yml
@@ -1,0 +1,15 @@
+domain_type: "column"
+column_latlon: [40.0, -140.0]
+scm_surface_type: "ocean"
+mode_name: "amip"
+dt: "120secs"
+dt_cpl: "120secs"
+t_end: "480secs"
+start_date: "20100101"
+rad: "gray"
+microphysics_model: "0M"
+surface_setup: "PrescribedSurface"
+vert_diff: "DecayWithHeightDiffusion"
+z_elem: 30
+z_max: 30000.0
+z_stretch: false

--- a/config/ci_configs/scm_slabplanet_aqua.yml
+++ b/config/ci_configs/scm_slabplanet_aqua.yml
@@ -1,0 +1,15 @@
+domain_type: "column"
+column_latlon: [40.0, -140.0]
+scm_surface_type: "ocean"
+mode_name: "slabplanet_aqua"
+dt: "120secs"
+dt_cpl: "120secs"
+t_end: "480secs"
+start_date: "20100101"
+rad: "gray"
+microphysics_model: "0M"
+surface_setup: "PrescribedSurface"
+vert_diff: "DecayWithHeightDiffusion"
+z_elem: 30
+z_max: 30000.0
+z_stretch: false

--- a/config/ci_configs/scm_slabplanet_terra_bucket.yml
+++ b/config/ci_configs/scm_slabplanet_terra_bucket.yml
@@ -1,0 +1,16 @@
+domain_type: "column"
+column_latlon: [35.0, 97.0]
+scm_surface_type: "land"
+mode_name: "slabplanet_terra"
+bucket_albedo_type: "function"
+dt: "120secs"
+dt_cpl: "120secs"
+t_end: "480secs"
+start_date: "20100101"
+rad: "gray"
+microphysics_model: "0M"
+surface_setup: "PrescribedSurface"
+vert_diff: "DecayWithHeightDiffusion"
+z_elem: 30
+z_max: 30000.0
+z_stretch: false

--- a/config/ci_configs/scm_slabplanet_terra_land.yml
+++ b/config/ci_configs/scm_slabplanet_terra_land.yml
@@ -1,0 +1,17 @@
+domain_type: "column"
+column_latlon: [35.0, 97.0]
+scm_surface_type: "land"
+mode_name: "slabplanet_terra"
+bucket_albedo_type: "function"
+dt: "120secs"
+dt_cpl: "120secs"
+t_end: "480secs"
+start_date: "20100101"
+rad: "gray"
+land_model: "integrated"
+microphysics_model: "0M"
+surface_setup: "PrescribedSurface"
+vert_diff: "DecayWithHeightDiffusion"
+z_elem: 30
+z_max: 30000.0
+z_stretch: false

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -185,6 +185,14 @@ specific timesteps should be specified, rather than only `dt`.
 |----------|------|---------|---------------|-------------|
 | `--evolving_ocean` | Bool | `true` | `true`, `false` | Whether to use a dynamic slab ocean model, as opposed to constant surface temperatures |
 
+#### Single-column model (SCM) settings
+
+| Argument | Type | Default | Valid Options | Description |
+|----------|------|---------|---------------|-------------|
+| `--domain_type` | String | `"global"` | `global`, `column` | Domain type for the simulation. Use `column` for single-column model runs |
+| `--column_latlon` | Vector{Float64} | `[0.0, 0.0]` | `[lat, lon]` in degrees | Latitude within [-90, 90] and longitude within [-180, 180] for the SCM column location |
+| `--scm_surface_type` | String | `nothing` | `land`, `ocean`, `sea_ice` (required for `column`) | Select SCM surface model: enables exactly one of land, ocean, or sea ice. Ignored for global runs. |
+
 ## Input API
 
 ```@docs

--- a/docs/src/running.md
+++ b/docs/src/running.md
@@ -150,3 +150,50 @@ end
 
 This is equivalent to what `run!` does internally, without the precompilation warmup
 and SYPD timing. See [SimCoordinator](@ref) for the full API.
+
+## Single-column model (SCM) experiments
+
+To run a single-column model (SCM) experiment, set `domain_type: "column"`, **`scm_surface_type`**
+(which surface runs: land, ocean, or sea ice), and **`column_latlon`** (where the column sits).
+Example config file:
+
+```yaml
+domain_type: "column"
+column_latlon: [37.0, -120.0]   # [latitude, longitude] in degrees
+scm_surface_type: "ocean"       # "land", "ocean", or "sea_ice"
+mode_name: "slabplanet_aqua"    # or "amip", "slabplanet_terra", etc.
+dt: "120secs"
+dt_cpl: "120secs"
+t_end: "480secs"
+start_date: "20100101"
+# ... other options (rad, microphysics_model, surface_setup, vert_diff, z_elem, etc.)
+```
+
+Run it the same way as a global run, e.g.:
+
+```bash
+julia --project=experiments/AMIP experiments/AMIP/run_simulation.jl --config_file=config/ci_configs/scm_slabplanet_aqua.yml --job_id=my_scm
+```
+
+Or from the REPL:
+
+```julia
+include("experiments/AMIP/code_loading.jl")
+cs = CoupledSimulation("config/ci_configs/scm_slabplanet_aqua.yml")
+run!(cs)
+```
+
+Ready-to-use SCM configs are in `config/ci_configs/` (e.g. `scm_slabplanet_aqua.yml`,
+`scm_slabplanet_terra_land.yml`, `scm_amip_ocean.yml`).
+
+### SCM surface model selection
+
+`scm_surface_type` is used to select which surface model runs in SCM mode. It must
+be set to `"land"`, `"ocean"`, or `"sea_ice"`. The coupler then keeps exactly one of the land,
+ocean, or sea-ice component models active (the others are disabled). Which *kind* of ocean,
+land, or ice model (e.g. slab vs prescribed) still follows from `mode_name` and the usual
+`ocean_model` / `land_model` / `ice_model` config where applicable. Multiple surface
+model types (e.g. half ocean, half land) are currently not supported in SCM mode.
+
+`column_latlon` sets the geographic location of the column (e.g. for spatially-varying
+land parameters, prescribed ocean albedo calculation, radiation).

--- a/experiments/AMIP/Manifest-v1.11.toml
+++ b/experiments/AMIP/Manifest-v1.11.toml
@@ -476,7 +476,7 @@ uuid = "908f55d8-4145-4867-9c14-5dad1a479e4d"
 version = "0.4.7"
 
 [[deps.ClimaCoupler]]
-deps = ["ArgParse", "ClimaAnalysis", "ClimaAtmos", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "Insolation", "Interpolations", "JLD2", "LinearAlgebra", "Logging", "NCDatasets", "Random", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics", "YAML"]
+deps = ["ArgParse", "ClimaAnalysis", "ClimaAtmos", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "Insolation", "Interpolations", "JLD2", "LinearAlgebra", "Logging", "NCDatasets", "Random", "SciMLBase", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "YAML"]
 path = "../.."
 uuid = "4ade58fe-a8da-486c-bd89-46df092ec0c7"
 version = "0.1.2"

--- a/experiments/AMIP/Manifest.toml
+++ b/experiments/AMIP/Manifest.toml
@@ -473,7 +473,7 @@ uuid = "908f55d8-4145-4867-9c14-5dad1a479e4d"
 version = "0.4.7"
 
 [[deps.ClimaCoupler]]
-deps = ["ArgParse", "ClimaAnalysis", "ClimaAtmos", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "Insolation", "Interpolations", "JLD2", "LinearAlgebra", "Logging", "NCDatasets", "Random", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics", "YAML"]
+deps = ["ArgParse", "ClimaAnalysis", "ClimaAtmos", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "Insolation", "Interpolations", "JLD2", "LinearAlgebra", "Logging", "NCDatasets", "Random", "SciMLBase", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "YAML"]
 path = "../.."
 uuid = "4ade58fe-a8da-486c-bd89-46df092ec0c7"
 version = "0.1.2"

--- a/experiments/CMIP/Manifest-v1.11.toml
+++ b/experiments/CMIP/Manifest-v1.11.toml
@@ -499,7 +499,7 @@ uuid = "908f55d8-4145-4867-9c14-5dad1a479e4d"
 version = "0.4.7"
 
 [[deps.ClimaCoupler]]
-deps = ["ArgParse", "ClimaAnalysis", "ClimaAtmos", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "Insolation", "Interpolations", "JLD2", "LinearAlgebra", "Logging", "NCDatasets", "Random", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics", "YAML"]
+deps = ["ArgParse", "ClimaAnalysis", "ClimaAtmos", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "Insolation", "Interpolations", "JLD2", "LinearAlgebra", "Logging", "NCDatasets", "Random", "SciMLBase", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "YAML"]
 path = "../.."
 uuid = "4ade58fe-a8da-486c-bd89-46df092ec0c7"
 version = "0.1.2"

--- a/experiments/CMIP/Manifest.toml
+++ b/experiments/CMIP/Manifest.toml
@@ -496,7 +496,7 @@ uuid = "908f55d8-4145-4867-9c14-5dad1a479e4d"
 version = "0.4.7"
 
 [[deps.ClimaCoupler]]
-deps = ["ArgParse", "ClimaAnalysis", "ClimaAtmos", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "Insolation", "Interpolations", "JLD2", "LinearAlgebra", "Logging", "NCDatasets", "Random", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics", "YAML"]
+deps = ["ArgParse", "ClimaAnalysis", "ClimaAtmos", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "Insolation", "Interpolations", "JLD2", "LinearAlgebra", "Logging", "NCDatasets", "Random", "SciMLBase", "StaticArrays", "Statistics", "SurfaceFluxes", "Thermodynamics", "YAML"]
 path = "../.."
 uuid = "4ade58fe-a8da-486c-bd89-46df092ec0c7"
 version = "0.1.2"

--- a/experiments/test/component_model_tests/climaatmos_tests.jl
+++ b/experiments/test/component_model_tests/climaatmos_tests.jl
@@ -1,12 +1,23 @@
 import Test: @test, @testset
 import ClimaCore as CC
 import ClimaCoupler
+import ClimaCoupler.Utilities
 
 import ClimaAtmos
 import ClimaParams as CP
 
 # Needed to construct ClimaAtmosSimulation
 ClimaAtmosExt = Base.get_extension(ClimaCoupler, :ClimaCouplerClimaAtmosExt)
+function ClimaCoupler.Utilities.apply_dss!(field::NamedTuple, buffer)
+    if isnothing(buffer)
+        return nothing
+    else
+        return map(
+            key -> ClimaCoupler.Utilities.apply_dss!(getproperty(field, key), buffer[key]),
+            propertynames(field),
+        )
+    end
+end
 
 for FT in (Float32, Float64)
     @testset "dss_state! ClimaAtmosSimulation for FT=$FT" begin

--- a/ext/ClimaCouplerClimaAtmosExt.jl
+++ b/ext/ClimaCouplerClimaAtmosExt.jl
@@ -633,6 +633,9 @@ function get_atmos_config_dict(
         atmos_config["toml"] = toml
     end
 
+    # If running in SCM mode, set the atmosphere space type and lat/lon
+    coupler_config["domain_type"] == "column" && (atmos_config["config"] = "column")
+
     # Override atmos parameters with coupled parameters
     FT = atmos_config["FLOAT_TYPE"] == "Float64" ? Float64 : Float32
     override_file = CP.merge_toml_files(atmos_config["toml"], override = true)
@@ -692,11 +695,9 @@ one here.
 """
 function dss_state!(sim::ClimaAtmosSimulation)
     Y = sim.integrator.u
-    for key in propertynames(Y)
-        field = getproperty(Y, key)
-        buffer = CC.Spaces.create_dss_buffer(field)
-        CC.Spaces.weighted_dss!(field, buffer)
-    end
+    buffer = Utilities.init_dss_buffer(Y)
+    Utilities.apply_dss!(Y, buffer)
+    return nothing
 end
 
 """

--- a/ext/ClimaCouplerClimaLandExt/climaland_helpers.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_helpers.jl
@@ -100,6 +100,42 @@ function make_land_domain(
 end
 
 """
+     make_land_domain(
+         shared_surface_space::CC.Spaces.PointSpace,
+         depth::FT;
+         nelements_vert::Int = 15,
+         dz_tuple::Tuple{FT, FT} = FT.((10.0, 0.05)),
+         ) where {FT}
+
+Creates the land model domain from a PointSpace (single-column mode).
+Extracts lat/long from the PointSpace coordinate field and constructs
+a `CL.Domains.Column` with those coordinates.
+
+If `coords` does not have `long` and `lat` fields, the column will be
+constructed without any lat/long information. This is only acceptable
+for bucket model with albedo from function. For integrated land or bucket
+when reading in prescribed albedo, we need to provide lat/long information.
+"""
+function make_land_domain(
+    shared_surface_space::CC.Spaces.PointSpace,
+    depth::FT;
+    nelements_vert::Int = 15,
+    dz_tuple::Tuple{FT, FT} = FT.((10.0, 0.05)),
+) where {FT}
+    coords = CC.Fields.coordinate_field(shared_surface_space)
+    longlat =
+        hasproperty(coords, :long) ?
+        (FT(parent(coords.long)[1]), FT(parent(coords.lat)[1])) : nothing
+    domain = CL.Domains.Column(;
+        zlim = (-depth, FT(0)),
+        nelements = nelements_vert,
+        dz_tuple,
+        longlat,
+    )
+    return domain
+end
+
+"""
     _coupler_set_ic!(Y, p, t, model, atmos_T, set_ic!)
 
 Helper function to set initial conditions using the provided set_ic! function.

--- a/ext/ClimaCouplerClimaLandExt/climaland_integrated.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_integrated.jl
@@ -178,7 +178,9 @@ function ClimaLandSimulation(
     # Snow model setup
     # Set β = 0 in order to regain model without density dependence
     α_snow = CL.Snow.ZenithAngleAlbedoModel(toml_dict)
-    horz_degree_res = FT(sum(CL.Domains.average_horizontal_resolution_degrees(domain)) / 2) # mean of resolution in latitude and longitude, in degrees
+    horz_degree_res =
+        domain isa CL.Domains.Column ? FT(1) :
+        FT(sum(CL.Domains.average_horizontal_resolution_degrees(domain)) / 2)
     scf = CL.Snow.WuWuSnowCoverFractionModel(toml_dict, horz_degree_res)
     snow = CL.Snow.SnowModel(
         FT,

--- a/ext/ClimaCouplerMakieExt/debug_plots.jl
+++ b/ext/ClimaCouplerMakieExt/debug_plots.jl
@@ -124,9 +124,13 @@ plot the anomalies of the fields with respect to `cs_fields_ref`.
 
 For vector fields which are not defined on a Cartesian basis, rotate them to the Cartesian
 basis before plotting so they can be interpreted physically.
+
+For single-column (PointSpace) fields, each subplot shows only the title with extrema;
+no heatmap or table is drawn.
 """
 function Plotting.debug(cs_fields::CC.Fields.Field, dir, cs_fields_ref = nothing)
     field_names = propertynames(cs_fields)
+
     fig = Makie.Figure(size = (1500, 800))
     min_square_len = ceil(Int, sqrt(length(field_names)))
 
@@ -233,17 +237,90 @@ end
 """
     Plotting.debug_plot!(ax, fig, field::CC.Fields.Field, i, j)
 
-Helper function to plot a heatmap of a ClimaCore field in the given figure at position (i, j).
-If the field is constant, skip plotting it to avoid heatmap errors.
+Helper function to plot a ClimaCore field in the given figure at position (i, j).
+Dispatches on the field's space type via `_debug_plot_field!`.
 """
 function Plotting.debug_plot!(ax, fig, field::CC.Fields.Field, i, j)
-    # Copy field onto cpu space if necessary
     cpu_field = CC.to_cpu(field)
-    if cpu_field isa CC.Fields.ExtrudedCubedSphereSpectralElementField3D
-        cpu_field = CC.Fields.level(cpu_field, 1)
-    end
+    _debug_plot_field!(ax, fig, cpu_field, axes(cpu_field), i, j)
+end
 
-    # ClimaCoreMakie doesn't support NaNs/Infs, so we substitute them with 100max
+"""
+    _debug_plot_field!(ax, fig, cpu_field, space::CC.Spaces.FiniteDifferenceSpace, i, j)
+
+Plot a 1D column field (center or face FD space) as a line with z on the y-axis.
+"""
+function _debug_plot_field!(
+    ax,
+    fig,
+    cpu_field,
+    space::CC.Spaces.FiniteDifferenceSpace,
+    i,
+    j,
+)
+    _debug_plot_column!(ax, cpu_field)
+    return nothing
+end
+
+"""
+    _debug_plot_field!(ax, fig, cpu_field, space::CC.Spaces.ExtrudedFiniteDifferenceSpace, i, j)
+
+Plot a 3D extruded field: if horizontal space is cubed-sphere, take level 1 and heatmap;
+otherwise extract a single column and plot as a line (for BoxGrid column mode, used by atmos).
+"""
+function _debug_plot_field!(
+    ax,
+    fig,
+    cpu_field,
+    space::CC.Spaces.ExtrudedFiniteDifferenceSpace,
+    i,
+    j,
+)
+    hspace = CC.Spaces.horizontal_space(space)
+    if hspace isa CC.Spaces.CubedSphereSpectralElementSpace2D
+        # Cubed sphere case: make heatmap of level 1
+        _debug_plot_heatmap!(ax, fig, CC.Fields.level(cpu_field, 1), i, j)
+    else
+        # BoxGrid column mode: extract a single column and plot as a line
+        col_field = CC.Fields.column(cpu_field, 1, 1, 1)
+        _debug_plot_column!(ax, col_field)
+    end
+    return nothing
+end
+
+"""
+    _debug_plot_field!(ax, fig, cpu_field, space, i, j)
+
+Fallback: plot a 2D spatial field as a heatmap (e.g. `SpectralElementSpace2D`).
+"""
+function _debug_plot_field!(ax, fig, cpu_field, space, i, j)
+    _debug_plot_heatmap!(ax, fig, cpu_field, i, j)
+    return nothing
+end
+
+"""
+    _debug_plot_column!(ax, field)
+
+Plot a 1D column field as a line with z on the y-axis.
+"""
+function _debug_plot_column!(ax, field)
+    z = vec(Array(parent(CC.Fields.coordinate_field(field).z)))
+    vals = vec(Array(parent(field)))
+
+    valid = @. !(isnan(vals) || isinf(vals))
+    any(valid) || return nothing
+
+    Makie.lines!(ax, vals[valid], z[valid])
+    ax.ylabel = "z"
+    return nothing
+end
+
+"""
+    _debug_plot_heatmap!(ax, fig, cpu_field, i, j)
+
+Plot a 2D spatial field as a heatmap with colorbar.
+"""
+function _debug_plot_heatmap!(ax, fig, cpu_field, i, j)
     FT = CC.Spaces.undertype(axes(cpu_field))
     isinvalid = (x) -> isnan(x) || isinf(x)
     field_valid_min, field_valid_max =

--- a/ext/ClimaCouplerMakieExt/diagnostics_plots.jl
+++ b/ext/ClimaCouplerMakieExt/diagnostics_plots.jl
@@ -30,6 +30,10 @@ This function will plot all variables that have been saved in `output_path`.
 
 When plotting diagnostics, diagnostics that are daily averages in z coordinates
 (if available) are prioritized first.
+
+For column / box-grid output (no lat/lon dimensions), degenerate horizontal
+dimensions are sliced out and 3-D variables are plotted as vertical profiles
+(value vs z) instead of being zonally averaged.
 """
 function Plotting.make_diagnostics_plots(
     output_path::AbstractString,
@@ -55,29 +59,69 @@ function Plotting.make_diagnostics_plots(
         vars[i] = get(simdir; short_name, reduction, period, coord_type)
     end
 
-    # Filter vars into 2D and 3D variable diagnostics vectors
-    # 3D fields are zonally averaged platted on the lat-z plane
-    # 2D fields are plotted on the lon-lat plane
     is_3d = var -> CAN.has_altitude(var) || CAN.has_pressure(var)
-    vars_3D = map(var_3D -> CAN.average_lon(var_3D), filter(is_3d, vars))
-    vars_2D = filter(var -> !is_3d(var), vars)
+    has_latlon = any(v -> CAN.has_longitude(v) || CAN.has_latitude(v), vars)
 
-    # Generate plots and save in `plot_path`
-    !isempty(vars_3D) && make_plots_generic(
-        output_path,
-        plot_path,
-        vars_3D,
-        time = LAST_SNAP,
-        output_name = output_prefix * "summary_3D",
-        more_kwargs = YLINEARSCALE,
-    )
-    !isempty(vars_2D) && make_plots_generic(
-        output_path,
-        plot_path,
-        vars_2D,
-        time = LAST_SNAP,
-        output_name = output_prefix * "summary_2D",
-    )
+    if has_latlon
+        # Global mode: zonally-averaged 3-D fields on lat-z, 2-D fields on lon-lat
+        vars_3D = map(var_3D -> CAN.average_lon(var_3D), filter(is_3d, vars))
+        vars_2D = filter(var -> !is_3d(var), vars)
+
+        !isempty(vars_3D) && make_plots_generic(
+            output_path,
+            plot_path,
+            vars_3D,
+            time = LAST_SNAP,
+            output_name = output_prefix * "summary_3D",
+            more_kwargs = YLINEARSCALE,
+        )
+        !isempty(vars_2D) && make_plots_generic(
+            output_path,
+            plot_path,
+            vars_2D,
+            time = LAST_SNAP,
+            output_name = output_prefix * "summary_2D",
+        )
+    else
+        # Column / box-grid mode: slice out degenerate horizontal dims
+        vars_profile = _slice_to_column.(filter(is_3d, vars))
+        vars_surface = _slice_to_column.(filter(var -> !is_3d(var), vars))
+
+        !isempty(vars_profile) && make_plots_generic(
+            output_path,
+            plot_path,
+            vars_profile,
+            time = LAST_SNAP,
+            output_name = output_prefix * "summary_profiles",
+            more_kwargs = YLINEARSCALE,
+        )
+        !isempty(vars_surface) && make_plots_generic(
+            output_path,
+            plot_path,
+            vars_surface,
+            time = LAST_SNAP,
+            output_name = output_prefix * "summary_surface",
+        )
+    end
+end
+
+
+
+"""
+    _slice_to_column(var)
+
+Remove horizontal dimensions from a `CAN.OutputVar` by slicing at the first
+value. Used for column / box-grid diagnostics saved by the atmosphere in
+column mode to get 1D vertical profiles.
+"""
+function _slice_to_column(var)
+    CAN.has_longitude(var) && (var = CAN.slice(var, by = CAN.Index(), longitude = 1))
+    CAN.has_latitude(var) && (var = CAN.slice(var, by = CAN.Index(), latitude = 1))
+
+    dim_names = collect(keys(var.dims))
+    "x" in dim_names && (var = CAN.slice(var, by = CAN.Index(), x = 1))
+    "y" in dim_names && (var = CAN.slice(var, by = CAN.Index(), y = 1))
+    return var
 end
 
 """

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -45,8 +45,8 @@ function update_surface_fractions!(cs::Interfacer.CoupledSimulation)
     # ice and ocean fractions are dynamic
     if haskey(cs.model_sims, :ice_sim)
         ice_sim = cs.model_sims.ice_sim
-        Interfacer.get_field!(cs.fields.scalar_temp1, ice_sim, Val(:ice_concentration))
-        ice_concentration = cs.fields.scalar_temp1
+        Interfacer.get_field!(cs.fields.scalar_temp2, ice_sim, Val(:ice_concentration))
+        ice_concentration = cs.fields.scalar_temp2
 
         # max needed to avoid Float32 errors (see issue #271; Heisenbug on HPC)
         Interfacer.update_field!(
@@ -56,8 +56,8 @@ function update_surface_fractions!(cs::Interfacer.CoupledSimulation)
         )
         ice_fraction = Interfacer.get_field(ice_sim, Val(:area_fraction))
     else
-        cs.fields.scalar_temp1 .= 0
-        ice_fraction = cs.fields.scalar_temp1
+        cs.fields.scalar_temp2 .= 0
+        ice_fraction = cs.fields.scalar_temp2
     end
 
     if haskey(cs.model_sims, :ocean_sim)
@@ -74,8 +74,8 @@ function update_surface_fractions!(cs::Interfacer.CoupledSimulation)
             resolve_area_fractions!(ocean_sim, cs.model_sims.ice_sim, land_fraction)
         end
     else
-        cs.fields.scalar_temp1 .= 0
-        ocean_fraction = cs.fields.scalar_temp1
+        cs.fields.scalar_temp3 .= 0
+        ocean_fraction = cs.fields.scalar_temp3
     end
 
     # check that the sum of area fractions is 1

--- a/src/Input.jl
+++ b/src/Input.jl
@@ -263,6 +263,19 @@ function argparse_settings()
         help = "Boolean flag indicating whether to use binary (thresholded) area fractions for land and ice [`true` (default), `false`]. When true, land fraction > eps becomes 1, and ice fraction > 0.5 becomes 1."
         arg_type = Bool
         default = true
+        # Single-column model (SCM) settings
+        "--domain_type"
+        help = "Domain type for the simulation. [`global` (default), `column`]"
+        arg_type = String
+        default = "global"
+        "--column_latlon"
+        help = "Latitude and longitude (degrees) for SCM column as [lat, lon]. Latitude should be in the range [-90, 90] and longitude should be in [-180, 180]. [[0.0, 0.0] (default)]"
+        arg_type = Vector{Float64}
+        default = [0.0, 0.0]
+        "--scm_surface_type"
+        help = "Select the surface type for SCM runs. [`ocean` (default), `land`, `sea_ice`]."
+        arg_type = String
+        default = "ocean"
     end
     return s
 end
@@ -502,9 +515,35 @@ function get_coupler_args(config_dict::Dict)
     # Ice model-specific information
     ice_model = Val(Symbol(config_dict["ice_model"]))
 
-    # Validate and correct model types based on simulation mode
-    ocean_model, ice_model, land_model =
-        validate_model_types_for_mode(sim_mode, ocean_model, ice_model, land_model)
+    # SCM settings
+    domain_type = config_dict["domain_type"]
+    column_latlon = Tuple(config_dict["column_latlon"])
+    scm_surface_type = config_dict["scm_surface_type"]
+
+    # Validate column lat/lon values
+    if domain_type == "column"
+        lat = first(column_latlon)
+        lon = last(column_latlon)
+        @assert lat >= -90 && lat <= 90 "Latitude must be between -90 and 90 degrees"
+        @assert lon >= -180 && lon <= 180 "Longitude must be between -180 and 180 degrees"
+    end
+
+    # SCM mode: no file-based land ICs available; use programmatic defaults
+    if domain_type == "column" && isempty(scm_surface_type)
+        error(
+            "domain_type=\"column\" requires `scm_surface_type` to be set to \"land\", " *
+            "\"ocean\", or \"sea_ice\". This selects the active surface type for the column.",
+        )
+    end
+
+    ocean_model, ice_model, land_model = validate_model_types_for_mode(
+        sim_mode,
+        ocean_model,
+        ice_model,
+        land_model;
+        domain_type,
+        scm_surface_type,
+    )
 
     # Land fraction source
     land_fraction_source = config_dict["land_fraction_source"]
@@ -553,6 +592,9 @@ function get_coupler_args(config_dict::Dict)
         ice_model,
         land_fraction_source,
         binary_area_fraction,
+        domain_type,
+        column_latlon,
+        scm_surface_type,
     )
 end
 
@@ -657,7 +699,7 @@ end
 
 
 """
-    get_land_fraction(boundary_space, comms_ctx; land_fraction_source = "etopo", binary_area_fraction = true)
+    get_land_fraction(boundary_space, comms_ctx; land_fraction_source = "etopo", binary_area_fraction = true, domain_type = "global", scm_surface_type = "ocean")
 
 Read and remap the land-sea fraction field onto the coupler boundary grid.
 
@@ -667,6 +709,8 @@ Read and remap the land-sea fraction field onto the coupler boundary grid.
 - `land_fraction_source`: Source of land fraction data. Either "etopo" (default) or "era5".
 - `binary_area_fraction`: If true (default), threshold land fraction to binary (0 or 1).
 - `mode_name`: The name of the simulation mode.
+- `domain_type`: The type of domain. Either "global" or "column".
+- `scm_surface_type`: The surface type for SCM runs. Either "land", "ocean", or "sea_ice".
 
 # Returns
 - A field containing land fraction values (0 to 1) on the boundary space.
@@ -689,10 +733,19 @@ function get_land_fraction(
     land_fraction_source::String = "etopo",
     binary_area_fraction::Bool = true,
     sim_mode = Interfacer.AMIPMode,
+    domain_type = "global",
+    scm_surface_type = "ocean",
 )
-    sim_mode <: Interfacer.SlabplanetTerraMode && return ones(boundary_space)
+    # SCM column: land vs sea fraction follows `scm_surface_type`
+    if domain_type == "column"
+        if scm_surface_type == "land"
+            return ones(boundary_space)
+        else
+            return zeros(boundary_space)
+        end
+    end
 
-    FT = CC.Spaces.undertype(boundary_space)
+    sim_mode <: Interfacer.SlabplanetTerraMode && return ones(boundary_space)
     if land_fraction_source == "era5"
         land_fraction_data = joinpath(
             @clima_artifact("era5_land_fraction", comms_ctx),
@@ -711,6 +764,7 @@ function get_land_fraction(
         )
     end
 
+    FT = CC.Spaces.undertype(boundary_space)
     # Ensure land fraction is finite/not NaN and clamp to [0, 1]
     land_fraction = ifelse.(isfinite.(land_fraction), land_fraction, FT(0))
     land_fraction = max.(min.(land_fraction, FT(1)), FT(0))
@@ -725,15 +779,31 @@ function get_land_fraction(
 end
 
 """
-    validate_model_types_for_mode(sim_mode, ocean_model, ice_model, land_model)
+    validate_model_types_for_mode(sim_mode, ocean_model, ice_model, land_model;
+        domain_type = "global", scm_surface_type = nothing)
 
-Validate and correct model types based on simulation mode requirements.
+Validate and correct model types based on simulation mode requirements and
+domain type. For SCM (`domain_type == "column"`), applies `scm_surface_type`
+surface selection and rejects unsupported component models.
 Issues warnings and returns updated model types if they don't match the expected values.
 
 # Returns
 - `(ocean_model, ice_model, land_model)`: Tuple of validated model types
 """
-function validate_model_types_for_mode(sim_mode, ocean_model, ice_model, land_model)
+function validate_model_types_for_mode(
+    sim_mode,
+    ocean_model,
+    ice_model,
+    land_model;
+    domain_type = "global",
+    scm_surface_type = "ocean",
+)
+    # SCM case: choose surface type based on `scm_surface_type`
+    if domain_type == "column"
+        return _apply_scm_surface_type(scm_surface_type, ocean_model, ice_model, land_model)
+    end
+
+    # Global case: validate surface model types based on simulation mode
     expected_ocean = ocean_model
     expected_ice = ice_model
     expected_land = land_model
@@ -794,6 +864,49 @@ function validate_model_types_for_mode(sim_mode, ocean_model, ice_model, land_mo
     return ocean_model, ice_model, land_model
 end
 
+
+"""
+    _apply_scm_surface_type(scm_surface_type, ocean_model, ice_model, land_model)
+
+Override component model selections based on `scm_surface_type`.
+When running an SCM with a specified surface type, only the corresponding
+component model is active; the others are set to `:nothing`.
+"""
+function _apply_scm_surface_type(scm_surface_type, ocean_model, ice_model, land_model)
+    if scm_surface_type == "land"
+        ocean_model = Val(:nothing)
+        ice_model = Val(:nothing)
+    elseif scm_surface_type == "ocean"
+        land_model = Val(:nothing)
+        ice_model = Val(:nothing)
+    elseif scm_surface_type == "sea_ice"
+        land_model = Val(:nothing)
+        ocean_model = Val(:nothing)
+    else
+        error(
+            "Unknown scm_surface_type: \"$scm_surface_type\". " *
+            "Must be \"land\", \"ocean\", or \"sea_ice\".",
+        )
+    end
+    @info "SCM surface type: scm_surface_type=$scm_surface_type → " *
+          "land_model=$land_model, ocean_model=$ocean_model, ice_model=$ice_model"
+
+
+    # Reject unsupported component models in column mode
+    if ocean_model == Val(:oceananigans)
+        error(
+            "Oceananigans ocean model is not supported with domain_type=\"column\". " *
+            "Use ocean_model=\"slab\" or ocean_model=\"prescribed\", or a different surface type instead.",
+        )
+    end
+    if ice_model == Val(:clima_seaice)
+        error(
+            "ClimaSeaIce model is not supported with domain_type=\"column\". " *
+            "Use ice_model=\"prescribed\", or a different surface type instead.",
+        )
+    end
+    return ocean_model, ice_model, land_model
+end
 
 """
     get_era5_filepaths(::Type{<:Interfacer.SubseasonalMode}, era5_initial_condition_dir, start_date, bucket_initial_condition)

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -12,6 +12,7 @@ import Dates
 import Thermodynamics as TD
 import SciMLBase: step!
 import ClimaUtilities.TimeManager: ITime, date
+import Statistics
 
 export CoupledSimulation,
     LandSimulation,
@@ -37,7 +38,8 @@ export CoupledSimulation,
     CMIPMode,
     SlabplanetMode,
     SlabplanetAquaMode,
-    SlabplanetTerraMode
+    SlabplanetTerraMode,
+    is_column_mode
 
 """
     AbstractSimulation
@@ -103,6 +105,17 @@ Return the model date at the current timestep.
 """
 current_date(cs::CoupledSimulation) =
     cs.t[] isa ITime ? date(cs.t[]) : cs.start_date + Dates.Second(cs.t[])
+
+"""
+    is_column_mode(cs::Interfacer.CoupledSimulation)
+
+Return `true` when the coupler boundary fields live on a `PointSpace`, which
+indicates a single-column model (SCM) run.
+"""
+function is_column_mode(cs::Interfacer.CoupledSimulation)
+    names = propertynames(cs.fields)
+    return axes(getproperty(cs.fields, first(names))) isa CC.Spaces.PointSpace
+end
 
 """
     default_coupler_fields()
@@ -553,9 +566,30 @@ function remap!(target_field::CC.Fields.Field, source_field::CC.Fields.Field)
         return nothing
     end
 
+    # SCM mode: The boundary space is a PointSpace while the atmos surface space
+    # is a small SpectralElementSpace2D (from BoxGrid with 4 quadrature points),
+    # so we allow the mismatch and use the mean of the source values.
+    if target_space isa CC.Spaces.PointSpace
+        target_field .= Statistics.mean(source_field)
+        return nothing
+    end
+    # SCM mode: When remapping from the coupler's boundary space to the atmosphere's box column,
+    # the spaces won't match, so we copy the source values to the target field.
+    # Note this works for the PointSpace to PointSpace case as well.
+    if source_space isa CC.Spaces.PointSpace
+        parent(target_field) .= parent(source_field)
+        return nothing
+    end
+
     # Get vector of LatLongPoints for the target space to get the hcoords
     # Copy target coordinates to CPU if they are on GPU
     coords = CC.to_cpu(CC.Fields.coordinate_field(target_space))
+    if !(hasproperty(coords, :lat) && hasproperty(coords, :long))
+        error(
+            "Cannot remap between incompatible spaces: target space " *
+            "$(typeof(target_space)) does not have lat/long coordinates.",
+        )
+    end
     lats = CC.Fields.field2array(coords.lat)
     lons = CC.Fields.field2array(coords.long)
     hcoords = CC.Geometry.LatLongPoint.(lats, lons)

--- a/src/Models/prescr_seaice.jl
+++ b/src/Models/prescr_seaice.jl
@@ -227,6 +227,7 @@ function PrescribedIceSimulation(
     stepper = CTS.RK4(),
     sic_path::Union{Nothing, String} = nothing,
     binary_area_fraction::Bool = true,
+    domain_type::String = "global",
     extra_kwargs...,
 ) where {FT}
     # Set up prescribed sea ice concentration object
@@ -256,16 +257,20 @@ function PrescribedIceSimulation(
 
     # Get initial SIC values and use them to calculate ice fraction
     ice_fraction = CC.Fields.zeros(boundary_space)
-    evaluate!(ice_fraction, SIC_timevaryinginput, tspan[1])
+    if domain_type == "column"
+        ice_fraction .= FT(1)
+    else
+        evaluate!(ice_fraction, SIC_timevaryinginput, tspan[1])
 
-    # Ensure ice fraction is finite and not NaN
-    @. ice_fraction = ifelse(isfinite(ice_fraction), ice_fraction, FT(0))
-    # binary ice fraction (threshold at 0.5)
-    if binary_area_fraction
-        @. ice_fraction = ifelse(ice_fraction > FT(0.5), FT(1), FT(0))
+        # Ensure ice fraction is finite and not NaN
+        @. ice_fraction = ifelse(isfinite(ice_fraction), ice_fraction, FT(0))
+        # binary ice fraction (threshold at 0.5)
+        if binary_area_fraction
+            @. ice_fraction = ifelse(ice_fraction > FT(0.5), FT(1), FT(0))
+        end
+        # max/min needed to avoid Float32 errors (see issue #271; Heisenbug on HPC)
+        @. ice_fraction = max(min(ice_fraction, FT(1) - land_fraction), FT(0))
     end
-    # max/min needed to avoid Float32 errors (see issue #271; Heisenbug on HPC)
-    @. ice_fraction = max(min(ice_fraction, FT(1) - land_fraction), FT(0))
 
     params = IceSlabParameters{FT}(coupled_param_dict)
 
@@ -288,16 +293,17 @@ function PrescribedIceSimulation(
         SIC_timevaryinginput = SIC_timevaryinginput,
         land_fraction = land_fraction,
         binary_area_fraction = binary_area_fraction,
+        domain_type = domain_type,
         dt = dt,
         thermo_params = thermo_params,
         # add dss_buffer to cache to avoid runtime dss allocation
-        dss_buffer = CC.Spaces.create_dss_buffer(Y),
+        dss_buffer = Utilities.init_dss_buffer(Y),
     )
 
     ode_algo = CTS.ExplicitAlgorithm(stepper)
     ode_function = CTS.ClimaODEFunction(
         T_exp! = ice_rhs!,
-        dss! = (Y, p, t) -> CC.Spaces.weighted_dss!(Y, p.dss_buffer),
+        dss! = (Y, p, t) -> Utilities.apply_dss!(Y, p.dss_buffer),
     )
     if dt isa Number
         dt = Float64(dt)
@@ -426,16 +432,20 @@ function ice_rhs!(dY, Y, p, t)
     (; k_ice, h, T_base, ρ, c, ϵ, α, T_freeze, σ) = p.params
 
     # Update the cached area fraction with the current SIC
-    evaluate!(p.area_fraction, p.SIC_timevaryinginput, t)
-    @. p.area_fraction = ifelse(isfinite(p.area_fraction), p.area_fraction, FT(0))
-    # binary ice fraction (threshold at 0.5)
-    if p.binary_area_fraction
-        @. p.area_fraction = ifelse(p.area_fraction > FT(0.5), FT(1), FT(0))
-    end
+    if p.domain_type == "column"
+        @. p.area_fraction = FT(1)
+    else
+        evaluate!(p.area_fraction, p.SIC_timevaryinginput, t)
+        @. p.area_fraction = ifelse(isfinite(p.area_fraction), p.area_fraction, FT(0))
+        # binary ice fraction (threshold at 0.5)
+        if p.binary_area_fraction
+            @. p.area_fraction = ifelse(p.area_fraction > FT(0.5), FT(1), FT(0))
+        end
 
-    # Overwrite ice fraction with the static land area fraction anywhere we have nonzero land area
-    #  max needed to avoid Float32 errors (see issue #271; Heisenbug on HPC)
-    @. p.area_fraction = max(min(p.area_fraction, FT(1) - p.land_fraction), FT(0))
+        # Overwrite ice fraction with the static land area fraction anywhere we have nonzero land area
+        #  max needed to avoid Float32 errors (see issue #271; Heisenbug on HPC)
+        @. p.area_fraction = max(min(p.area_fraction, FT(1) - p.land_fraction), FT(0))
+    end
 
     # Calculate the conductive flux (positive when upward)
     (; T_sfc_min) = p.params
@@ -465,7 +475,7 @@ Perform DSS on the state of a component simulation, intended to be used
 before the initial step of a run. This method acts on prescribed ice simulations.
 """
 dss_state!(sim::PrescribedIceSimulation) =
-    CC.Spaces.weighted_dss!(sim.integrator.u, sim.integrator.p.dss_buffer)
+    Utilities.apply_dss!(sim.integrator.u, sim.integrator.p.dss_buffer)
 
 function Checkpointer.get_model_cache(sim::PrescribedIceSimulation)
     return sim.integrator.p

--- a/src/Models/slab_ocean.jl
+++ b/src/Models/slab_ocean.jl
@@ -162,14 +162,14 @@ function SlabOceanSimulation(
         u_atmos = CC.Fields.zeros(boundary_space),
         v_atmos = CC.Fields.zeros(boundary_space),
         # add dss_buffer to cache to avoid runtime dss allocation
-        dss_buffer = CC.Spaces.create_dss_buffer(Y),
+        dss_buffer = Utilities.init_dss_buffer(Y),
         coare3_roughness_params,
     )
 
     ode_algo = CTS.ExplicitAlgorithm(stepper)
     ode_function = CTS.ClimaODEFunction(;
         T_exp! = slab_ocean_rhs!,
-        dss! = (Y, p, t) -> CC.Spaces.weighted_dss!(Y, p.dss_buffer),
+        dss! = (Y, p, t) -> Utilities.apply_dss!(Y, p.dss_buffer),
     )
     if typeof(dt) isa Number
         dt = Float64(dt)
@@ -308,4 +308,4 @@ Perform DSS on the state of a component simulation, intended to be used
 before the initial step of a run. This method acts on slab ocean model sims.
 """
 dss_state!(sim::SlabOceanSimulation) =
-    CC.Spaces.weighted_dss!(sim.integrator.u, sim.integrator.p.dss_buffer)
+    Utilities.apply_dss!(sim.integrator.u, sim.integrator.p.dss_buffer)

--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -135,18 +135,21 @@ function postprocess(
     # Plot all model states and coupler fields (useful for debugging)
     ClimaComms.context(cs) isa ClimaComms.SingletonCommsContext && debug(cs, artifacts_dir)
 
-    # If we have enough data (in time, but also enough variables), plot the leaderboard.
-    # We need pressure to compute the leaderboard.
-    simdir = CAN.SimDir(atmos_output_dir)
-    if !isempty(simdir)
-        pressure_in_output = "pfull" in CAN.available_vars(simdir)
-        t_end = float(cs.t[])
-        if t_end > 84600 * 31 * 3 # 3 months for spin up
-            leaderboard_base_path = artifacts_dir
-            compute_leaderboard(leaderboard_base_path, atmos_output_dir, 3)
-            rmse_check && SimOutput.test_rmse_thresholds(atmos_output_dir, 3)
-            pressure_in_output &&
-                compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir, 3)
+    # Leaderboard requires global spatial data; skip in column / SCM mode.
+    if !Interfacer.is_column_mode(cs)
+        simdir = CAN.SimDir(atmos_output_dir)
+        if !isempty(simdir)
+            # We need pressure to compute the leaderboard.
+            pressure_in_output = "pfull" in CAN.available_vars(simdir)
+            t_end = float(cs.t[])
+            # Make sure we have enough data to compute the leaderboard.
+            if t_end > 84600 * 31 * 3 # 3 months for spin up
+                leaderboard_base_path = artifacts_dir
+                compute_leaderboard(leaderboard_base_path, atmos_output_dir, 3)
+                rmse_check && SimOutput.test_rmse_thresholds(atmos_output_dir, 3)
+                pressure_in_output &&
+                    compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir, 3)
+            end
         end
     end
 

--- a/src/SimCoordinator.jl
+++ b/src/SimCoordinator.jl
@@ -243,6 +243,9 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
         ice_model,
         land_fraction_source,
         binary_area_fraction,
+        domain_type,
+        column_latlon,
+        scm_surface_type,
     ) = Input.get_coupler_args(config_dict)
 
     override_file = CP.merge_toml_files(parameter_files; override = true)
@@ -276,17 +279,22 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
 
     #=
     ### Boundary Space
-    We use a 2D boundary space at the surface for coupling.
-    If `share_surface_space` is true, the atmosphere's horizontal space is used directly;
-    otherwise a separate cubed-sphere space is created at the specified resolution.
+    We use a boundary space at the surface for coupling operations (computing fluxes, regridding, etc).
+    For column mode, this is a 1D PointSpace with lat/long coordinates.
+    For global mode, this is a 2D CubedSphereSpace or the atmosphere's horizontal space
+    (if `share_surface_space` is true).
     =#
-    if share_surface_space
-        boundary_space = CC.Spaces.horizontal_space(atmos_sim.domain.face_space)
-    else
-        n_quad_points = nh_poly + 1
-        radius = coupled_param_dict["planet_radius"]
-        boundary_space = CC.CommonSpaces.CubedSphereSpace(FT; radius, n_quad_points, h_elem)
-    end
+    boundary_space = Utilities.create_boundary_space(
+        FT,
+        domain_type,
+        atmos_sim,
+        share_surface_space,
+        comms_ctx;
+        column_latlon,
+        nh_poly,
+        h_elem,
+        coupled_param_dict,
+    )
 
     surface_elevation = Interfacer.get_field(boundary_space, atmos_sim, Val(:height_sfc))
     atmos_h = Interfacer.get_atmos_height_delta(
@@ -300,6 +308,8 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
         land_fraction_source,
         binary_area_fraction,
         sim_mode,
+        domain_type,
+        scm_surface_type,
     )
 
     #=
@@ -312,7 +322,8 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
     (; sst_path, sic_path, land_ic_path, albedo_path, bucket_initial_condition) =
         era5_filepaths
 
-    shared_surface_space = share_surface_space ? boundary_space : nothing
+    shared_surface_space =
+        (share_surface_space || domain_type == "column") ? boundary_space : nothing
     land_sim = Interfacer.LandSimulation(
         FT,
         land_model;
@@ -369,6 +380,7 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
         land_fraction,
         sic_path,
         binary_area_fraction,
+        domain_type,
     )
 
     #=
@@ -386,9 +398,9 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
 
     coupler_fields = Interfacer.init_coupler_fields(FT, coupler_field_names, boundary_space)
 
-    ## Conservation checks (only applicable to slabplanet mode)
+    ## Conservation checks (only applicable to global slabplanet mode)
     conservation_checks = nothing
-    if energy_check
+    if energy_check && domain_type == "global"
         @assert(
             sim_mode <: Interfacer.AbstractSlabplanetSimulationMode &&
             comms_ctx isa ClimaComms.SingletonCommsContext,
@@ -398,6 +410,8 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
             energy = ConservationChecker.EnergyConservationCheck(model_sims),
             water = ConservationChecker.WaterConservationCheck(model_sims),
         )
+    elseif energy_check && domain_type == "column"
+        @warn "Conservation checks are disabled for single-column mode."
     end
 
     ## Callbacks

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -12,7 +12,12 @@ import Logging
 import ClimaUtilities.OutputPathGenerator: generate_output_path
 
 export get_device,
-    get_comms_context, show_memory_usage, setup_output_dirs, time_to_seconds, integral
+    get_comms_context,
+    show_memory_usage,
+    setup_output_dirs,
+    time_to_seconds,
+    integral,
+    create_boundary_space
 
 """
     get_device(config_dict)
@@ -237,6 +242,145 @@ end
 
 function integral(field::AbstractArray)
     return sum(field)
+end
+
+"""
+    _column_boundary_space(::Type{FT}, latlon, comms_ctx) where {FT}
+
+Create a `PointSpace` with lat/long coordinates for use as a single-column
+boundary space. Constructs a minimal extruded domain with `LatPoint`/`LongPoint`
+intervals centered at the given coordinates, then extracts the top face level
+as a `PointSpace`.
+
+The resulting `PointSpace` has `LatLongZPoint` coordinates (with `.lat`, `.long`,
+and `.z`), so `SpaceVaryingInput`, `TimeVaryingInput`, insolation calculations,
+and coordinate-dependent physics all work correctly.
+
+# Arguments
+- `FT`: floating-point type
+- `latlon`: tuple of `(latitude, longitude)` in degrees
+- `comms_ctx`: ClimaComms context
+"""
+function _column_boundary_space(::Type{FT}, latlon, comms_ctx) where {FT}
+    lat, long = FT.(latlon)
+    device = ClimaComms.device(comms_ctx)
+
+    # Build a small non-degenerate horizontal domain centered at (lat, long).
+    # GL{1} gives 1 quadrature point per element, located at the interval center.
+    offset = FT(0.2)
+    domain_x = CC.Domains.IntervalDomain(
+        CC.Geometry.LatPoint(lat - offset),
+        CC.Geometry.LatPoint(lat + offset);
+        boundary_names = (:north, :south),
+    )
+    domain_y = CC.Domains.IntervalDomain(
+        CC.Geometry.LongPoint(long - offset),
+        CC.Geometry.LongPoint(long + offset);
+        boundary_names = (:west, :east),
+    )
+    plane = CC.Domains.RectangleDomain(domain_x, domain_y)
+    mesh = CC.Meshes.RectilinearMesh(plane, 1, 1)
+    topology = CC.Topologies.Topology2D(comms_ctx, mesh)
+    quad = CC.Spaces.Quadratures.GL{1}()
+    hspace = CC.Spaces.SpectralElementSpace2D(topology, quad)
+
+    # Minimal vertical domain
+    z_sfc = FT(0)
+    vertdomain = CC.Domains.IntervalDomain(
+        CC.Geometry.ZPoint(z_sfc - FT(1)),
+        CC.Geometry.ZPoint(z_sfc);
+        boundary_names = (:bottom, :top),
+    )
+    vertmesh = CC.Meshes.IntervalMesh(vertdomain; nelems = 2)
+    vert_center_space = CC.Spaces.CenterFiniteDifferenceSpace(device, vertmesh)
+    center_extruded = CC.Spaces.ExtrudedFiniteDifferenceSpace(hspace, vert_center_space)
+
+    # Extract the top face level as a PointSpace.
+    # level(FaceFiniteDifferenceSpace, PlusHalf) → PointSpace
+    face_extruded = CC.Spaces.face_space(center_extruded)
+    face_column = CC.Spaces.column(face_extruded, 1, 1, 1)
+    point_space = CC.Spaces.level(face_column, CC.Utilities.half)
+
+    return point_space
+end
+
+"""
+    create_boundary_space(::Type{FT}, domain_type, atmos_sim, share_surface_space, comms_ctx; kwargs...)
+
+Construct the 2D boundary space used for coupler field exchange.
+
+For `domain_type == "column"`, returns a `PointSpace` with lat/long coordinates.
+For global simulations, returns either the atmosphere's horizontal surface space
+(when `share_surface_space` is true) or an independent `CubedSphereSpace`.
+
+# Arguments
+- `FT`: floating-point type
+- `domain_type`: `"global"` or `"column"`
+- `atmos_sim`: atmosphere simulation (used when sharing surface space)
+- `share_surface_space`: whether to reuse the atmosphere's horizontal space
+- `comms_ctx`: ClimaComms context
+- `column_latlon`: `(lat, lon)` tuple, required when `domain_type == "column"`
+- `nh_poly`: polynomial order, required when not sharing surface space
+- `h_elem`: number of horizontal elements, required when not sharing surface space
+- `coupled_param_dict`: parameter dictionary, required when not sharing surface space
+"""
+function create_boundary_space(
+    ::Type{FT},
+    domain_type,
+    atmos_sim,
+    share_surface_space,
+    comms_ctx;
+    column_latlon = nothing,
+    nh_poly = nothing,
+    h_elem = nothing,
+    coupled_param_dict = nothing,
+) where {FT}
+    if domain_type == "column"
+        return _column_boundary_space(FT, column_latlon, comms_ctx)
+    elseif share_surface_space
+        return CC.Spaces.horizontal_space(atmos_sim.domain.face_space)
+    else
+        n_quad_points = nh_poly + 1
+        radius = coupled_param_dict["planet_radius"]
+        return CC.CommonSpaces.CubedSphereSpace(FT; radius, n_quad_points, h_elem)
+    end
+end
+
+"""
+    init_dss_buffer(field::CC.Fields.Field)
+    init_dss_buffer(field_object::Union{CC.Fields.FieldVector, NamedTuple})
+
+Initialize a DSS buffer for the given Field or FieldVector object.
+If the object is defined on a `PointSpace`, return `nothing`.
+"""
+function init_dss_buffer(field::CC.Fields.Field)
+    if axes(field) isa CC.Spaces.PointSpace
+        return nothing
+    else
+        return CC.Spaces.create_dss_buffer(field)
+    end
+end
+function init_dss_buffer(field_object::Union{CC.Fields.FieldVector, NamedTuple})
+    buffers = map(
+        key -> init_dss_buffer(getproperty(field_object, key)),
+        propertynames(field_object),
+    )
+    all(isnothing, buffers) && return nothing
+    return NamedTuple{propertynames(field_object)}(buffers)
+end
+
+"""
+    apply_dss!(field::Union{CC.Fields.Field, CC.Fields.FieldVector}, buffer)
+
+Apply DSS to the given Field or FieldVector object.
+If the object is defined on a `PointSpace`, return `nothing`.
+"""
+function apply_dss!(field::Union{CC.Fields.Field, CC.Fields.FieldVector}, buffer)
+    if isnothing(buffer)
+        return nothing
+    else
+        return CC.Spaces.weighted_dss!(field, buffer)
+    end
 end
 
 end # module

--- a/test/input_tests.jl
+++ b/test/input_tests.jl
@@ -4,7 +4,7 @@
 using Test
 import ArgParse
 import Dates
-import ClimaCoupler: Input, Utilities
+import ClimaCoupler: Input, Utilities, Interfacer
 import ClimaCoupler
 import YAML
 
@@ -97,6 +97,9 @@ end
         "sst_adjustment" => 2.0,
         "land_fraction_source" => "etopo",
         "binary_area_fraction" => true,
+        "domain_type" => "global",
+        "column_latlon" => [0.0, 0.0],
+        "scm_surface_type" => nothing,
         "component_dt_dict" => Dict(
             "dt_atmos" => 400.0,
             "dt_land" => 400.0,
@@ -125,6 +128,9 @@ end
     @test args.ice_model == Val(:prescribed)
     @test args.land_fraction_source == "etopo"
     @test args.sst_adjustment == 2.0
+    @test args.domain_type == "global"
+    @test args.column_latlon == (0.0, 0.0)
+    @test args.scm_surface_type === nothing
 
     # Test that component_dt_dict is preserved
     @test args.component_dt_dict isa Dict
@@ -267,4 +273,145 @@ end
         config_dict,
     )
     @test !haskey(config_dict, "dt")
+end
+
+@testset "validate_model_types_for_mode" begin
+    ocean, ice, land = Input.validate_model_types_for_mode(
+        Interfacer.AMIPMode, # sim_mode
+        Val(:slab), # ocean_model
+        Val(:nothing), # ice_model
+        Val(:bucket), # land_model
+    )
+    @test ocean == Val(:prescribed)
+    @test ice == Val(:prescribed)
+    @test land == Val(:bucket)
+
+    ocean, ice, land = Input.validate_model_types_for_mode(
+        Interfacer.SlabplanetAquaMode,
+        Val(:slab),
+        Val(:nothing),
+        Val(:bucket),
+    )
+    @test ocean == Val(:slab)
+    @test ice == Val(:nothing)
+    @test land == Val(:nothing)
+
+    ocean, ice, land = Input.validate_model_types_for_mode(
+        Interfacer.SlabplanetTerraMode,
+        Val(:slab),
+        Val(:prescribed),
+        Val(:integrated),
+    )
+    @test ocean == Val(:nothing)
+    @test ice == Val(:nothing)
+    @test land == Val(:integrated)
+
+    ocean, ice, land = Input.validate_model_types_for_mode(
+        Interfacer.CMIPMode,
+        Val(:prescribed),
+        Val(:prescribed),
+        Val(:bucket),
+    )
+    @test ocean == Val(:oceananigans)
+    @test ice == Val(:clima_seaice)
+    @test land == Val(:bucket)
+
+    ocean, ice, land = Input.validate_model_types_for_mode(
+        Interfacer.SlabplanetTerraMode,
+        Val(:nothing),
+        Val(:nothing),
+        Val(:integrated);
+        domain_type = "column",
+        scm_surface_type = "land",
+    )
+    @test ocean == Val(:nothing)
+    @test ice == Val(:nothing)
+    @test land == Val(:integrated)
+
+    ocean, ice, land = Input.validate_model_types_for_mode(
+        Interfacer.SlabplanetAquaMode,
+        Val(:slab),
+        Val(:nothing),
+        Val(:nothing);
+        domain_type = "column",
+        scm_surface_type = "ocean",
+    )
+    @test ocean == Val(:slab)
+    @test ice == Val(:nothing)
+    @test land == Val(:nothing)
+
+    # Test default scm_surface_type is "ocean"
+    ocean, ice, land = Input.validate_model_types_for_mode(
+        Interfacer.AMIPMode,
+        Val(:prescribed),
+        Val(:prescribed),
+        Val(:bucket);
+        domain_type = "column",
+    )
+    @test ocean == Val(:prescribed)
+    @test ice == Val(:nothing)
+    @test land == Val(:nothing)
+
+    ocean, ice, land = Input.validate_model_types_for_mode(
+        Interfacer.AMIPMode,
+        Val(:prescribed),
+        Val(:prescribed),
+        Val(:bucket);
+        domain_type = "column",
+        scm_surface_type = "land",
+    )
+    @test ocean == Val(:nothing)
+    @test ice == Val(:nothing)
+    @test land == Val(:bucket)
+
+    ocean, ice, land = Input.validate_model_types_for_mode(
+        Interfacer.AMIPMode,
+        Val(:prescribed),
+        Val(:prescribed),
+        Val(:bucket);
+        domain_type = "column",
+        scm_surface_type = "ocean",
+    )
+    @test ocean == Val(:prescribed)
+    @test ice == Val(:nothing)
+    @test land == Val(:nothing)
+
+    ocean, ice, land = Input.validate_model_types_for_mode(
+        Interfacer.AMIPMode,
+        Val(:prescribed),
+        Val(:prescribed),
+        Val(:bucket);
+        domain_type = "column",
+        scm_surface_type = "sea_ice",
+    )
+    @test ocean == Val(:nothing)
+    @test ice == Val(:prescribed)
+    @test land == Val(:nothing)
+
+    @test_throws "Oceananigans ocean model is not supported" Input.validate_model_types_for_mode(
+        Interfacer.CMIPMode,
+        Val(:oceananigans),
+        Val(:prescribed),
+        Val(:bucket);
+        domain_type = "column",
+        scm_surface_type = "ocean",
+    )
+
+    @test_throws "ClimaSeaIce model is not supported" Input.validate_model_types_for_mode(
+        Interfacer.CMIPMode,
+        Val(:prescribed),
+        Val(:clima_seaice),
+        Val(:bucket);
+        domain_type = "column",
+        scm_surface_type = "sea_ice",
+    )
+
+    @test_throws "Unknown scm_surface_type" Input.validate_model_types_for_mode(
+        Interfacer.SlabplanetAquaMode,
+        Val(:slab),
+        Val(:nothing),
+        Val(:nothing);
+        domain_type = "column",
+        scm_surface_type = "invalid_surface",
+    )
 end

--- a/test/models/prescr_seaice_tests.jl
+++ b/test/models/prescr_seaice_tests.jl
@@ -4,10 +4,9 @@ import NCDatasets
 import ClimaCore as CC
 import Thermodynamics.Parameters as TDP
 import ClimaParams as CP # required for TDP
-import ClimaCoupler
+import ClimaCoupler: Models, Utilities
 import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput, evaluate!
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
-import ClimaCoupler.Models
 
 for FT in (Float32, Float64)
     @testset "test sea-ice energy slab for FT=$FT" begin
@@ -71,6 +70,7 @@ for FT in (Float32, Float64)
                 thermo_params = thermo_params,
                 dt = dt,
                 binary_area_fraction = true,
+                domain_type = "global",
             )
 
             p = (; cache..., params = params)
@@ -159,9 +159,6 @@ for FT in (Float32, Float64)
             h_elem = 4,
         )
 
-        # construct dss buffer to put in cache
-        dss_buffer = CC.Spaces.create_dss_buffer(CC.Fields.zeros(boundary_space))
-
         # set up objects for test
         u = CC.Fields.FieldVector(;
             state_field1 = CC.Fields.ones(boundary_space),
@@ -169,7 +166,8 @@ for FT in (Float32, Float64)
         )
         p = (;
             cache_field = CC.Fields.zeros(boundary_space),
-            dss_buffer = CC.Spaces.create_dss_buffer(u),
+            dss_buffer = Utilities.init_dss_buffer(u),
+            domain_type = "global",
         )
         integrator = (; u, p)
         sim = Models.PrescribedIceSimulation(nothing, integrator)

--- a/test/models/slab_ocean_tests.jl
+++ b/test/models/slab_ocean_tests.jl
@@ -1,7 +1,7 @@
 import Test: @test, @testset
 import ClimaCore as CC
 import ClimaParams as CP
-import ClimaCoupler
+import ClimaCoupler: Utilities
 import SurfaceFluxes as SF
 import ClimaCoupler.Models
 
@@ -16,9 +16,6 @@ for FT in (Float32, Float64)
             h_elem = 4,
         )
 
-        # construct dss buffer to put in cache
-        dss_buffer = CC.Spaces.create_dss_buffer(CC.Fields.zeros(boundary_space))
-
         # set up objects for test
         u = CC.Fields.FieldVector(;
             state_field1 = CC.Fields.ones(boundary_space),
@@ -29,7 +26,7 @@ for FT in (Float32, Float64)
         coare3_roughness_params .= SF.COARE3RoughnessParams{FT}()
         p = (;
             cache_field = CC.Fields.zeros(boundary_space),
-            dss_buffer = CC.Spaces.create_dss_buffer(u),
+            dss_buffer = Utilities.init_dss_buffer(u),
             coare3_roughness_params,
         )
         integrator = (; u, p)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We want ClimaCoupler to be a general coupling infrastructure. Right now it has the limitation of only supporting global runs. Since each component model can run in single column mode, there isn't really anything holding us back from running coupled SCM runs.

This PR adds a couple of hacky things to get SCMs working:
- `_column_boundary_space` - needed because we can't easily construct a PointSpace that includes lat/lon using ClimaCore functions. Land model needs lat/lon for spatial inputs, and we pass the lat/lon to the atmosphere so that's in sync too
  - alternative solution: construct spaces without lat/lon, and for land use land domain functions to add in lat/lon
- dss functions (`Utilities.init_dss_buffer`, `Utilities.apply_dss!`) - dss doesn't make sense for a space without horizontal direction, so it should do nothing. However ClimaCore doesn't handle this case - instead of doing nothing, calling dss on a PointSpace or Column errors.
  - I'll fix this in ClimaCore and update ClimaCoupler after

## Content
- [x] add new input options specific to the SCM mode `domain_type`, `column_latlon`, `scm_surface_type`
- [x] add a function `create_boundary_space` which constructs the correct space based on `domain_type`
- [x] extend `remap!` for PointSpaces (no regridding)
- [x] write wrappers for dss since dss doesn't handle the PointSpace case (this should be changed in ClimaCore - we just want to do nothing in this case)
- [x] update docs (new options, example for running SCM)
- [x] add SCM tests to CI
- [x] add plots to SCM cases

## Plotting
The SCM case requires new plotting infrastructure. For depth-resolved (column) variables, line plots of the value vs depth are made (for whatever time the variable was saved at/reduced over. For 1D (scalar) variables, a plot axis is made but is left empty. The extrema are put in the plot title, which for the scalar case displays the variable's value.

For example, atmosphere debug plots:
<img width="1495" height="777" alt="Screenshot 2026-03-17 at 1 05 16 PM" src="https://github.com/user-attachments/assets/82e625f6-7f5a-4037-a625-bf1a2d7e6d37" />

coupler debug plots (intentionally blank, with extrema in the titles)
<img width="1496" height="777" alt="Screenshot 2026-03-17 at 1 05 35 PM" src="https://github.com/user-attachments/assets/e2e84686-ab3a-4d89-aa5e-d64954190e19" />


## To add in future PRs
- [ ] support Oceananigans + ClimaSeaIce in SCM runs https://github.com/CliMA/ClimaCoupler.jl/issues/1860
- [ ] update ClimaCore to handle dss of PointSpace fields - https://github.com/CliMA/ClimaCoupler.jl/issues/1859
- [ ] update plotting: make timeseries of 1D fields (scalars) if we have multiple diagnostics saved https://github.com/CliMA/ClimaCoupler.jl/issues/1862
- [ ] add a PointSpace constructor in ClimaCore that accepts lat/lon so we don't have to do gymnastics in constructing one - ?


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
