### PR TITLE
Add area fracs to coupler fields diags

### DIFF
--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -82,30 +82,33 @@ to update the coupler fields from the component model that computes the field.
 The default coupler exchange fields are the following, defined in
 `default_coupler_fields()` in the Interfacer module:
 
-| Coupler name      | Description                                                 | Units      |
-|-------------------|-------------------------------------------------------------|------------|
-| `T_atmos`         | atmosphere temperature at the bottom layer                  | K          |
-| `q_tot_atmos`     | atmosphere total humidity at the bottom layer               | kg kg⁻¹    |
-| `q_liq_atmos`     | atmosphere liquid humidity at the bottom layer              | kg kg⁻¹    |
-| `q_ice_atmos`     | atmosphere ice humidity at the bottom layer                 | kg kg⁻¹    |
-| `ρ_atmos`         | atmosphere air density at the bottom layer                  | kg m⁻³     |
-| `height_int`      | height at the bottom cell center of the atmosphere space    | m          |
-| `height_sfc`      | height at the bottom face of the atmosphere space           | m          |
-| `F_lh`            | latent heat flux                                            | W m⁻²      |
-| `F_sh`            | sensible heat flux                                          | W m⁻²      |
-| `F_turb_moisture` | turbulent moisture flux                                     | kg m⁻² s⁻¹ |
-| `F_turb_ρτxz`     | turbulent momentum flux in the zonal direction              | kg m⁻¹ s⁻² |
-| `F_turb_ρτyz`     | turbulent momentum flux in the meridional direction         | kg m⁻¹ s⁻² |
-| `SW_d`            | downward SW flux at the surface                             | W m⁻²      |
-| `LW_d`            | downward LW flux at the surface                             | W m⁻²      |
-| `emissivity`      | surface emissivity                                          | -          |
-| `T_sfc`           | surface temperature, averaged across components             | K          |
-| `P_liq`           | liquid precipitation                                        | kg m⁻² s⁻¹ |
-| `P_snow`          | snow precipitation                                          | kg m⁻² s⁻¹ |
-| `scalar_temp1`    | a surface scalar field used for intermediate calculations   | -          |
-| `scalar_temp2`    | a surface scalar field used for intermediate calculations   | -          |
-| `scalar_temp3`    | a surface scalar field used for intermediate calculations   | -          |
-| `scalar_temp4`    | a surface scalar field used for intermediate calculations   | -          |
+| Coupler name          | Description                                                 | Units      |
+|-----------------------|-------------------------------------------------------------|------------|
+| `land_area_fraction`  | area fraction of the land model                             | -          |
+| `ocean_area_fraction` | area fraction of the ocean model                            | -          |
+| `ice_area_fraction`   | area fraction of the sea-ice model                          | -          |
+| `T_atmos`             | atmosphere temperature at the bottom layer                  | K          |
+| `q_tot_atmos`         | atmosphere total humidity at the bottom layer               | kg kg⁻¹    |
+| `q_liq_atmos`         | atmosphere liquid humidity at the bottom layer              | kg kg⁻¹    |
+| `q_ice_atmos`         | atmosphere ice humidity at the bottom layer                 | kg kg⁻¹    |
+| `ρ_atmos`             | atmosphere air density at the bottom layer                  | kg m⁻³     |
+| `height_int`          | height at the bottom cell center of the atmosphere space    | m          |
+| `height_sfc`          | height at the bottom face of the atmosphere space           | m          |
+| `F_lh`                | latent heat flux                                            | W m⁻²      |
+| `F_sh`                | sensible heat flux                                          | W m⁻²      |
+| `F_turb_moisture`     | turbulent moisture flux                                     | kg m⁻² s⁻¹ |
+| `F_turb_ρτxz`         | turbulent momentum flux in the zonal direction              | kg m⁻¹ s⁻² |
+| `F_turb_ρτyz`         | turbulent momentum flux in the meridional direction         | kg m⁻¹ s⁻² |
+| `SW_d`                | downward SW flux at the surface                             | W m⁻²      |
+| `LW_d`                | downward LW flux at the surface                             | W m⁻²      |
+| `emissivity`          | surface emissivity                                          | -          |
+| `T_sfc`               | surface temperature, averaged across components             | K          |
+| `P_liq`               | liquid precipitation                                        | kg m⁻² s⁻¹ |
+| `P_snow`              | snow precipitation                                          | kg m⁻² s⁻¹ |
+| `scalar_temp1`        | a surface scalar field used for intermediate calculations   | -          |
+| `scalar_temp2`        | a surface scalar field used for intermediate calculations   | -          |
+| `scalar_temp3`        | a surface scalar field used for intermediate calculations   | -          |
+| `scalar_temp4`        | a surface scalar field used for intermediate calculations   | -          |
 
 !!! note "What should be stored in the coupler exchange fields?"
     In general, the coupler fields should contain exchange fields for fluxes, including

