### PR TITLE
Fix command to run simulation in README

### DIFF
--- a/experiments/AMIP/README.md
+++ b/experiments/AMIP/README.md
@@ -8,7 +8,7 @@ ClimaSeaIce, KernelAbstractions). For CMIP, see `experiments/CMIP/`.
 ## Running
 
 ```bash
-julia --project=experiments/AMIP experiments/AMIP/run_simulation.jl
+julia --project=experiments/AMIP/run_simulation.jl
 ```
 
 To run with a specific configuration file:


### PR DESCRIPTION
Update path to `AMIP/run_simulation.jl` shown in AMIP README.md.