### PR TITLE
fix filenames and dts for longruns

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -156,7 +156,7 @@ steps:
       - label: "GPU AMIP + prog. EDMF + 1M + integrated land"
         key: "amip_progedmf_1m_land"
         command:
-          - "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/run_amip.jl --config_file $CONFIG_PATH/amip_progedmf_1m_land.yml --job_id amip_progedmf_1m_land"
+          - "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/amip_progedmf_1m_land.yml --job_id amip_progedmf_1m_land"
         artifact_paths: "output/amip_progedmf_1m_land/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -174,7 +174,7 @@ steps:
       - label: "GPU CMIP: ED only + bucket"
         key: "cmip_edonly_bucket"
         command:
-            - "julia --color=yes --project=experiments/CMIP experiments/CMIP/run_amip.jl --config_file $CONFIG_PATH/cmip_edonly_bucket.yml --job_id cmip_edonly_bucket"
+            - "julia --color=yes --project=experiments/CMIP experiments/CMIP/run_simulation.jl --config_file $CONFIG_PATH/cmip_edonly_bucket.yml --job_id cmip_edonly_bucket"
         artifact_paths: "output/cmip_edonly_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -198,7 +198,7 @@ steps:
       - label: "GPU CMIP: diag. EDMF + integrated land"
         key: "cmip_diagedmf_land"
         command:
-            - "julia --color=yes --project=experiments/CMIP experiments/CMIP/run_amip.jl --config_file $CONFIG_PATH/cmip_diagedmf_land.yml --job_id cmip_diagedmf_land"
+            - "julia --color=yes --project=experiments/CMIP experiments/CMIP/run_simulation.jl --config_file $CONFIG_PATH/cmip_diagedmf_land.yml --job_id cmip_diagedmf_land"
         artifact_paths: "output/cmip_diagedmf_land/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
@@ -210,7 +210,7 @@ steps:
       - label: "GPU CMIP: prog. EDMF + integrated land"
         key: "cmip_progedmf_land"
         command:
-            - "julia --color=yes --project=experiments/CMIP experiments/CMIP/run_amip.jl --config_file $CONFIG_PATH/cmip_progedmf_land.yml --job_id cmip_progedmf_land"
+            - "julia --color=yes --project=experiments/CMIP experiments/CMIP/run_simulation.jl --config_file $CONFIG_PATH/cmip_progedmf_land.yml --job_id cmip_progedmf_land"
         artifact_paths: "output/cmip_progedmf_land/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Note: If you want to set the configuration file to something other than the defa
 while running the driver interactively, you'll need to
 manually set the value for `config_file`.
 
-For example, to use the configuration file found at `config/ci_configs/amip_default.yml`, you would set `config_file` as follows in the `run_amip` driver:
+For example, to use the configuration file found at `config/ci_configs/amip_default.yml`, you would set `config_file`
+as follows in the `run_simulation.jl` driver:
 ```
 config_file = "config/ci_configs/amip_default.yml"
 ```

--- a/config/longrun_configs/cmip_diagedmf_land.yml
+++ b/config/longrun_configs/cmip_diagedmf_land.yml
@@ -5,7 +5,7 @@ checkpoint_dt: "1months"
 coupler_toml: ["toml/amip_diagedmf.toml"]
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "120secs" # 2 minutes
+dt_cpl: "1800secs" # 30 minutes
 dt_land: "120secs" # 2 minutes
 dt_ocean: "1800secs" # 30 minutes
 dt_rad: "1hours"

--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -4,7 +4,7 @@ bucket_albedo_type: "map_temporal"
 checkpoint_dt: "1months"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "120secs" # 2 minutes
+dt_cpl: "1800secs" # 30 minutes
 dt_land: "120secs" # 2 minutes
 dt_ocean: "1800secs" # 30 minutes
 dt_rad: "1hours"

--- a/config/longrun_configs/cmip_edonly_land.yml
+++ b/config/longrun_configs/cmip_edonly_land.yml
@@ -3,7 +3,7 @@ atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 checkpoint_dt: "1months"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "120secs" # 2 minutes
+dt_cpl: "1800secs" # 30 minutes
 dt_land: "120secs" # 2 minutes
 dt_ocean: "1800secs" # 30 minutes
 dt_rad: "1hours"

--- a/config/longrun_configs/cmip_progedmf_land.yml
+++ b/config/longrun_configs/cmip_progedmf_land.yml
@@ -5,7 +5,7 @@ checkpoint_dt: "1months"
 coupler_toml: ["toml/amip_progedmf.toml"]
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "120secs" # 2 minutes
+dt_cpl: "1800secs" # 30 minutes
 dt_land: "120secs" # 2 minutes
 dt_ocean: "1800secs" # 30 minutes
 dt_rad: "1hours"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Fixes failures from the [most recent longruns](https://buildkite.com/clima/climacoupler-longruns/builds/1074#_)

After approval I'll merge without CI since this only affects longruns.

## Content
- [x] replace `run_amip.jl` --> `run_simulation.jl`
- [x] make coupler dt the max of all component dts (currently working on resolving this limitation)