### PR TITLE
add prognostic edmf 1m to nightly amip

### DIFF
--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -91,6 +91,21 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 30GB
+      
+      - label: "Coarse current AMIP: progedmf + 1M + integrated land"
+        key: "amip_progedmf_1m_land"
+        command:
+          - echo "--- Run simulation"
+          - "julia --threads=3 --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/amip_coarse_progedmf_1m_land.yml --job_id amip_coarse_progedmf_1m_land"
+        artifact_paths: "output/amip_coarse_progedmf_1m_land/artifacts/*"
+        timeout_in_minutes: 840
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        agents:
+          slurm_gpus_per_task: 1
+          slurm_cpus_per_task: 4
+          slurm_ntasks: 1
+          slurm_mem: 30GB
 
       - label: "Flagship AMIP GPU with prognostic EDMF + 1M + integrated land (16 helems)"
         key: "gpu_amip_progedmf_1M_land_he16"

--- a/config/amip_configs/amip_land.yml
+++ b/config/amip_configs/amip_land.yml
@@ -1,8 +1,8 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
-atmos_config_file: "config/atmos_configs/climaatmos_diagedmf.yml"
-checkpoint_dt: "366days"
-coupler_toml: ["toml/amip_diagedmf.toml"]
+atmos_config_file: "config/atmos_configs/climaatmos_progedmf.yml"
+checkpoint_dt: "1months"
+coupler_toml: ["toml/amip_progedmf.toml"]
 dt: "120secs"
 dt_cpl: "120secs"
 energy_check: false

--- a/config/atmos_configs/climaatmos_diagedmf.yml
+++ b/config/atmos_configs/climaatmos_diagedmf.yml
@@ -17,6 +17,7 @@ h_elem: 16
 implicit_diffusion: true
 insolation: "timevarying"
 netcdf_output_at_levels: true
+ode_algo: ARS343
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 prognostic_tke: true
 rad: "allskywithclear"

--- a/config/atmos_configs/climaatmos_edonly.yml
+++ b/config/atmos_configs/climaatmos_edonly.yml
@@ -11,6 +11,7 @@ h_elem: 16
 implicit_diffusion: true
 insolation: "timevarying"
 netcdf_output_at_levels: true
+ode_algo: ARS343
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 rad: "allskywithclear"
 rayleigh_sponge: true

--- a/config/atmos_configs/climaatmos_progedmf.yml
+++ b/config/atmos_configs/climaatmos_progedmf.yml
@@ -23,6 +23,7 @@ implicit_sgs_nh_pressure: true
 implicit_sgs_vertdiff: true
 insolation: "timevarying"
 netcdf_output_at_levels: true
+ode_algo: ARS222
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 prognostic_tke: true
 rad: "allskywithclear"

--- a/config/atmos_configs/climaatmos_progedmf_1m.yml
+++ b/config/atmos_configs/climaatmos_progedmf_1m.yml
@@ -23,6 +23,7 @@ implicit_sgs_nh_pressure: true
 implicit_sgs_vertdiff: true
 insolation: "timevarying"
 netcdf_output_at_levels: true
+ode_algo: ARS222
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 prognostic_tke: true
 rad: "allskywithclear"

--- a/config/atmos_configs/climaatmos_wx_diagedmf.yml
+++ b/config/atmos_configs/climaatmos_wx_diagedmf.yml
@@ -16,6 +16,7 @@ dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
 aerosol_radiation: true
 # time_varying_trace_gases: ["CO2", "O3"]
+ode_algo: ARS343
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 turbconv: diagnostic_edmfx
 implicit_diffusion: true

--- a/config/atmos_configs/climaatmos_wx_progedmf.yml
+++ b/config/atmos_configs/climaatmos_wx_progedmf.yml
@@ -15,6 +15,7 @@ rad: allskywithclear
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
 # time_varying_trace_gases: ["CO2", "O3"]
+ode_algo: ARS222
 prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
 turbconv: "prognostic_edmfx"
 implicit_diffusion: true

--- a/config/longrun_configs/amip_diagedmf_land.yml
+++ b/config/longrun_configs/amip_diagedmf_land.yml
@@ -18,7 +18,6 @@ initial_condition: "AMIPFromERA5"
 land_model: "integrated"
 mode_name: "amip"
 netcdf_output_at_levels: true
-ode_algo: "ARS343"
 output_default_diagnostics: true
 rmse_check: true
 start_date: "20100101"

--- a/config/longrun_configs/amip_diagedmf_land_p2k.yml
+++ b/config/longrun_configs/amip_diagedmf_land_p2k.yml
@@ -19,7 +19,6 @@ initial_condition: "AMIPFromERA5"
 land_model: "integrated"
 mode_name: "amip"
 netcdf_output_at_levels: true
