### PR TITLE
CMIP cleanup

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -336,6 +336,17 @@ steps:
 
   - group: "CMIP"
     steps:
+      - label: "GPU CMIP: ClimaAtmos + bucket land + Oceananigans + ClimaSeaIce"
+        key: "gpu_cmip_oceananigans_climaseaice_bucket"
+        command: "julia -O0 --color=yes --project=experiments/CMIP/ experiments/CMIP/run_simulation.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice_bucket.yml --job_id gpu_cmip_oceananigans_climaseaice_bucket"
+        artifact_paths: "output/gpu_cmip_oceananigans_climaseaice_bucket/artifacts/*"
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+        retry: *retry_policy
+        agents:
+          slurm_mem: 20GB
+          slurm_gpus: 1
+
       - label: "GPU CMIP: ClimaAtmos + integrated land + Oceananigans + ClimaSeaIce"
         key: "gpu_cmip_oceananigans_climaseaice"
         command: "julia -O0 --color=yes --project=experiments/CMIP/ experiments/CMIP/run_simulation.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice.yml --job_id gpu_cmip_oceananigans_climaseaice"
@@ -347,6 +358,8 @@ steps:
           slurm_mem: 20GB
           slurm_gpus: 1
 
+  - group: "Calibration"
+    steps:
       - label: "AMIP calibration pipeline with emulated diagnostics"
         key: "amip_test_calibration"
         command:

--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -9,22 +9,16 @@ dt_land: "120secs" # 2 minutes
 dt_ocean: "360secs" # 6 minutes
 dt_rad: "1hours"
 dt_seaice: "360secs" # 6 minutes
-ocean_progress_interval: 1 
 energy_check: false
-h_elem: 16 # atmosphere
-h_elem_coupler: 64 # coupler
 ice_model: "clima_seaice"
 insolation: "timevarying"
 mode_name: "cmip"
-nh_poly: 3
-nh_poly_coupler: 2
 ocean_model: "oceananigans"
 ocean_diagnostic_interval: "1days"
 ocean_diagnostic_mode: "averaged"
 seaice_diagnostic_interval: "1days"
 seaice_diagnostic_mode: "averaged"
 rmse_check: true
-share_surface_space: false
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "366days"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR does 3 things:
- [x] Undo the high resolution boundary space for the CMIP+bucket longrun (which made last week's longrun fail [here](https://buildkite.com/clima/climacoupler-longruns/builds/1105#019e10e7-a8a4-4c2c-bba4-b9b194cc7eef)). See the passing longrun from this branch [here](https://buildkite.com/clima/climacoupler-longruns/builds/1106) (I canceled it to free up the GPU but it got past where it previously failed).
- [x] Add back the CMIP+bucket run to regular CI. Since we're actively debugging and changing CMIP a lot, I think this is worth the extra GPU usage
- [x] Remove progress printing in CMIP+bucket longrun, which clogs up the log a lot when not actively debugging
