### PR TITLE
Compute bflux, ustar, L_MO from combined fluxes

### DIFF
--- a/docs/src/fluxcalculator.md
+++ b/docs/src/fluxcalculator.md
@@ -34,10 +34,6 @@ fluxes and the CoupledSimulation object's fluxes fields.
 - the flux of energy due to latent heat, `F_lh`;
 - the flux of energy due to sensible heat, `F_sh`;
 - the flux of moisture, `F_turb_moisture`;
-- the Obukhov length, `L_MO`;
-- the buoyancy flux, `buoyancy_flux`;
-- the roughness lengths for momentum and buoyancy, `z0m` and `z0b`;
-- the frictional velocity `ustar`.
 
 !!! note
 

--- a/docs/src/interfacer.md
+++ b/docs/src/interfacer.md
@@ -184,15 +184,6 @@ properties needed by a component model.
 | `surface_temperature`    | temperature over the combined surface space              | K     |
 | `turbulent_fluxes`       | turbulent fluxes                                         | W m⁻² |
 
-ClimaAtmos should also add the following coupler fields for Monin-Obukhov similarity theory:
-
-| Coupler name    | Description       | Units  |
-|-----------------|-------------------|--------|
-| `ustar`         | friction velocity | m s⁻¹  |
-| `L_MO`          | Obukhov length    | m      |
-| `buoyancy_flux` | flux of buoyancy  | m⁻²s⁻³ |
-
-
 ### AbstractAtmosSimulation - required functions to run with the ClimaLandSimulation
 
 Coupling with the integrated `ClimaLandSimulation` requires the following functions, in addition

--- a/ext/ClimaCouplerClimaAtmosExt.jl
+++ b/ext/ClimaCouplerClimaAtmosExt.jl
@@ -16,6 +16,7 @@ import ClimaParams as CP
 import ClimaCore as CC
 import ClimaCore.Geometry: ⊗
 import SurfaceFluxes as SF
+import SurfaceFluxes.Parameters as SFP
 import Thermodynamics as TD
 import ClimaCoupler:
     Checkpointer, FieldExchanger, FluxCalculator, Interfacer, Utilities, Plotting
