### PR TITLE
Temporarily mark MPI jobs soft-fail

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,6 +66,8 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_mem: 16GB
+          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
+        soft_fail: true # remove this after library issues are fixed
 
       - label: "MPI Interfacer unit tests"
         key: "interfacer_mpi_tests"
@@ -76,6 +78,8 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_mem: 16GB
+          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
+        soft_fail: true # remove this after library issues are fixed
 
   - group: "GPU: unit tests"
     steps:
@@ -108,6 +112,8 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_mem: 32GB
+          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
+        soft_fail: true # remove this after library issues are fixed
 
       - label: "GPU restarts (state and cache)"
         command: "julia -O0 --color=yes --project=experiments/ClimaEarth/ experiments/ClimaEarth/test/restart.jl"
@@ -217,6 +223,8 @@ steps:
         agents:
           slurm_ntasks: 4
           slurm_mem_per_cpu: 12GB
+          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
+        soft_fail: true # remove this after library issues are fixed
 
       # short high-res performance test
       - label: "Unthreaded AMIP FINE" # also reported by longruns with a flame graph


### PR DESCRIPTION
Due to the MPI trampoline [issues](https://github.com/CliMA/ClimaModules/issues/48), I split MPI out from climacommon. This PR adds MPI back in and marks relevant jobs as soft-fail 