### PR TITLE
use julia 1.11 for CI

### DIFF
--- a/.buildkite/amip/pipeline.yml
+++ b/.buildkite/amip/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 96:00:00
-  modules: climacommon/2026_02_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100

--- a/.buildkite/benchmarks/pipeline.yml
+++ b/.buildkite/benchmarks/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 24:00:00
-  modules: climacommon/2026_02_18
+  modules: climacommon/2025_05_15
 
 env:
   OPENBLAS_NUM_THREADS: 1

--- a/.buildkite/hierarchies/pipeline.yml
+++ b/.buildkite/hierarchies/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: central
   slurm_time: 24:00:00
-  modules: climacommon/2026_02_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
@@ -29,7 +29,7 @@ steps:
 
     agents:
       queue: clima
-      modules: climacommon/2026_02_18
+      modules: climacommon/2025_05_15
     env:
       JULIA_NUM_PRECOMPILE_TASKS: 8
       JULIA_MAX_NUM_PRECOMPILE_FILES: 50
@@ -51,7 +51,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2026_02_18
+          modules: climacommon/2025_05_15
 
       - label: "Clima: GPU ClimaCoupler moist HS"
         command:
@@ -63,7 +63,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2026_02_18
+          modules: climacommon/2025_05_15
 
       - label: "Clima: GPU ClimaCoupler Cloudless Aquaplanet"
         command:
@@ -75,7 +75,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2026_02_18
+          modules: climacommon/2025_05_15
 
       - label: "Clima: GPU ClimaCoupler Cloudy Aquaplanet"
         command:
@@ -87,7 +87,7 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2026_02_18
+          modules: climacommon/2025_05_15
 
       - label: "Clima: GPU ClimaCoupler Cloudy Slabplanet"
         command:
@@ -99,4 +99,4 @@ steps:
           queue: clima
           slurm_mem: 20GB
           slurm_gpus: 1
-          modules: climacommon/2026_02_18
+          modules: climacommon/2025_05_15

--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: central
   slurm_time: 30:00:00
-  modules: climacommon/2026_02_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"

--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_time: 14:00:00
-  modules: climacommon/2026_02_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_MAX_NUM_PRECOMPILE_FILES: 100

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: central
   slurm_time: 4:00:00
-  modules: climacommon/2026_02_18
+  modules: climacommon/2025_05_15
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
@@ -60,7 +60,7 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_mem: 16GB
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
+          modules: mpiwrapper/2024_05_27 climacommon/2025_05_15
         soft_fail: true # remove this after library issues are fixed
 
       - label: "MPI Interfacer unit tests"
@@ -72,7 +72,7 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_mem: 16GB
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
+          modules: mpiwrapper/2024_05_27 climacommon/2025_05_15
         soft_fail: true # remove this after library issues are fixed
 
   - group: "GPU: unit tests"
@@ -106,7 +106,7 @@ steps:
         agents:
           slurm_ntasks: 2
           slurm_mem: 32GB
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
+          modules: mpiwrapper/2024_05_27 climacommon/2025_05_15
         soft_fail: true # remove this after library issues are fixed
 
       - label: "GPU restarts (state and cache)"
@@ -217,7 +217,7 @@ steps:
         agents:
           slurm_ntasks: 4
           slurm_mem_per_cpu: 12GB
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
+          modules: mpiwrapper/2024_05_27 climacommon/2025_05_15
         soft_fail: true # remove this after library issues are fixed
 
       # short high-res performance test

--- a/test/mpi_tests/local_checks.sh
+++ b/test/mpi_tests/local_checks.sh
@@ -7,7 +7,7 @@
 
 export MODULEPATH="/resnick/groups/esm/modules:$MODULEPATH"
 module purge
-module load climacommon/2026_02_18
+module load climacommon/2025_05_15
 
 export CC_PATH=$(pwd)/ # adjust this to the path of your ClimaCoupler.jl directory
 export JOB_ID=amip_coarse_ft64_hourly_checkpoints_restart


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Revert to julia 1.11 in CI to avoid GPU errors seen on 1.12 with ClimaAtmos/CloudMicrophysics. E.g. [here](https://buildkite.com/clima/cloudmicrophysics-ci/builds/2675#019cf8d8-1f09-42e0-abb1-527882ca4732) and [here](https://buildkite.com/clima/climaatmos-ci/builds/28971#019cfcaf-e24a-4e67-a85b-dc33812affff).

Reverts #1761

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