@@ -499,15 +500,39 @@ function FluxCalculator.update_turbulent_fluxes!(sim::ClimaAtmosSimulation, fiel
     sim.integrator.p.precomputed.sfc_conditions.ρ_flux_q_tot .=
         temp_field_surface .* surface_normal # (evap)
 
-    Interfacer.remap!(
-        sim.integrator.p.precomputed.sfc_conditions.obukhov_length,
-        fields.L_MO,
+    # Compute buoyancy flux, ustar, and L_MO using combined coupler fields
+    surface_fluxes_params = FluxCalculator.get_surface_params(sim)
+    (; T_sfc, ρ_atmos, q_tot_atmos, q_liq_atmos, q_ice_atmos, scalar_temp1, scalar_temp2) =
+        fields
+    # Note: It isn't clear that q_vap_sfc should come from q_vap_int like this, but this is
+    # easy and not too wrong (see https://github.com/CliMA/ClimaCoupler.jl/issues/1817)
+    @. scalar_temp1 = q_tot_atmos - q_liq_atmos - q_ice_atmos
+    q_vap_atmos = scalar_temp1 # rename for clarity
+    @. scalar_temp2 = SF.buoyancy_flux(
+        surface_fluxes_params,
+        F_sh,
+        F_lh,
+        T_sfc, # Same note here as the one above for q_vap_sfc
+        ρ_atmos,
+        q_vap_atmos,
+        q_liq_atmos,
+        q_ice_atmos,
+        SF.MoistModel(),
     )
-    Interfacer.remap!(sim.integrator.p.precomputed.sfc_conditions.ustar, fields.ustar)
+    buoyancy_flux = scalar_temp2 # rename for clarity
     Interfacer.remap!(
         sim.integrator.p.precomputed.sfc_conditions.buoyancy_flux,
-        fields.buoyancy_flux,
+        buoyancy_flux,
     )
+
+    @. scalar_temp1 = sqrt(sqrt(F_turb_ρτxz^2 + F_turb_ρτyz^2) / ρ_atmos) # reuse (q_vap_atmos no longer needed)
+    ustar = scalar_temp1 # rename for clarity
+    Interfacer.remap!(sim.integrator.p.precomputed.sfc_conditions.ustar, ustar)
+
+    @. scalar_temp1 =
+        -ustar^3 / SFP.von_karman_const(surface_fluxes_params) / SF.non_zero(buoyancy_flux) # reuse (ustar no longer needed)
+    L_MO = scalar_temp1 # rename for clarity
+    Interfacer.remap!(sim.integrator.p.precomputed.sfc_conditions.obukhov_length, L_MO)
 
     return nothing
 end
@@ -518,14 +543,12 @@ Extend Interfacer.add_coupler_fields! to add the fields required for ClimaAtmosS
 The fields added are:
 - `:surface_direct_albedo` (for radiation)
 - `:surface_diffuse_albedo` (for radiation)
-- `:ustar`, `:L_MO`, `:buoyancy_flux` (for EDMF boundary conditions)
 """
 function Interfacer.add_coupler_fields!(
     coupler_field_names,
     atmos_sim::ClimaAtmosSimulation,
 )
-    atmos_coupler_fields =
-        [:surface_direct_albedo, :surface_diffuse_albedo, :ustar, :L_MO, :buoyancy_flux]
+    atmos_coupler_fields = [:surface_direct_albedo, :surface_diffuse_albedo]
     push!(coupler_field_names, atmos_coupler_fields...)
 end
 

--- a/ext/ClimaCouplerClimaLandExt/climaland_bucket.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_bucket.jl
@@ -420,9 +420,6 @@ Update the surface simulation `sim` with the values stored in `fluxes,
 without any area-weighting. Then, update the coupler fields `csf` with
 the area-weighted fluxes after remapping to the boundary space.
 
-This method also computes ustar and L_MO from the momentum fluxes and buoyancy flux,
-and updates the coupler fields `csf` with these values.
-
 # Arguments
 - `csf`: [CC.Fields.Field] containing a NamedTuple of turbulent flux fields:
     `F_turb_ρτxz`, `F_turb_ρτyz`, `F_lh`, `F_sh`, `F_turb_moisture`.
@@ -469,32 +466,6 @@ function FluxCalculator.update_flux_fields!(csf, sim::BucketSimulation, fluxes)
         ifelse(area_fraction == 0, zero(csf.scalar_temp1), csf.scalar_temp1)
     @. csf.F_turb_ρτyz += csf.scalar_temp1 * area_fraction
 
-    # Combine the buoyancy flux from each component of the land model
-    # Note that we exclude the canopy component here for now, since ClimaLand doesn't
-    #  include its extra resistance term in the buoyancy flux calculation.
-    Interfacer.remap!(csf.scalar_temp1, fluxes.buoyancy_flux)
-    @. csf.scalar_temp1 =
-        ifelse(area_fraction == 0, zero(csf.scalar_temp1), csf.scalar_temp1)
-    @. csf.buoyancy_flux += csf.scalar_temp1 * area_fraction
-
-    # Compute ustar from the momentum fluxes and surface air density
-    #  ustar = sqrt(ρτ / ρ)
-    @. csf.scalar_temp1 = sqrt(sqrt(csf.F_turb_ρτxz^2 + csf.F_turb_ρτyz^2) / csf.ρ_atmos)
-    @. csf.scalar_temp1 =
-        ifelse(area_fraction == 0, zero(csf.scalar_temp1), csf.scalar_temp1)
-    # If ustar is zero, set it to eps to avoid division by zero in the atmosphere
-    @. csf.ustar += max(csf.scalar_temp1 * area_fraction, eps(FT))
-
-    # Compute the Monin-Obukhov length from ustar and the buoyancy flux
-    #  L_MO = -u^3 / (k * buoyancy_flux)
-    surface_params = LP.surface_fluxes_parameters(sim.model.parameters.earth_param_set)
-    @. csf.scalar_temp1 =
-        -csf.ustar^3 / SFP.von_karman_const(surface_params) / SF.non_zero(csf.buoyancy_flux)
-    @. csf.scalar_temp1 =
-        ifelse(area_fraction == 0, zero(csf.scalar_temp1), csf.scalar_temp1)
-    # When L_MO is infinite, avoid multiplication by zero to prevent NaN
-    @. csf.L_MO +=
-        ifelse(isinf(csf.scalar_temp1), csf.scalar_temp1, csf.scalar_temp1 * area_fraction)
     return nothing
 end
 

--- a/ext/ClimaCouplerClimaLandExt/climaland_integrated.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_integrated.jl
@@ -571,37 +571,6 @@ function FluxCalculator.compute_surface_fluxes!(
         ifelse(area_fraction == 0, zero(csf.scalar_temp1), csf.scalar_temp1)
     @. csf.F_turb_ρτyz += csf.scalar_temp1 * area_fraction
 
-    # Combine the buoyancy flux from each component of the land model
-    # Note that we exclude the canopy component here for now, since ClimaLand doesn't
-    #  include its extra resistance term in the buoyancy flux calculation.
-    Interfacer.remap!(
-        csf.scalar_temp1,
-        soil_dest.buoyancy_flux .* (1 .- p.snow.snow_cover_fraction) .+
-        p.snow.snow_cover_fraction .* snow_dest.buoyancy_flux,
-    )
-    @. csf.scalar_temp1 =
-        ifelse(area_fraction == 0, zero(csf.scalar_temp1), csf.scalar_temp1)
-    @. csf.buoyancy_flux += csf.scalar_temp1 * area_fraction
-
-    # Compute ustar from the momentum fluxes and surface air density
-    #  ustar = sqrt(ρτ / ρ)
-    @. csf.scalar_temp1 = sqrt(sqrt(csf.F_turb_ρτxz^2 + csf.F_turb_ρτyz^2) / csf.ρ_atmos)
-    @. csf.scalar_temp1 =
-        ifelse(area_fraction == 0, zero(csf.scalar_temp1), csf.scalar_temp1)
-    # If ustar is zero, set it to eps to avoid division by zero in the atmosphere
-    @. csf.ustar += max(csf.scalar_temp1 * area_fraction, eps(FT))
-
-    # Compute the Monin-Obukhov length from ustar and the buoyancy flux
-    #  L_MO = -u^3 / (k * buoyancy_flux)
-    surface_params = LP.surface_fluxes_parameters(sim.model.soil.parameters.earth_param_set)
-    @. csf.scalar_temp1 =
-        -csf.ustar^3 / SFP.von_karman_const(surface_params) / SF.non_zero(csf.buoyancy_flux)
-    @. csf.scalar_temp1 =
-        ifelse(area_fraction == 0, zero(csf.scalar_temp1), csf.scalar_temp1)
-    # When L_MO is infinite, avoid multiplication by zero to prevent NaN
-    @. csf.L_MO +=
-        ifelse(isinf(csf.scalar_temp1), csf.scalar_temp1, csf.scalar_temp1 * area_fraction)
-
     return nothing
 end
 

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -52,16 +52,7 @@ function turbulent_fluxes!(csf, model_sims, thermo_params)
 
     # Reset the coupler fields will compute. We need to do this because we will compute
     # area-weighted averages
-    for p in (
-        :F_turb_ρτxz,
-        :F_turb_ρτyz,
-        :F_lh,
-        :F_sh,
-        :F_turb_moisture,
-        :L_MO,
-        :ustar,
-        :buoyancy_flux,
-    )
+    for p in (:F_turb_ρτxz, :F_turb_ρτyz, :F_lh, :F_sh, :F_turb_moisture)
         fill!(getproperty(csf, p), 0)
     end
 
@@ -135,19 +126,7 @@ function get_surface_fluxes(
         update_q_vap_sfc,
     )
 
-    (; shf, lhf, evaporation, ρτxz, ρτyz, T_sfc, q_vap_sfc, L_MO, ustar) = outputs
-
-    buoyancy_flux = SF.buoyancy_flux(
-        surface_fluxes_params,
-        shf,
-        lhf,
-        T_sfc,
-        ρ_int,
-        q_vap_sfc,
-        q_liq_int,
-        q_ice_int,
-        SF.MoistModel(),
-    )
+    (; shf, lhf, evaporation, ρτxz, ρτyz, T_sfc, q_vap_sfc) = outputs
 
     return (;
         F_turb_ρτxz = ρτxz,
@@ -155,9 +134,6 @@ function get_surface_fluxes(
         F_sh = shf,
         F_lh = lhf,
         F_turb_moisture = evaporation,
-        L_MO,
-        ustar,
-        buoyancy_flux,
         T_sfc_new = T_sfc,
     )
 end
@@ -321,8 +297,7 @@ the area-weighted fluxes.
 - `fluxes`: [NamedTuple] containing the fluxes to update the surface simulation with.
 """
 function update_flux_fields!(csf, sim::Interfacer.AbstractSurfaceSimulation, fluxes)
-    (; F_turb_ρτxz, F_turb_ρτyz, F_sh, F_lh, F_turb_moisture, L_MO, ustar, buoyancy_flux) =
-        fluxes
+    (; F_turb_ρτxz, F_turb_ρτyz, F_sh, F_lh, F_turb_moisture) = fluxes
     area_fraction = Interfacer.get_field(sim, Val(:area_fraction))
 
     # Zero out fluxes where the area fraction is zero
@@ -333,9 +308,6 @@ function update_flux_fields!(csf, sim::Interfacer.AbstractSurfaceSimulation, flu
     @. F_sh = ifelse(area_fraction ≈ 0, zero(F_sh), F_sh)
     @. F_lh = ifelse(area_fraction ≈ 0, zero(F_lh), F_lh)
     @. F_turb_moisture = ifelse(area_fraction ≈ 0, zero(F_turb_moisture), F_turb_moisture)
-    @. L_MO = ifelse(area_fraction ≈ 0, zero(L_MO), L_MO)
-    @. ustar = ifelse(area_fraction ≈ 0, zero(ustar), ustar)
-    @. buoyancy_flux = ifelse(area_fraction ≈ 0, zero(buoyancy_flux), buoyancy_flux)
 
     # update the fluxes, which are now area fraction-masked, of this surface model
     fields = (; F_turb_ρτxz, F_turb_ρτyz, F_lh, F_sh, F_turb_moisture)
@@ -350,14 +322,6 @@ function update_flux_fields!(csf, sim::Interfacer.AbstractSurfaceSimulation, flu
     @. csf.F_sh += F_sh * area_fraction
     @. csf.F_turb_moisture += F_turb_moisture * area_fraction
 
-    # NOTE: This is still an area weighted contribution, which maybe doesn't make
-    # too much sense for these quantities...
-
-    # L_MO can be Inf. We don't want to multiply Inf * 0, so we can handle this
-    # separately.
-    @. csf.L_MO += ifelse(isinf(L_MO), L_MO, L_MO * area_fraction)
-    @. csf.ustar += ustar * area_fraction
-    @. csf.buoyancy_flux += buoyancy_flux * area_fraction
     return nothing
 end
 

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -148,14 +148,7 @@ for FT in (Float32, Float64)
 
         model_sims = (; atmos_sim, ocean_sim, ocean_sim2)
 
-        coupler_cache_additional = [
-            :surface_direct_albedo,
-            :surface_diffuse_albedo,
-            :P_net,
-            :L_MO,
-            :ustar,
-            :buoyancy_flux,
-        ]
+        coupler_cache_additional = [:surface_direct_albedo, :surface_diffuse_albedo, :P_net]
 
         coupler_cache_names = Interfacer.default_coupler_fields()
         push!(coupler_cache_names, coupler_cache_additional...)


### PR DESCRIPTION
## Purpose 

Closes #1817 

## To-do

## Content

[x] Remove `buoyancy_flux`, `ustar`, `L_MO` from coupler fields
[x] Compute `buoyancy_flux`, `ustar`, `L_MO` from combined surface fluxes
[x] Update the docs to reflect changes