### PR TITLE
Add separate AMIP calibration config files

### DIFF
--- a/experiments/calibration/amip/config/pipeline_test.jl
+++ b/experiments/calibration/amip/config/pipeline_test.jl
@@ -1,0 +1,54 @@
+# To test a calibration, set `export TEST_CALIBRATION=` in the terminal or
+# `ENV["TEST_CALIBRATION"]=""` in the REPL. A test calibration differs from a
+# full calibration in three ways: it runs for only a single iteration, uses only
+# one prior, and emulates the production of the diagnostics. The diagnostics
+# produced will have the correct metadata, but the values may be nonsensical.
+
+# For the test calibration, we only care whether a single iteration can be
+# completed. Since each iteration follows the same structure, successfully
+# completing one iteration will catch most errors with the full calibration
+# pipeline
+
+# Define which coupler config to use
+config_file =
+    joinpath(pkgdir(ClimaCoupler), "config", "amip_configs", "amip_calibration.yml")
+
+# Calibrate only on Jan 1 2010
+sample_date_ranges =
+    [(Dates.DateTime(2010, 10, 1), Dates.DateTime(2010, 10, 1)) for _ in 1:6]
+
+# On Derecho, it is preferable to save the calibration output to the scratch
+# directory (e.g. "/glade/derecho/scratch")
+output_dir = joinpath(pkgdir(ClimaCoupler), "amip_calibration")
+
+# spinup and sample_date_ranges are chosen to match the only dates
+# available in the wxquest_initial_conditions artifact
+const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
+    config_file,
+    # Note: Pressure-level variables require model output with
+    # pressure_coordinates: true in config
+    short_names = ["ta", "hur"],
+    minibatch_size = 1,
+    n_iterations = 1,
+    sample_date_ranges = [
+        (Dates.DateTime(2010, 10, 1), Dates.DateTime(2010, 10, 1)) for _ in 1:6
+    ],
+    extend = Dates.Month(1),
+    spinup = Dates.Day(0),
+    output_dir,
+    rng_seed = 42,
+)
+
+# Used in generate_observations.jl and observation_map.jl
+# Units: Pa (not hPa)
+const PRESSURE_LEVELS = 100.0 .* [200.0, 500.0, 850.0]
+
+# To disable normalization, update generate_observations.jl to not apply the
+# normalization. You may want to do the same in the observation map as well.
+const NORMALIZATION_STATS_FP =
+    joinpath(CALIBRATE_CONFIG.output_dir, "normalization_stats.jld2")
+
+const CALIBRATION_PRIORS =
+    [PD.constrained_gaussian("precipitation_timescale", 1200, 300, 300, 2400)]
+
+const PRIORS = EKP.combine_distributions(CALIBRATION_PRIORS)

--- a/experiments/calibration/amip/config/pressure_levels.jl
+++ b/experiments/calibration/amip/config/pressure_levels.jl
@@ -1,0 +1,44 @@
+# Define which coupler file to use
+config_file =
+    joinpath(pkgdir(ClimaCoupler), "config", "amip_configs", "amip_calibration.yml")
+
+# Calibrate only on Jan 1 2010
+sample_date_ranges =
+    [(Dates.DateTime(2010, 10, 1), Dates.DateTime(2010, 10, 1)) for _ in 1:6]
+
+# On Derecho, it is preferable to save the calibration output to the scratch
+# directory (e.g. "/glade/derecho/scratch")
+output_dir = joinpath(pkgdir(ClimaCoupler), "amip_calibration")
+
+const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
+    config_file,
+    # Note: Pressure-level variables require model output with
+    # pressure_coordinates: true in config
+    short_names = ["ta", "hur"],
+    minibatch_size = 1,
+    n_iterations = 6,
+    sample_date_ranges,
+    extend = Dates.Month(1),
+    spinup = Dates.Day(7),
+    output_dir,
+    rng_seed = 42,
+)
+
+# Used in generate_observations.jl and observation_map.jl
+# Units: Pa (not hPa)
+const PRESSURE_LEVELS = 100.0 .* [200.0, 500.0, 850.0]
+
+# To disable normalization, update generate_observations.jl to not apply the
+# normalization. You may want to do the same in the observation map as well.
+const NORMALIZATION_STATS_FP =
+    joinpath(CALIBRATE_CONFIG.output_dir, "normalization_stats.jld2")
+
+const CALIBRATION_PRIORS = [
+    PD.constrained_gaussian("precipitation_timescale", 1200, 300, 300, 2400),
+    PD.constrained_gaussian("Tq_correlation_coefficient", 0.4, 0.4, -1.0, 1.0),
+    PD.constrained_gaussian("mixing_length_eddy_viscosity_coefficient", 0.2, 0.1, 0, 1.0),
+    PD.constrained_gaussian("mixing_length_diss_coeff", 0.22, 0.15, 0.0, 10.0),
+    PD.constrained_gaussian("mixing_length_tke_surf_flux_coeff", 8.0, 4.0, 0, 100.0),
+]
+
+const PRIORS = EKP.combine_distributions(CALIBRATION_PRIORS)

