### PR TITLE
Add time incrementing test

### DIFF
--- a/experiments/test/runtests.jl
+++ b/experiments/test/runtests.jl
@@ -20,3 +20,6 @@ end
 @safetestset "AMIP test" begin
     include("amip_test.jl")
 end
+@safetestset "time incrementing test" begin
+    include("time_increment_test.jl")
+end

--- a/experiments/test/time_increment_test.jl
+++ b/experiments/test/time_increment_test.jl
@@ -1,0 +1,36 @@
+using Test
+using ClimaCoupler
+import ClimaAtmos
+ClimaAtmosExt = Base.get_extension(ClimaCoupler, :ClimaCouplerClimaAtmosExt)
+
+@testset "Float64 time" begin
+    FT = Float64
+    t = FT(10^17)
+    smallest_dt = FT(60)
+    # use a fake sim and integrator because their functionality is not needed in this test
+    struct FakeIntegrator{FT}
+        dt::FT
+        t::Ref{FT}
+    end
+    Base.getproperty(integrator::FakeIntegrator, s::Symbol) =
+        s == :t ? getfield(integrator, s)[] : getfield(integrator, s)
+    fake_sim = ClimaAtmosExt.ClimaAtmosSimulation(
+        nothing,
+        nothing,
+        FakeIntegrator(6 * smallest_dt, Ref(t)),
+        nothing,
+    )
+    function ClimaCoupler.Interfacer.step!(sim::FakeIntegrator, _, _)
+        getfield(sim, :t)[] = t
+        return
+    end
+    for i in 1:(10^5)
+        t += smallest_dt
+        ClimaCoupler.Interfacer.step!(fake_sim, t)
+        if i % 6 == 0
+            @test fake_sim.integrator.t == t
+        else
+            @test fake_sim.integrator.t < t
+        end
+    end
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add a test for Float64 time at high values. 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
Uses a fake integrator, and starts with t = 10^17. Then it steps many times, and checks that the fake integrator is being stepped as expected.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