-ode_algo: "ARS343"
 output_default_diagnostics: true
 rmse_check: true
 sst_adjustment: 2.0

--- a/config/longrun_configs/amip_edonly.yml
+++ b/config/longrun_configs/amip_edonly.yml
@@ -18,7 +18,6 @@ extra_atmos_diagnostics:
 initial_condition: "AMIPFromERA5"
 mode_name: "amip"
 netcdf_interpolate_z_over_msl: true
-ode_algo: "ARS232"
 output_default_diagnostics: true
 rmse_check: true
 start_date: "20100101"

--- a/config/longrun_configs/amip_progedmf_1m_land.yml
+++ b/config/longrun_configs/amip_progedmf_1m_land.yml
@@ -16,7 +16,6 @@ land_model: "integrated"
 microphysics_model: "1M"
 mode_name: "amip"
 netcdf_output_at_levels: true
-ode_algo: "ARS222"
 output_default_diagnostics: true
 radiation_reset_rng_seed: true
 start_date: "20100101"

--- a/config/longrun_configs/amip_progedmf_land.yml
+++ b/config/longrun_configs/amip_progedmf_land.yml
@@ -15,7 +15,6 @@ extra_atmos_diagnostics:
 land_model: "integrated"
 mode_name: "amip"
 netcdf_output_at_levels: true
-ode_algo: "ARS222"
 output_default_diagnostics: true
 radiation_reset_rng_seed: true
 start_date: "20100101"

--- a/config/nightly_configs/amip_coarse_diagedmf_1m_land.yml
+++ b/config/nightly_configs/amip_coarse_diagedmf_1m_land.yml
@@ -22,7 +22,6 @@ insolation: "timevarying"
 mode_name: "amip"
 netcdf_output_at_levels: true
 microphysics_model: "1M"
-ode_algo: "ARS343"
 output_default_diagnostics: true
 rmse_check: true
 start_date: "20100101"

--- a/config/nightly_configs/amip_coarse_diagedmf_land.yml
+++ b/config/nightly_configs/amip_coarse_diagedmf_land.yml
@@ -1,7 +1,7 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_diagedmf.yml"
-checkpoint_dt: "366days"
+checkpoint_dt: "1months"
 coupler_toml: ["toml/amip_diagedmf.toml"]
 dt: "240secs"
 dt_cpl: "240secs"
@@ -19,7 +19,6 @@ land_model: "integrated"
 mode_name: "amip"
 netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
-ode_algo: "ARS343"
 output_default_diagnostics: true
 radiation_reset_rng_seed: true
 start_date: "20100101"

--- a/config/nightly_configs/amip_coarse_progedmf_1m_land.yml
+++ b/config/nightly_configs/amip_coarse_progedmf_1m_land.yml
@@ -1,13 +1,11 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
-atmos_config_file: "config/atmos_configs/climaatmos_diagedmf.yml"
-bucket_albedo_type: "map_temporal"
+atmos_config_file: "config/atmos_configs/climaatmos_progedmf_1m.yml"
 checkpoint_dt: "1months"
-coupler_toml: ["toml/amip_diagedmf_1m.toml"]
-dt: "120secs"
-dt_cloud_fraction: "1hours"
-dt_cpl: "120secs"
-dt_rad: "1hours"
+coupler_toml: ["toml/amip_progedmf_1m.toml"]
+dt: "180secs"
+dt_cpl: "180secs"
+dz_bottom: 100.0
 energy_check: false
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]
@@ -15,15 +13,16 @@ extra_atmos_diagnostics:
     reduction_time: average
     pressure_coordinates: true
     compute_every: 6hours
-initial_condition: "AMIPFromERA5"
+h_elem: 8
 land_model: "integrated"
 mode_name: "amip"
+netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
-microphysics_model: "1M"
 output_default_diagnostics: true
-rmse_check: true
+radiation_reset_rng_seed: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "124days"
+t_end: "186days"
 topo_smoothing: true
 topography: "Earth"
+z_elem: 39

--- a/config/nightly_configs/amip_coarse_progedmf_land.yml
+++ b/config/nightly_configs/amip_coarse_progedmf_land.yml
@@ -1,7 +1,7 @@
 FLOAT_TYPE: "Float32"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_progedmf.yml"
-checkpoint_dt: "366days"
+checkpoint_dt: "1months"
 coupler_toml: ["toml/amip_progedmf.toml"]
 dt: "180secs"
 dt_cpl: "180secs"
@@ -18,7 +18,6 @@ land_model: "integrated"
 mode_name: "amip"
 netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
-ode_algo: "ARS222"
 output_default_diagnostics: true
 radiation_reset_rng_seed: true
 start_date: "20100101"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Also changes weekly amip to prognostic edmf 0M. Also adds ode_algo to atmos_configs so we don't need to specify it in coupler configs.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
