### PR TITLE
set ustar to non zero

### DIFF
--- a/ext/ClimaCouplerClimaAtmosExt.jl
+++ b/ext/ClimaCouplerClimaAtmosExt.jl
@@ -464,6 +464,7 @@ function FluxCalculator.update_turbulent_fluxes!(sim::ClimaAtmosSimulation, fiel
     temp_field_surface = sim.integrator.p.scratch.ᶠtemp_field_level
 
     Y = sim.integrator.u
+    FT = eltype(sim.integrator.p.params)
     surface_local_geometry =
         CC.Fields.level(CC.Fields.local_geometry_field(Y.f), CC.Utilities.half)
     surface_normal = @. CA.C3(CA.unit_basis_vector_data(CA.C3, surface_local_geometry))
@@ -525,7 +526,8 @@ function FluxCalculator.update_turbulent_fluxes!(sim::ClimaAtmosSimulation, fiel
         buoyancy_flux,
     )
 
-    @. scalar_temp1 = sqrt(sqrt(F_turb_ρτxz^2 + F_turb_ρτyz^2) / ρ_atmos) # reuse (q_vap_atmos no longer needed)
+    # ustar needs to be non-zero for EDMF boundary conditions
+    @. scalar_temp1 = max(eps(FT), sqrt(sqrt(F_turb_ρτxz^2 + F_turb_ρτyz^2) / ρ_atmos)) # reuse (q_vap_atmos no longer needed)
     ustar = scalar_temp1 # rename for clarity
     Interfacer.remap!(sim.integrator.p.precomputed.sfc_conditions.ustar, ustar)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Fixes a bug in #1902 where ustar can be zero, which causes issues in EDMF boundary conditions.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
