### PR TITLE
feat: expose DateTime clock parameter for CMIP simulations (#1819)

### DIFF
--- a/ext/ClimaCouplerCMIPExt/clima_seaice.jl
+++ b/ext/ClimaCouplerCMIPExt/clima_seaice.jl
@@ -32,6 +32,7 @@ struct ClimaSeaIceSimulation{SIM, A, REMAP, NT, IP} <: Interfacer.AbstractSeaIce
     remapping::REMAP
     ocean_ice_interface::NT
     ice_properties::IP
+    start_date::DateTime
 end
 
 """
@@ -77,7 +78,7 @@ function ClimaSeaIceSimulation(
     arch = OC.Architectures.architecture(grid)
 
     advection = ocean.ocean.model.advection.T
-    ice = sea_ice_simulation(grid, ocean.ocean; Δt = float(dt), advection)
+    ice = sea_ice_simulation(grid, ocean.ocean; Δt = float(dt), advection, start_date)
 
     ocean_ice_flux_formulation =
         CO.OceanSeaIceModels.InterfaceComputations.ThreeEquationHeatFlux(ice)
@@ -161,6 +162,7 @@ function ClimaSeaIceSimulation(
         remapping,
         ocean_ice_interface,
         ice_properties,
+        start_date,
     )
 
     # Ensure ocean temperature is above freezing where there is sea ice
@@ -172,6 +174,7 @@ function sea_ice_simulation(
     grid,
     ocean = nothing;
     Δt = 5 * 60.0, # 5 minutes
+    start_date,
     ice_salinity = 4, # psu
     advection = nothing, # for the moment
     tracers = (),
@@ -215,7 +218,7 @@ function sea_ice_simulation(
     )
 
     # Build the simulation
-    return OC.Simulation(sea_ice_model; Δt)
+    return OC.Simulation(sea_ice_model; Δt, clock = OC.Clock{DateTime}(time = start_date))
 end
 
 ###############################################################################
@@ -223,8 +226,11 @@ end
 ###############################################################################
 
 # Timestep the simulation forward to time `t`
-Interfacer.step!(sim::ClimaSeaIceSimulation, t) =
-    OC.time_step!(sim.ice, float(t) - sim.ice.model.clock.time)
+Interfacer.step!(sim::ClimaSeaIceSimulation, t) = begin
+    current_time = sim.start_date + Dates.Second(float(t))
+    Δt = current_time - sim.ice.model.clock.time
+    OC.time_step!(sim.ice, Δt)
+end
 
 Interfacer.get_field(sim::ClimaSeaIceSimulation, ::Val{:area_fraction}) = sim.area_fraction
 Interfacer.get_field(sim::ClimaSeaIceSimulation, ::Val{:ice_concentration}) =

--- a/ext/ClimaCouplerCMIPExt/oceananigans.jl
+++ b/ext/ClimaCouplerCMIPExt/oceananigans.jl
@@ -25,6 +25,7 @@ struct OceananigansSimulation{SIM, A, OPROP, REMAP, SIC} <:
     ocean_properties::OPROP
     remapping::REMAP
     ice_concentration::SIC
+    start_date::DateTime
 end
 
 """
@@ -54,6 +55,7 @@ dispatch in coupling.
 
 # Optional keyword arguments
 - `dt`: Time step (default: `nothing`)
+- `clock`: Clock object for the simulation (default: `OC.Clock{DateTime}(time = start_date)` for DateTime precision)
 - `comms_ctx`: Communication context (default: `ClimaComms.context()`)
 - `coupled_param_dict`: Coupled parameter dictionary (default: created from `area_fraction`)
 
@@ -68,6 +70,7 @@ function OceananigansSimulation(
     output_dir,
     simple_ocean = false,
     dt = nothing,
+    clock = nothing,
     comms_ctx = ClimaComms.context(),
     coupled_param_dict = CP.create_toml_dict(FT),
     extra_kwargs...,
@@ -157,6 +160,8 @@ function OceananigansSimulation(
     end
 
     Δt = isnothing(dt) ? CO.OceanSimulations.estimate_maximum_Δt(grid) : float(dt)
+    # Use provided clock or default to DateTime clock for better precision
+    sim_clock = isnothing(clock) ? OC.Clock{DateTime}(time = start_date) : clock
     ocean = CO.ocean_simulation(
         grid;
         Δt,
@@ -165,6 +170,7 @@ function OceananigansSimulation(
         tracer_advection,
         free_surface,
         closure,
+        clock = sim_clock,
     )
 
     # Set initial condition to EN4 state estimate at start_date
@@ -287,6 +293,7 @@ function OceananigansSimulation(
         ocean_properties,
         remapping,
         ice_concentration,
+        start_date,
     )
 end
 
@@ -336,8 +343,11 @@ end
 ###############################################################################
 
 # Timestep the simulation forward to time `t`
-Interfacer.step!(sim::OceananigansSimulation, t) =
-    OC.time_step!(sim.ocean, float(t) - sim.ocean.model.clock.time)
+Interfacer.step!(sim::OceananigansSimulation, t) = begin
+    current_time = sim.start_date + Dates.Second(float(t))
+    Δt = current_time - sim.ocean.model.clock.time
+    OC.time_step!(sim.ocean, Δt)
+end
 
 Interfacer.get_field(sim::OceananigansSimulation, ::Val{:area_fraction}) = sim.area_fraction
 


### PR DESCRIPTION
## Purpose 
Replace the default Float64-based clock with a DateTime-based clock in ocean and sea ice simulations to improve temporal precision for CMIP runs.  
Closes #1819


## To-do
- [x] Add DateTime-based clock support to ocean and sea ice simulations  
- [x] Update time-stepping logic to use DateTime arithmetic  
- [x] Update docstrings  
- [x] Run tests and formatting checks  


## Content
- Added `start_date::DateTime` to:
  - `OceananigansSimulation`
  - `ClimaSeaIceSimulation`

- Updated constructors to initialize clocks using:
  `OC.Clock{DateTime}(time = start_date)`

- Replaced Float64-based time stepping with DateTime-based Δt computation in:
  - `Interfacer.step!` for ocean
  - `Interfacer.step!` for sea ice

- Ensured consistent use of DateTime clocks across both components


## Testing
- Ran test suite using:
  `julia --project -e 'using Pkg; Pkg.test()'`

- Verified:
  - Simulations initialize with `OC.Clock{DateTime}`
  - Time stepping behaves correctly

- Code formatted using JuliaFormatter

----
- [x] I have read and checked the items on the review checklist.


Snapshots of Test passed 
---

<img width="790" height="127" alt="Screenshot 2026-03-24 at 1 27 34 AM" src="https://github.com/user-attachments/assets/48687784-778b-4cb2-9564-309dee1786a3" />

