### PR TITLE
Add time incrementing test

### DIFF
--- a/experiments/test/runtests.jl
+++ b/experiments/test/runtests.jl
@@ -20,3 +20,6 @@ end
 @safetestset "AMIP test" begin
     include("amip_test.jl")
 end
+@safetestset "time incrementing test" begin
+    include("time_increment_test.jl")
+end

--- a/experiments/test/time_increment_test.jl
+++ b/experiments/test/time_increment_test.jl
@@ -1,0 +1,34 @@
+using Test
+using ClimaCoupler
+import ClimaAtmos
+ClimaAtmosExt = Base.get_extension(ClimaCoupler, :ClimaCouplerClimaAtmosExt)
+
+@testset "Floating Point time-stepping" begin
+    FT = Float64
+    t = FT(10^7)
+    smallest_dt = FT(60)
+    # use a fake sim and integrator because their functionality is not needed in this test
+    struct FakeIntegrator{FT}
+        dt::FT
+        t::Ref{FT}
+    end
+    Base.getproperty(integrator::FakeIntegrator, s::Symbol) =
+        s == :t ? getfield(integrator, s)[] : getfield(integrator, s)
+    fake_sim = ClimaAtmosExt.ClimaAtmosSimulation(
+        nothing,
+        nothing,
+        # component models can use float32 time
+        FakeIntegrator(Float32(smallest_dt), Ref(Float32(t))),
+        nothing,
+    )
+    function ClimaCoupler.Interfacer.step!(sim::FakeIntegrator, Δt, _)
+        getfield(sim, :t)[] += Δt
+        return
+    end
+    # 951815 is the number of steps after which the time incrementing test fails
+    for i in 1:951815
+        t += smallest_dt
+        ClimaCoupler.Interfacer.step!(fake_sim, t)
+        @test fake_sim.integrator.t == t broken = i >= 951815
+    end
+end


### PR DESCRIPTION
Use F32 for atmos

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- add a test to show the point at which the coupler and a component model's time will no longer agree


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
