### PR TITLE
fix start_date and stop_date of modis LAI for restarting simulations

### DIFF
--- a/ext/ClimaCouplerCMIPExt/oceananigans.jl
+++ b/ext/ClimaCouplerCMIPExt/oceananigans.jl
@@ -78,7 +78,7 @@ function OceananigansSimulation(
     OC.Oceananigans.defaults.FloatType = FT
 
     # Compute stop_date for oceananigans (needed for EN4 data retrieval)
-    stop_date = start_date + Dates.Second(float(tspan[2] - tspan[1]))
+    stop_date = start_date + Dates.Second(float(tspan[2]))
 
     # Use Float64 for the ocean to avoid precision issues
     FT_ocean = Float64

--- a/ext/ClimaCouplerClimaLandExt/climaland_bucket.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_bucket.jl
@@ -192,7 +192,7 @@ function BucketSimulation(
         diagnostics = nothing
     end
 
-    stop_date = start_date + Dates.Second(float(tspan[2] - tspan[1]))
+    stop_date = start_date + Dates.Second(float(tspan[2]))
     # Convert start_date and stop_date to ITime if using ITime
     if dt isa ITime
         start_date = tspan[1]

--- a/ext/ClimaCouplerClimaLandExt/climaland_integrated.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_integrated.jl
@@ -113,11 +113,15 @@ function ClimaLandSimulation(
     #  since that's where we compute fluxes for this land model
     atmos_h = Interfacer.remap(surface_space, atmos_h)
 
+    # `tspan` can contain non-zero values (e.g. (720.0, 900.0)) when restarting
+    sim_start_date = start_date + Dates.Second(float(tspan[1]))
+    sim_stop_date = start_date + Dates.Second(float(tspan[2]))
+
     # Set up atmosphere and radiation forcing
     forcing = (;
         atmos = CL.CoupledAtmosphere{FT, typeof(atmos_h)}(atmos_h, gustiness),
         radiation = CL.CoupledRadiativeFluxes{FT}(
-            start_date;
+            sim_start_date;
             latitude = CC.Fields.coordinate_field(domain.space.surface).lat,
             longitude = CC.Fields.coordinate_field(domain.space.surface).long,
             toml_dict,
@@ -125,13 +129,12 @@ function ClimaLandSimulation(
     )
 
     # Set up leaf area index (LAI)
-    stop_date = start_date + Dates.Second(float(tspan[2] - tspan[1]))
     if lai_source == "modis_monthly"
         # Full monthly MODIS LAI data
         LAI = CL.prescribed_lai_modis(
             surface_space,
-            start_date,
-            stop_date;
+            sim_start_date,
+            sim_stop_date;
             time_interpolation_method = LinearInterpolation(),
         )
     elseif lai_source == "modis_monthly_climatology"
@@ -142,8 +145,8 @@ function ClimaLandSimulation(
         )
         LAI = CL.prescribed_lai_modis(
             surface_space,
-            start_date,
-            stop_date;
+            sim_start_date,
+            sim_stop_date;
             modis_lai_ncdata_path = modis_lai_clim_path,
             time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
         )
@@ -272,11 +275,11 @@ function ClimaLandSimulation(
     # Convert start_date and stop_date to ITime if using ITime
     if dt isa ITime
         start_date = tspan[1]
-        stop_date = tspan[2]
+        sim_stop_date = tspan[2]
     end
     simulation = CL.Simulations.LandSimulation(
         start_date,
-        stop_date,
+        sim_stop_date,
         dt,
         model;
         outdir = output_dir,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Currently we don't take into account t_start when creating LAI with CL.prescribed_lai_modis. This results in an error when restarting the simulation (stop_date is before the actual start time of the simulation), e.g. [here](https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/1102#019df97f-c2ca-4380-b175-65ddb07c1e59/L273). With this fix the restart works: https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/1103#019dfa0e-59b8-4ba8-a4eb-b10240e8f3ea. cc @kmdeck 

I'm not sure if this is the best solution. @ph-kev Could you take over this PR and see if there is a better fix, and maybe check if start_date and stop_date need to be updated in other places? Thanks!

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
