### PR TITLE
Fix typo in documentation for SurfaceFluxes.jl

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@ Key functionality of ClimaCoupler.jl includes:
 - **Time stepping**: Coupled system time stepping control allowing for component models to use
   various timesteps individually.
 - **Flux calculation**: Flux calculation between the atmosphere and each surface models
-  utilizing SurfaceFluxees.jl.
+  utilizing SurfaceFluxes.jl.
 - **Information exchange**: A generic interface to retrieve information from component models that is
   needed to compute surface fluxes, and to update component models with the
   resulting fluxes.


### PR DESCRIPTION
SurfaceFluxees.jl --> SurfaceFluxes.jl

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
