### PR TITLE
unify microphysics params in diagnostic and prognostic edmf

### DIFF
--- a/config/nightly_configs/amip_coarse_diagedmf_1m_land.yml
+++ b/config/nightly_configs/amip_coarse_diagedmf_1m_land.yml
@@ -26,7 +26,7 @@ output_default_diagnostics: true
 rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "186days"
+t_end: "366days"
 topo_smoothing: true
 topography: "Earth"
 z_elem: 39

--- a/config/nightly_configs/amip_coarse_diagedmf_land.yml
+++ b/config/nightly_configs/amip_coarse_diagedmf_land.yml
@@ -17,7 +17,6 @@ h_elem: 8
 initial_condition: "AMIPFromERA5"
 land_model: "integrated"
 mode_name: "amip"
-netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: true
 radiation_reset_rng_seed: true

--- a/config/nightly_configs/amip_coarse_progedmf_1m_land.yml
+++ b/config/nightly_configs/amip_coarse_progedmf_1m_land.yml
@@ -16,13 +16,12 @@ extra_atmos_diagnostics:
 h_elem: 8
 land_model: "integrated"
 mode_name: "amip"
-netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: true
 radiation_reset_rng_seed: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "186days"
+t_end: "366days"
 topo_smoothing: true
 topography: "Earth"
 z_elem: 39

--- a/config/nightly_configs/amip_coarse_progedmf_land.yml
+++ b/config/nightly_configs/amip_coarse_progedmf_land.yml
@@ -16,7 +16,6 @@ extra_atmos_diagnostics:
 h_elem: 8
 land_model: "integrated"
 mode_name: "amip"
-netcdf_interpolation_num_points: [90, 45, 31]
 netcdf_output_at_levels: true
 output_default_diagnostics: true
 radiation_reset_rng_seed: true

--- a/toml/amip_diagedmf.toml
+++ b/toml/amip_diagedmf.toml
@@ -77,7 +77,3 @@ type = "float"
 [precipitation_timescale]
 value = 1200
 type = "float"
-
-[Tq_correlation_coefficient]
-value = -1
-type = "float"

--- a/toml/amip_diagedmf_1m.toml
+++ b/toml/amip_diagedmf_1m.toml
@@ -74,26 +74,14 @@ type = "float"
 value = 0.29736273245468714
 type = "float"
 
-[Tq_correlation_coefficient]
-value = -1
-type = "float"
-
 [tracer_vertical_diffusion_factor]
 value = 0
 type = "float"
 
 [condensation_evaporation_timescale]
-value = 150
+value = 100
 type = "float"
 
 [sublimation_deposition_timescale]
-value = 150
-type = "float"
-
-[snow_autoconversion_timescale]
-value = 1e3
-type = "float"
-
-[rain_autoconversion_timescale]
-value = 150
+value = 100
 type = "float"

--- a/toml/amip_edonly.toml
+++ b/toml/amip_edonly.toml
@@ -37,7 +37,3 @@ type = "float"
 [precipitation_timescale]
 value = 1200
 type = "float"
-
-[Tq_correlation_coefficient]
-value = -1
-type = "float"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Diagnostic EDMF and Prognostic EDMF are using different microphysics parameters now. I changed them to be the same. These are not the best parameters. I will change them again once I have a better set of parameters.

Also removes user specified `netcdf_interpolation_num_points` so all the output are on the same grid, which is easier for comparison. Also extends t_end in nightly 1M jobs.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
