### PR TITLE
Use smaller coupling timestep for CMIP

### DIFF
--- a/config/longrun_configs/cmip_diagedmf_land.yml
+++ b/config/longrun_configs/cmip_diagedmf_land.yml
@@ -5,11 +5,11 @@ checkpoint_dt: "1months"
 coupler_toml: ["toml/amip_diagedmf.toml"]
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "1800secs" # 30 minutes
+dt_cpl: "360secs" # 6 minutes
 dt_land: "120secs" # 2 minutes
-dt_ocean: "1800secs" # 30 minutes
+dt_ocean: "360secs" # 6 minutes
 dt_rad: "1hours"
-dt_seaice: "1800secs" # 30 minutes
+dt_seaice: "360secs" # 6 minutes
 energy_check: false
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]

--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -4,11 +4,11 @@ bucket_albedo_type: "map_temporal"
 checkpoint_dt: "1months"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "1800secs" # 30 minutes
+dt_cpl: "360secs" # 6 minutes
 dt_land: "120secs" # 2 minutes
-dt_ocean: "1800secs" # 30 minutes
+dt_ocean: "360secs" # 6 minutes
 dt_rad: "1hours"
-dt_seaice: "1800secs" # 30 minutes
+dt_seaice: "360secs" # 6 minutes
 energy_check: false
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]

--- a/config/longrun_configs/cmip_edonly_land.yml
+++ b/config/longrun_configs/cmip_edonly_land.yml
@@ -3,11 +3,11 @@ atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 checkpoint_dt: "1months"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "1800secs" # 30 minutes
+dt_cpl: "360secs" # 6 minutes
 dt_land: "120secs" # 2 minutes
-dt_ocean: "1800secs" # 30 minutes
+dt_ocean: "360secs" # 6 minutes
 dt_rad: "1hours"
-dt_seaice: "1800secs" # 30 minutes
+dt_seaice: "360secs" # 6 minutes
 energy_check: false
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]

--- a/config/longrun_configs/cmip_progedmf_land.yml
+++ b/config/longrun_configs/cmip_progedmf_land.yml
@@ -5,11 +5,11 @@ checkpoint_dt: "1months"
 coupler_toml: ["toml/amip_progedmf.toml"]
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
-dt_cpl: "1800secs" # 30 minutes
+dt_cpl: "360secs" # 6 minutes
 dt_land: "120secs" # 2 minutes
-dt_ocean: "1800secs" # 30 minutes
+dt_ocean: "360secs" # 6 minutes
 dt_rad: "1hours"
-dt_seaice: "1800secs" # 30 minutes
+dt_seaice: "360secs" # 6 minutes
 energy_check: false
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Right now we use 30 minute timesteps for the coupler, ocean, and sea ice in CMIP. This is causing instabilities because the fluxes are computed very infrequently by the coupler. This PR decreases these dts from 30 to 6 minutes to try to make the simulations more stable.

I'll merge this without running CI since it only changes longruns.

Stable longrun with these changes (manually canceled to free up resources): https://buildkite.com/clima/climacoupler-longruns/builds/1096