### PR TITLE
Enable GPU outputs for OC > 0.96.22

### DIFF
--- a/ext/ClimaCouplerCMIPExt/clima_seaice.jl
+++ b/ext/ClimaCouplerCMIPExt/clima_seaice.jl
@@ -111,14 +111,14 @@ function ClimaSeaIceSimulation(
     remapping = ocean.remapping
 
     # Before version 0.96.22, the NetCDFWriter was broken on GPU
-    if arch isa OC.CPU
+    if (arch isa OC.CPU) || (pkgversion(OC) > v"0.96.22")
         # Save all tracers and velocities to a NetCDF file at daily frequency
         outputs = OC.prognostic_fields(ice.model)
-        jld_writer = OC.JLD2Writer(
+        jld_writer = OC.NetCDFWriter(
             ice.model,
             outputs;
             schedule = OC.TimeInterval(86400), # Daily output
-            filename = joinpath(output_dir, "seaice_diagnostics.jld2"),
+            filename = joinpath(output_dir, "seaice_diagnostics.nc"),
             overwrite_existing = true,
             array_type = Array{FT},
         )

--- a/ext/ClimaCouplerCMIPExt/oceananigans.jl
+++ b/ext/ClimaCouplerCMIPExt/oceananigans.jl
@@ -236,7 +236,7 @@ function OceananigansSimulation(
     )
 
     # Before version 0.96.22, the NetCDFWriter was broken on GPU
-    if arch isa OC.CPU
+    if (arch isa OC.CPU) || (pkgversion(OC) > v"0.96.22")
         # Save all tracers and velocities to a NetCDF file at daily frequency
         outputs = merge(ocean.model.tracers, ocean.model.velocities)
         surface_writer = OC.NetCDFWriter(


### PR DESCRIPTION
If we have OC > 0.96.22 we can use NetCDFWriter also from the GPU.
Also, sea ice should use the same writer as the ocean

cc @jm-c 