--- a/docs/src/simoutput.md
+++ b/docs/src/simoutput.md
@@ -72,8 +72,9 @@ units, any comments, and the function to compute it. This is then used to create
 Once we have created a `ScheduledDiagnostic` for each variable we're interested in,
 we collect them in a vector and pass this to our `DiagnosticsHandler` object.
 
-An example of this process for the combined turbulent energy flux, `F_turb_energy`, can be found in
-`src/SimOutput/diagnostics.jl` in the [`SimOutput.diagnostics_setup`](@ref) function.
+An example of this process for the combined turbulent energy flux, `F_turb_energy`, and the 
+land/ocean/sea-ice area fractions can be found in `src/SimOutput/diagnostics.jl` in the 
+[`SimOutput.diagnostics_setup`](@ref) function.
 
 For more information about this process, please see the
 ClimaDiagnostics.jl [documentation](https://clima.github.io/ClimaDiagnostics.jl/stable/).

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -78,6 +78,10 @@ function update_surface_fractions!(cs::Interfacer.CoupledSimulation)
         ocean_fraction = cs.fields.scalar_temp3
     end
 
+    # update the ice and ocean area fraction coupler fields (land is static)
+    cs.fields.ice_area_fraction .= ice_fraction
+    cs.fields.ocean_area_fraction .= ocean_fraction
+
     # check that the sum of area fractions is 1
     @assert minimum(ice_fraction .+ land_fraction .+ ocean_fraction) ≈ FT(1)
     @assert maximum(ice_fraction .+ land_fraction .+ ocean_fraction) ≈ FT(1)

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -123,6 +123,10 @@ end
 Return a list of default coupler fields needed to run a simulation.
 """
 default_coupler_fields() = [
+    # fields used to define area fractions for flux calculations
+    :land_area_fraction,
+    :ocean_area_fraction,
+    :ice_area_fraction,
     # fields used to compute turbulent fluxes
     :T_atmos,
     :q_tot_atmos,

--- a/src/SimCoordinator.jl
+++ b/src/SimCoordinator.jl
@@ -398,6 +398,11 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
 
     coupler_fields = Interfacer.init_coupler_fields(FT, coupler_field_names, boundary_space)
 
+    # set initial area fractions
+    coupler_fields.land_area_fraction .= land_fraction
+    coupler_fields.ice_area_fraction .= 0  # initialized as 0 since we start with no sea ice, but will evolve in time
+    coupler_fields.ocean_area_fraction .= 1 .- land_fraction  # no sea ice
+
     ## Conservation checks (only applicable to global slabplanet mode)
     conservation_checks = nothing
     if energy_check && domain_type == "global"

--- a/src/SimOutput/diagnostics.jl
+++ b/src/SimOutput/diagnostics.jl
@@ -4,6 +4,24 @@ import Dates
 
 export diagnostics_setup
 
+#### Custom Schedule for diagnostics that only get output once at the beginning of the simulation
+
+struct OnceSchedule <: CD.Schedules.AbstractSchedule end
+
+function (::OnceSchedule)(integrator)
+    return integrator.step == 1
+end
+
+function CD.Schedules.short_name(::OnceSchedule)
+    return "once"
+end
+
+function CD.Schedules.long_name(::OnceSchedule)
+    return "once at the first step of the simulation"
+end
+
+#### Diagnostics orchestration and setup functions
+
 """
     CD.orchestrate_diagnostics(cs::CoupledSimulation)
 
@@ -21,7 +39,8 @@ end
 
 Set up the default diagnostics for an AMIP simulation, using ClimaDiagnostics.
 The diagnostics are saved to NetCDF files. Currently, this just includes a
-diagnostic for turbulent energy fluxes.
+diagnostic for turbulent energy fluxes and diagnostics for each of the land, ocean,
+and sea-ice area fractions.
 
 Return a DiagnosticsHandler object to coordinate the diagnostics.
 """
@@ -33,10 +52,14 @@ function diagnostics_setup(
     diagnostics_dt,
     coupled_dt,
 )
-    # Create schedules and writer
-    schedule_everystep = CD.Schedules.EveryStepSchedule()
-    schedule_calendar_dt = CD.Schedules.EveryCalendarDtSchedule(diagnostics_dt; start_date)
-    netcdf_writer = CD.Writers.NetCDFWriter(axes(fields.F_sh), output_dir)
+    # Create a list to hold the scheduled diagnostics
+    scheduled_diags = []
+
+    # Create output writer (shared across all diagnostics since they all live on the boundary space)
+    boundary_space = axes(fields.F_lh)
+    netcdf_writer = CD.Writers.NetCDFWriter(boundary_space, output_dir)
+
+    #### Turbulent energy fluxes diagnostic
 
     # Create the diagnostic for turbulent energy fluxes
     F_turb_energy_diag = CD.DiagnosticVariable(;
@@ -55,19 +78,114 @@ function diagnostics_setup(
         end,
     )
 
-    # Schedule the turbulent energy fluxes to save at every step, and output at the frequency calculated above
+    # Schedule the turbulent energy fluxes to save at every step and output at the frequency calculated above
+    compute_sched = CD.Schedules.EveryStepSchedule()  # Note that these are stateful, so we create new ones for each diagnostic
+    output_sched = CD.Schedules.EveryCalendarDtSchedule(diagnostics_dt; start_date)
     F_turb_energy_diag_sched = CD.ScheduledDiagnostic(
         variable = F_turb_energy_diag,
         output_writer = netcdf_writer,
         reduction_time_func = (+),
-        compute_schedule_func = schedule_everystep,
-        output_schedule_func = schedule_calendar_dt,
+        compute_schedule_func = compute_sched,
+        output_schedule_func = output_sched,
         pre_output_hook! = CD.average_pre_output_hook!,
     )
 
+    push!(scheduled_diags, F_turb_energy_diag_sched)
+
+    #### Land area fraction diagnostic (only at beginning of the simulation since it's static)
+
+    # Create the diagnostic for land fraction
+    land_fraction_diag = CD.DiagnosticVariable(;
+        short_name = "sftlf",
+        long_name = "Percentage of the Grid Cell Occupied by Land (Including Lakes)",
+        standard_name = "land_area_fraction",
+        units = "%",
+        comments = "Percentage of each grid cell that is land",
+        compute! = (out, state, cache, time) -> begin
+            if isnothing(out)
+                return 100 .* state.land_area_fraction
+            else
+                out .= 100 .* state.land_area_fraction
+            end
+        end,
+    )
+
+    # Schedule the land fraction to save and output at the first step only
+    compute_sched = OnceSchedule()
+    output_sched = OnceSchedule()
+    land_fraction_diag_sched = CD.ScheduledDiagnostic(
+        variable = land_fraction_diag,
+        output_writer = netcdf_writer,
+        compute_schedule_func = compute_sched,
+        output_schedule_func = output_sched,
+    )
+
+    push!(scheduled_diags, land_fraction_diag_sched)
+
+    #### Ocean area fraction diagnostic
+
+    # Create the diagnostic for ocean fraction
+    ocean_fraction_diag = CD.DiagnosticVariable(;
+        short_name = "sftof",
+        long_name = "Sea Area Percentage",
+        standard_name = "sea_area_fraction",
+        units = "%",
+        comments = "Percentage of each grid cell that is ocean",
+        compute! = (out, state, cache, time) -> begin
+            if isnothing(out)
+                return 100 .* state.ocean_area_fraction
+            else
+                out .= 100 .* state.ocean_area_fraction
+            end
+        end,
+    )
+
+    # Schedule the ocean fraction to save and output at diagnostic frequency 
+    # since it can change in time with evolving sea ice
+    compute_sched = CD.Schedules.EveryCalendarDtSchedule(diagnostics_dt; start_date)
+    output_sched = CD.Schedules.EveryCalendarDtSchedule(diagnostics_dt; start_date)
+    ocean_fraction_diag_sched = CD.ScheduledDiagnostic(
+        variable = ocean_fraction_diag,
+        output_writer = netcdf_writer,
+        compute_schedule_func = compute_sched,
+        output_schedule_func = output_sched,
+    )
+
+    push!(scheduled_diags, ocean_fraction_diag_sched)
+
+    #### Ice area fraction diagnostic
+
+    # Create the diagnostic for ice fraction
+    ice_fraction_diag = CD.DiagnosticVariable(;
+        short_name = "siconca",
+        long_name = "Sea-Ice Area Percentage (Atmospheric Grid)",  # technically this is on the exchange grid, but this was the closest CMIP standard name
+        standard_name = "sea_ice_area_fraction",
+        units = "%",
+        comments = "Percentage of each grid cell that is ice",
+        compute! = (out, state, cache, time) -> begin
+            if isnothing(out)
+                return 100 .* state.ice_area_fraction
+            else
+                out .= 100 .* state.ice_area_fraction
+            end
+        end,
+    )
+
+    # Schedule the ice fraction to save and output at diagnostic frequency 
+    compute_sched = CD.Schedules.EveryCalendarDtSchedule(diagnostics_dt; start_date)
+    output_sched = CD.Schedules.EveryCalendarDtSchedule(diagnostics_dt; start_date)
+    ice_fraction_diag_sched = CD.ScheduledDiagnostic(
+        variable = ice_fraction_diag,
+        output_writer = netcdf_writer,
+        compute_schedule_func = compute_sched,
+        output_schedule_func = output_sched,
+    )
+
+    push!(scheduled_diags, ice_fraction_diag_sched)
+
     # Create the diagnostics handler containing the scheduled diagnostics
-    scheduled_diags = [F_turb_energy_diag_sched]
     diags_handler =
         CD.DiagnosticsHandler(scheduled_diags, fields, nothing, t_start, dt = coupled_dt)
+
     return diags_handler
 end


### PR DESCRIPTION
Closes #1549

Changes:
- The `CoupledSimulation` object now has the `land_area_fraction`, `ocean_area_fraction` and `ice_area_fraction` fields defined on the exchange grid.
- These fields are initialized in the `CoupledSimulation` constructor, updated every time `update_surface_fractions!` is called, and output periodically (land only at the beginning using a custom `OnceSchedule` struct implementing a `ClimaDiagnostics` `AbstractSchedule`).
- These changes are reflected in the docs.

Some potential todos/questions:
- Right now the ocean and sea-ice area fractions will be output regularly even for simulations that don't have these components. Maybe it would make more sense to have some `haskey(cs.model_sims, :ocean_sim)` checks, for instance?
- Looking at the output files, I see that these area fractions are not necessarily between 0 and 1. I think this is due to the way a `ClimaCore` `Field` is interpolated onto a latlon grid for NetCDF output. Would it instead be more useful to output the `Field`s themselves?
- It feels a bit hacky to have the land fraction be in the diagnostics scheduler while only having it saved at the beginning. Perhaps I should just save it when the `CoupledSimulation` is constructed and remove the scheduler?