### PR TITLE
allow finer coupler resolution

### DIFF
--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -10,19 +10,24 @@ dt_ocean: "360secs" # 6 minutes
 dt_rad: "1hours"
 dt_seaice: "360secs" # 6 minutes
 energy_check: false
+h_elem: 16 # atmosphere
+h_elem_coupler: 64 # coupler
+ice_model: "clima_seaice"
+insolation: "timevarying"
+mode_name: "cmip"
+nh_poly: 3
+nh_poly_coupler: 2
+ocean_model: "oceananigans"
+rmse_check: true
+share_surface_space: false
+start_date: "20100101"
+surface_setup: "PrescribedSurface"
+t_end: "366days"
+topo_smoothing: true
+topography: "Earth"
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]
     period: 1months
     reduction_time: average
     pressure_coordinates: true
     compute_every: 6hours
-ice_model: "clima_seaice"
-insolation: "timevarying"
-mode_name: "cmip"
-ocean_model: "oceananigans"
-rmse_check: true
-start_date: "20100101"
-surface_setup: "PrescribedSurface"
-t_end: "366days"
-topo_smoothing: true
-topography: "Earth"

--- a/src/Input.jl
+++ b/src/Input.jl
@@ -122,13 +122,21 @@ function argparse_settings()
         default = "90days"
         # Space information
         "--h_elem"
-        help = "Number of horizontal elements to use for the boundary space [16 (default)]"
+        help = "Number of horizontal elements to use for the atmosphere horizontal space [16 (default)]"
         arg_type = Int
         default = 16
+        "--h_elem_coupler"
+        help = "Number of horizontal elements to use for the boundary space when `share_surface_space` is false [16 (default)]"
+        arg_type = Int
+        default = 32
         "--nh_poly"
-        help = "Polynomial order to use for the boundary space [3 (default)]"
+        help = "Polynomial order to use for the atmosphere horizontal space [3 (default)]"
         arg_type = Int
         default = 3
+        "--nh_poly_coupler"
+        help = "Polynomial order to use for the boundary space when `share_surface_space` is false [3 (default)]"
+        arg_type = Int
+        default = 2
         "--share_surface_space"
         help = "Boolean flag indicating whether to share the surface space between the surface models, atmosphere, and boundary [`true` (default), `false`]"
         arg_type = Bool
@@ -458,8 +466,8 @@ function get_coupler_args(config_dict::Dict)
 
     # Space information
     share_surface_space = config_dict["share_surface_space"]
-    nh_poly = config_dict["nh_poly"]
-    h_elem = config_dict["h_elem"]
+    nh_poly_coupler = config_dict["nh_poly_coupler"]
+    h_elem_coupler = config_dict["h_elem_coupler"]
 
     # Checkpointing information
     checkpoint_dt = config_dict["checkpoint_dt"]
@@ -562,8 +570,8 @@ function get_coupler_args(config_dict::Dict)
         Δt_cpl,
         component_dt_dict,
         share_surface_space,
-        nh_poly,
-        h_elem,
+        nh_poly_coupler,
+        h_elem_coupler,
         saveat,
         checkpoint_dt,
         detect_restart_files,

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -535,11 +535,13 @@ abstract type SlabplanetTerraMode <: AbstractSlabplanetSimulationMode end
     remap(target_space, source_field)
 
 Remap the given `source_field` onto the `target_space`. Note that if the field is already
-on the target space or a compatible one (e.g. another instance of the same space),
-it is returned unchanged. Users should use caution in modifying the returned field
-in this case.
+on the target space it is returned unchanged; users should use caution in modifying the
+returned field in this case. If it is a compatible one (e.g. another instance of the
+same space), the field is copied to the target space.
 
 This is a convenience wrapper around `remap!` that allocates the output field.
