### PR TITLE
allow sea ice dynamics to be off; plot u and v

### DIFF
--- a/ext/ClimaCouplerCMIPExt/clima_seaice.jl
+++ b/ext/ClimaCouplerCMIPExt/clima_seaice.jl
@@ -386,39 +386,42 @@ function FluxCalculator.update_turbulent_fluxes!(sim::ClimaSeaIceSimulation, fie
     grid = sim.ice.model.grid
     ice_concentration = sim.ice.model.ice_concentration
 
-    # Convert the momentum fluxes from contravariant to Cartesian basis
-    contravariant_to_cartesian!(sim.remapping.temp_uv_vec, F_turb_ρτxz, F_turb_ρτyz)
-    F_turb_ρτxz_uv = sim.remapping.temp_uv_vec.components.data.:1
-    F_turb_ρτyz_uv = sim.remapping.temp_uv_vec.components.data.:2
+    # We only need to provide momentum fluxes if the sea ice model has dynamics
+    if !isnothing(sim.ice.model.dynamics)
+        # Convert the momentum fluxes from contravariant to Cartesian basis
+        contravariant_to_cartesian!(sim.remapping.temp_uv_vec, F_turb_ρτxz, F_turb_ρτyz)
+        F_turb_ρτxz_uv = sim.remapping.temp_uv_vec.components.data.:1
+        F_turb_ρτyz_uv = sim.remapping.temp_uv_vec.components.data.:2
 
-    # Remap momentum fluxes onto reduced 2D Center, Center fields using scratch arrays and fields
-    CC.Remapping.interpolate!(
-        sim.remapping.scratch_arr1,
-        sim.remapping.remapper_cc,
-        F_turb_ρτxz_uv,
-    )
-    OC.set!(sim.remapping.scratch_cc1, sim.remapping.scratch_arr1) # zonal momentum flux
-    CC.Remapping.interpolate!(
-        sim.remapping.scratch_arr2,
-        sim.remapping.remapper_cc,
-        F_turb_ρτyz_uv,
-    )
-    OC.set!(sim.remapping.scratch_cc2, sim.remapping.scratch_arr2) # meridional momentum flux
+        # Remap momentum fluxes onto reduced 2D Center, Center fields using scratch arrays and fields
+        CC.Remapping.interpolate!(
+            sim.remapping.scratch_arr1,
+            sim.remapping.remapper_cc,
+            F_turb_ρτxz_uv,
+        )
+        OC.set!(sim.remapping.scratch_cc1, sim.remapping.scratch_arr1) # zonal momentum flux
+        CC.Remapping.interpolate!(
+            sim.remapping.scratch_arr2,
+            sim.remapping.remapper_cc,
+            F_turb_ρτyz_uv,
+        )
+        OC.set!(sim.remapping.scratch_cc2, sim.remapping.scratch_arr2) # meridional momentum flux
 
-    # Rename for clarity; these are now Center, Center Oceananigans fields
-    F_turb_ρτxz_cell = sim.remapping.scratch_cc1
-    F_turb_ρτyz_cell = sim.remapping.scratch_cc2
+        # Rename for clarity; these are now Center, Center Oceananigans fields
+        F_turb_ρτxz_cell = sim.remapping.scratch_cc1
+        F_turb_ρτyz_cell = sim.remapping.scratch_cc2
 
-    # Set the momentum flux BCs at the correct locations using the remapped scratch fields
-    # Note that this requires the sea ice model to always be run with dynamics turned on
-    si_flux_u = sim.ice.model.dynamics.external_momentum_stresses.top.u
-    si_flux_v = sim.ice.model.dynamics.external_momentum_stresses.top.v
-    set_from_extrinsic_vector!(
-        (; u = si_flux_u, v = si_flux_v),
-        grid,
-        F_turb_ρτxz_cell,
-        F_turb_ρτyz_cell,
-    )
+        # Set the momentum flux BCs at the correct locations using the remapped scratch fields
+        # Note that this requires the sea ice model to always be run with dynamics turned on
+        si_flux_u = sim.ice.model.dynamics.external_momentum_stresses.top.u
+        si_flux_v = sim.ice.model.dynamics.external_momentum_stresses.top.v
+        set_from_extrinsic_vector!(
+            (; u = si_flux_u, v = si_flux_v),
+            grid,
+            F_turb_ρτxz_cell,
+            F_turb_ρτyz_cell,
+        )
+    end
 
     # Remap the latent and sensible heat fluxes using scratch arrays
     CC.Remapping.interpolate!(sim.remapping.scratch_arr1, sim.remapping.remapper_cc, F_lh) # latent heat flux
@@ -643,12 +646,19 @@ function Checkpointer.get_model_prog_state(sim::ClimaSeaIceSimulation)
     @warn "get_model_prog_state not implemented for ClimaSeaIceSimulation"
 end
 
+# Additional ClimaSeaIceSimulation getter methods for plotting debug fields
+Interfacer.get_field(sim::ClimaSeaIceSimulation, ::Val{:u}) = sim.ice.model.velocities.u
+Interfacer.get_field(sim::ClimaSeaIceSimulation, ::Val{:v}) = sim.ice.model.velocities.v
+
 """
     Plotting.debug_plot_fields(sim::ClimaSeaIceSimulation)
 
 Return the fields to include in debug plots for a ClimaSeaIce simulation.
-This includes the area fraction, surface temperature, ice concentration, and ice thickness.
+This includes the area fraction, surface temperature, ice concentration, ice thickness, and
+zonal and meridional velocity fields. Note that if the sea ice model does not have dynamics,
+the velocity fields will be zero.
+
 These plots are not polished, and are intended for debugging.
 """
 Plotting.debug_plot_fields(sim::ClimaSeaIceSimulation) =
-    (:area_fraction, :surface_temperature, :ice_concentration, :ice_thickness)
+    (:area_fraction, :surface_temperature, :ice_concentration, :ice_thickness, :u, :v)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR does 2 things:
- correctly handle the case where ClimaSeaIce dynamics is turned off
- plot u and v in the debug plots (they'll just be zero is dynamics is off)

Closes #1830