--- a/experiments/calibration/amip/run_calibration.jl
+++ b/experiments/calibration/amip/run_calibration.jl
@@ -28,82 +28,20 @@ model_interface = joinpath(
     "model_interface.jl",
 )
 
-# CALIBRATION CONFIGURATION
+# Choose which calibration config to use
+config_path = joinpath(pkgdir(ClimaCoupler), "experiments", "calibration", "amip", "config")
+calibration_config_path = joinpath(config_path, "pressure_levels.jl")
 
-# To test a calibration, set `export TEST_CALIBRATION=` in the terminal or
-# `ENV["TEST_CALIBRATION"]=""` in the REPL. A test calibration differs from a
-# full calibration in three ways: it runs for only a single iteration, uses only
-# one prior, and emulates the production of the diagnostics. The diagnostics
-# produced will have the correct metadata, but the values may be nonsensical.
+test_calibration_config_path = joinpath(config_path, "pipeline_test.jl")
 const TEST_CALIBRATION = haskey(ENV, "TEST_CALIBRATION")
 
-config_file =
-    joinpath(pkgdir(ClimaCoupler), "config", "amip_configs", "amip_calibration.yml")
+config_path = TEST_CALIBRATION ? test_calibration_config_path : calibration_config_path
 
-# Calibrate only on Jan 1 2010
-sample_date_ranges =
-    [(Dates.DateTime(2010, 10, 1), Dates.DateTime(2010, 10, 1)) for _ in 1:6]
+@info "Using calibration configuration in: $config_path"
+include(config_path)
 
-# On Derecho, it is preferable to save the calibration output to the scratch
-# directory (e.g. "/glade/derecho/scratch")
-output_dir = joinpath(pkgdir(ClimaCoupler), "amip_calibration")
+(; output_dir) = CALIBRATE_CONFIG
 isdir(output_dir) || mkdir(output_dir)
-
-n_iterations = 6
-spinup = Dates.Day(7)
-
-# For the test calibration, we only care whether a single iteration can be
-# completed. Since each iteration follows the same structure, successfully
-# completing one iteration will catch most errors with the full calibration
-# pipeline
-if TEST_CALIBRATION
-    n_iterations = 1
-    # spinup and sample_date_ranges are chosen to match the only dates
-    # available in the wxquest_initial_conditions artifact
-    spinup = Dates.Day(0)
-    sample_date_ranges =
-        [(Dates.DateTime(2010, 10, 1), Dates.DateTime(2010, 10, 1)) for _ in 1:6]
-end
-
-const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
-    config_file,
-    # Note: Pressure-level variables require model output with
-    # pressure_coordinates: true in config
-    short_names = ["ta", "hur"],
-    minibatch_size = 1,
-    n_iterations,
-    sample_date_ranges,
-    extend = Dates.Month(1),
-    spinup,
-    output_dir,
-    rng_seed = 42,
-)
-
-# Used in generate_observations.jl and observation_map.jl
-# Units: Pa (not hPa)
-const PRESSURE_LEVELS = 100.0 .* [200.0, 500.0, 850.0]
-
-# To disable normalization, update generate_observations.jl to not apply the
-# normalization. You may want to do the same in the observation map as well.
-const NORMALIZATION_STATS_FP =
-    joinpath(CALIBRATE_CONFIG.output_dir, "normalization_stats.jld2")
-
-const CALIBRATION_PRIORS = [
-    PD.constrained_gaussian("precipitation_timescale", 1200, 300, 300, 2400),
-    PD.constrained_gaussian("Tq_correlation_coefficient", 0.4, 0.4, -1.0, 1.0),
-    PD.constrained_gaussian("mixing_length_eddy_viscosity_coefficient", 0.2, 0.1, 0, 1.0),
-    PD.constrained_gaussian("mixing_length_diss_coeff", 0.22, 0.15, 0.0, 10.0),
-    PD.constrained_gaussian("mixing_length_tke_surf_flux_coeff", 8.0, 4.0, 0, 100.0),
-]
-
-if TEST_CALIBRATION
-    # For testing a calibration, the number of priors should be small to
-    # minimize the number of ensemble members.
-    resize!(CALIBRATION_PRIORS, 1)
-end
-
-const PRIORS = EKP.combine_distributions(CALIBRATION_PRIORS)
-
 
 # Commit type piracy to overwrite module_load_string because an old version of
 # climacommon is being used


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaCoupler.jl/issues/1874

This PR adds configuration files for calibration instead of relying a single configuration that user would need to change when they run a calibration. Before this change, there was only one calibration configuration and conditionals to update the calibration configuration if it was to be used for testing. This PR updates this by using a conditional to include the appropriate calibration configuration and removing the in-place changes to the calibration config if it is a test calibration.