+Note that we could call `remap!` directly without checking `spaces_are_compatible`
+here, but then we would allocate a new field even if the spaces are the same.
 
 Non-ClimaCore fields should provide a method to this function.
 """
@@ -548,20 +550,24 @@ function remap end
 function remap(target_space::CC.Spaces.AbstractSpace, source_field::CC.Fields.Field)
     source_space = axes(source_field)
 
-    # Check if the source and target spaces are compatible
-    spaces_are_compatible =
-        source_space == target_space ||
-        CC.Spaces.issubspace(source_space, target_space) ||
-        CC.Spaces.issubspace(target_space, source_space)
-
     # TODO: Handle remapping of Vectors correctly
     if hasproperty(source_field, :components)
         @assert length(source_field.components) == 1 "Can only work with simple vectors"
         source_field = source_field.components.data.:1
     end
 
-    # If the spaces are the same or one is a subspace of the other, we can just return the input field
-    spaces_are_compatible && return source_field
+    # Check if the source and target spaces are compatible
+    spaces_are_compatible =
+        source_space == target_space ||
+        CC.Spaces.issubspace(source_space, target_space) ||
+        CC.Spaces.issubspace(target_space, source_space)
+
+    # If the spaces are the same or one is a subspace of the other, we can just copy the
+    # source field to the target space. Note this is a dangerous operation because it accesses
+    # the underlying array of the source field directly, which is not a reliable pattern.
+    if spaces_are_compatible
+        return CC.Fields.Field(CC.Fields.field_values(source_field), target_space)
+    end
 
     # Allocate target field and call remap!
     target_field = CC.Fields.zeros(target_space)
@@ -771,27 +777,26 @@ end
     get_atmos_height_delta(height_int, height_sfc)
 
 Return a Field of the height delta between the atmosphere bottom cell center
-and bottom face, defined on the boundary space.
+and the surface, defined on the boundary space.
 This is used to compute turbulent fluxes.
 
-Since the atmospheric height is defined on centers, we need to copy the values onto
-the boundary space to be able to subtract the surface elevation.
-This pattern is not reliable and should not be reused.
+Both `height_int` and `height_sfc` must already be defined on the same space
+(the boundary space). Use `get_field!` to remap the atmosphere height onto
+the boundary space before calling this function.
 
 Note this function allocates a new field, and the atmosphere heights won't change
 during a simulation, so it should only be called at initialization.
 
 # Arguments
-- `csf`: [NamedTuple] containing coupler fields.
+- `height_int`: [CC.Fields.Field] defined on the boundary space, containing the
+  atmosphere bottom cell center height.
+- `height_sfc`: [CC.Fields.Field] defined on the boundary space.
 
 # Returns
 - [CC.Fields.Field] defined on the boundary space containing the height delta.
 """
 function get_atmos_height_delta(height_int, height_sfc)
-    return CC.Fields.Field(
-        CC.Fields.field_values(height_int),
-        axes(height_sfc), # boundary space
-    ) .- height_sfc
+    return height_int .- height_sfc
 end
 
 end # module

--- a/src/SimCoordinator.jl
+++ b/src/SimCoordinator.jl
@@ -215,8 +215,8 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
         Δt_cpl,
         component_dt_dict,
         share_surface_space,
-        nh_poly,
-        h_elem,
+        nh_poly_coupler,
+        h_elem_coupler,
         saveat,
         checkpoint_dt,
         detect_restart_files,
@@ -291,16 +291,16 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
         share_surface_space,
         comms_ctx;
         column_latlon,
-        nh_poly,
-        h_elem,
+        nh_poly_coupler,
+        h_elem_coupler,
         coupled_param_dict,
     )
 
     surface_elevation = Interfacer.get_field(boundary_space, atmos_sim, Val(:height_sfc))
-    atmos_h = Interfacer.get_atmos_height_delta(
-        Interfacer.get_field(atmos_sim, Val(:height_int)),
-        surface_elevation,
-    )
+    atmos_bottom_center_height =
+        Interfacer.get_field(boundary_space, atmos_sim, Val(:height_int))
+    atmos_h =
+        Interfacer.get_atmos_height_delta(atmos_bottom_center_height, surface_elevation)
 
     land_fraction = Input.get_land_fraction(
         boundary_space,

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -331,8 +331,8 @@ function create_boundary_space(
     share_surface_space,
     comms_ctx;
     column_latlon = nothing,
-    nh_poly = nothing,
-    h_elem = nothing,
+    nh_poly_coupler = nothing,
+    h_elem_coupler = nothing,
     coupled_param_dict = nothing,
 ) where {FT}
     if domain_type == "column"
@@ -340,9 +340,14 @@ function create_boundary_space(
     elseif share_surface_space
         return CC.Spaces.horizontal_space(atmos_sim.domain.face_space)
     else
-        n_quad_points = nh_poly + 1
+        n_quad_points = nh_poly_coupler + 1
         radius = coupled_param_dict["planet_radius"]
-        return CC.CommonSpaces.CubedSphereSpace(FT; radius, n_quad_points, h_elem)
+        return CC.CommonSpaces.CubedSphereSpace(
+            FT;
+            radius,
+            n_quad_points,
+            h_elem = h_elem_coupler,
+        )
     end
 end
 

--- a/test/input_tests.jl
+++ b/test/input_tests.jl
@@ -70,6 +70,8 @@ end
         "share_surface_space" => true,
         "nh_poly" => 2,
         "h_elem" => 8,
+        "h_elem_coupler" => 16,
+        "nh_poly_coupler" => 2,
         "checkpoint_dt" => "90days",
         "detect_restart_files" => false,
         "restart_dir" => nothing,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We thought this was allowed before but it was being handled incorrectly. Note that ClimaAtmos reads in `h_elem` and `nh_poly` from the config dictionary, so we needed to add coupler-specific args to differentiate from those. Also `get_atmos_height_delta` becomes a very simple function that could probably be removed.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
