### PR TITLE
use start_date instead of reference_date

### DIFF
--- a/src/Models/prescr_ocean.jl
+++ b/src/Models/prescr_ocean.jl
@@ -117,8 +117,8 @@ function PrescribedOceanSimulation(
     SST_timevaryinginput = TimeVaryingInput(
         sst_data,
         "SST",
-        boundary_space,
-        reference_date = start_date,
+        boundary_space;
+        start_date,
         file_reader_kwargs = (;
             preprocess_func = (data) -> data + C_to_K + sst_adjustment,
         ), ## convert Celsius to Kelvin and apply adjustment

--- a/src/Models/prescr_seaice.jl
+++ b/src/Models/prescr_seaice.jl
@@ -135,8 +135,7 @@ function slab_ice_space_init(
 
     if has_ISTL1
         # Use ERA5 ISTL1 (0-7cm, near-surface layer) as a proxy for surface temperature
-        ISTL1_input =
-            TimeVaryingInput(sic_data, "ISTL1", space; reference_date = start_date)
+        ISTL1_input = TimeVaryingInput(sic_data, "ISTL1", space; start_date)
         T_sfc_data = CC.Fields.zeros(space)
         evaluate!(T_sfc_data, ISTL1_input, t_start)
 
@@ -249,8 +248,8 @@ function PrescribedIceSimulation(
     SIC_timevaryinginput = TimeVaryingInput(
         sic_data,
         "SEAICE",
-        boundary_space,
-        reference_date = start_date,
+        boundary_space;
+        start_date,
         file_reader_kwargs = (; preprocess_func = (data) -> data / 100,), ## convert to fraction
     )
 

--- a/test/models/prescr_ocean_tests.jl
+++ b/test/models/prescr_ocean_tests.jl
@@ -61,8 +61,8 @@ end
     SST_timevaryinginput = TimeVaryingInput(
         sst_data,
         "SST",
-        space,
-        reference_date = start_date,
+        space;
+        start_date,
         file_reader_kwargs = (; preprocess_func = (data) -> data + C_to_K,), ## convert Celsius to Kelvin
     )
     SST_expected = zeros(space)

--- a/test/models/prescr_seaice_tests.jl
+++ b/test/models/prescr_seaice_tests.jl
@@ -54,7 +54,7 @@ for FT in (Float32, Float64)
                 sic_data,
                 "SEAICE",
                 space,
-                reference_date = Dates.DateTime("20100101", Dates.dateformat"yyyymmdd"),
+                start_date = Dates.DateTime("20100101", Dates.dateformat"yyyymmdd"),
                 file_reader_kwargs = (; preprocess_func = (data) -> data / 100,), ## convert to fraction
             )
             # Get initial SIC values and use them to calculate ice fraction


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
To remove deprecated kwarg warnings from test logs.

Closes #1861 

Tests on main with warnings - [here](https://github.com/CliMA/ClimaCoupler.jl/actions/runs/23918486796/job/69758454698)
Tests on this branch without warnings - [here](https://github.com/CliMA/ClimaCoupler.jl/actions/runs/23963339120/job/69897969521?pr=1863)


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
