### PR TITLE
longrun improvements

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -139,11 +139,11 @@ steps:
           slurm_ntasks: 1
           slurm_mem: 32GB
 
-      - label: "GPU AMIP + prog. EDMF + bucket"
-        key: "amip_progedmf"
+      - label: "GPU AMIP + prog. EDMF + integrated land"
+        key: "amip_progedmf_land"
         command:
-          - "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/amip_progedmf.yml --job_id amip_progedmf"
-        artifact_paths: "output/amip_progedmf/artifacts/*"
+          - "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/amip_progedmf_land.yml --job_id amip_progedmf_land"
+        artifact_paths: "output/amip_progedmf_land/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"
         agents:

--- a/config/longrun_configs/amip_diagedmf_1m_land.yml
+++ b/config/longrun_configs/amip_diagedmf_1m_land.yml
@@ -15,6 +15,7 @@ extra_atmos_diagnostics:
     reduction_time: average
     pressure_coordinates: true
     compute_every: 6hours
+implicit_microphysics: false
 initial_condition: "AMIPFromERA5"
 land_model: "integrated"
 mode_name: "amip"

--- a/config/longrun_configs/amip_progedmf_1m_land.yml
+++ b/config/longrun_configs/amip_progedmf_1m_land.yml
@@ -1,7 +1,6 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_progedmf.yml"
-bucket_albedo_type: "map_temporal"
 checkpoint_dt: "1months"
 coupler_toml: ["toml/amip_progedmf_1m.toml"]
 dt: "120secs"
@@ -13,6 +12,7 @@ extra_atmos_diagnostics:
     reduction_time: average
     pressure_coordinates: true
     compute_every: 6hours
+implicit_microphysics: false
 land_model: "integrated"
 microphysics_model: "1M"
 mode_name: "amip"

--- a/config/longrun_configs/amip_progedmf_land.yml
+++ b/config/longrun_configs/amip_progedmf_land.yml
@@ -1,7 +1,6 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_progedmf.yml"
-bucket_albedo_type: "map_temporal"
 checkpoint_dt: "1months"
 coupler_toml: ["toml/amip_progedmf.toml"]
 dt: "120secs"
@@ -13,6 +12,7 @@ extra_atmos_diagnostics:
     reduction_time: average
     pressure_coordinates: true
     compute_every: 6hours
+land_model: "integrated"
 mode_name: "amip"
 netcdf_output_at_levels: true
 ode_algo: "ARS222"

--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -23,6 +23,6 @@ ocean_model: "oceananigans"
 rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "186days"
+t_end: "366days"
 topo_smoothing: true
 topography: "Earth"

--- a/config/longrun_configs/cmip_edonly_land.yml
+++ b/config/longrun_configs/cmip_edonly_land.yml
@@ -24,6 +24,6 @@ ocean_model: "oceananigans"
 rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "186days"
+t_end: "366days"
 topo_smoothing: true
 topography: "Earth"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Makes some improvements to the longruns based on the results of [this week's runs](https://buildkite.com/clima/climacoupler-longruns/builds/1076).

After approval I'll merge this without waiting for CI because it changes only longruns.

## Content
- extends CMIP longruns from 6 months to 1 year of runtime
  - these runs are both stable for at least a year now, so it makes sense to run them for longer
- add an AMIP + prog EDMF + integrated land run, and remove AMIP + prog EDMF + bucket
  - AMIP + prog EDMF is stable at 6 months with the bucket, but fails after ~2 weeks with CMIP + integrated land. I want to add in the AMIP + integrated land case to better understand what causes the failure
- add `implicit_microphysics: false` to 1M jobs

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
