### PR TITLE
Add sea-ice artifact for initialization

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -74,3 +74,7 @@ git-tree-sha1 = "c1c0a16127bd547124cdf7288140002d74846efe"
 
 [wxquest_initial_conditions]
 git-tree-sha1 = "85b1e3654fb88f19a715ea6c235e1d66f254d2e6"
+
+[ecco4_SIarea_SIheff_2010_01]
+git-tree-sha1 = "889d7209b1a3b066e2dd5b0dbf7a674e32e4a589"
+

--- a/experiments/CMIP/Manifest-v1.11.toml
+++ b/experiments/CMIP/Manifest-v1.11.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.9"
 manifest_format = "2.0"
-project_hash = "ffb8414753aaed439d19e599e119e4e795b9030a"
+project_hash = "6cb1bf2558553283a328fb24831b4e206a81f60a"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "bbc22a9a08a0ef6460041086d8a7b27940ed4ffd"
@@ -556,9 +556,9 @@ version = "1.8.1"
 
 [[deps.ClimaOcean]]
 deps = ["Adapt", "CFTime", "CUDA", "ClimaSeaIce", "CopernicusClimateDataStore", "CubicSplines", "DataDeps", "Dates", "DocStringExtensions", "Downloads", "Glob", "ImageMorphology", "JLD2", "KernelAbstractions", "MPI", "MeshArrays", "NCDatasets", "Oceananigans", "OffsetArrays", "PrecompileTools", "Printf", "Scratch", "SeawaterPolynomials", "StaticArrays", "Statistics", "Thermodynamics", "ZipFile"]
-git-tree-sha1 = "844bb9768f0382b0559398a65fbbdb981a58a28d"
+git-tree-sha1 = "6196f08be0d172985b52ccab8e41a10d2ca6a197"
 uuid = "0376089a-ecfe-4b0e-a64f-9c555d74d754"
-version = "0.9.6"
+version = "0.9.7"
 
     [deps.ClimaOcean.extensions]
     ClimaOceanCopernicusClimateDataStoreExt = "CopernicusClimateDataStore"

--- a/ext/ClimaCouplerCMIPExt/clima_seaice.jl
+++ b/ext/ClimaCouplerCMIPExt/clima_seaice.jl
@@ -8,6 +8,7 @@ import SurfaceFluxes.Parameters as SFP
 import Thermodynamics as TD
 import Dates
 import ClimaUtilities.TimeManager: ITime, date, counter, period
+import ClimaUtilities.ClimaArtifacts: @clima_artifact
 using StaticArrays
 
 # Rename ECCO password env variable to match ClimaOcean.jl
@@ -102,15 +103,28 @@ function ClimaSeaIceSimulation(
 
     # Initialize nonzero sea ice if start date provided
     if !isnothing(start_date)
+        # set up the `dir` keyword argument for `Metadatum`
+        if start_date == Dates.Date(2010, 1, 1)
+            # we have a ClimaArtifact saved for January 1, 2010 (so that CI can always run)
+            dir_kw = (; dir = @clima_artifact("ecco4_SIarea_SIheff_2010_01"))
+            @info "Using $(dir_kw.dir) ClimaArtifact for sea ice initialization on $(start_date)"
+        else
+            # otherwise, download the data
+            # (or load from scratchspace; ClimaOcean will automatically handle this)
+            dir_kw = (;)
+        end
+
         sic_metadata = CO.DataWrangling.Metadatum(
             :sea_ice_concentration,
             dataset = CO.DataWrangling.ECCO.ECCO4Monthly(),
-            date = start_date,
+            date = start_date;
+            dir_kw...,
         )
         h_metadata = CO.DataWrangling.Metadatum(
             :sea_ice_thickness,
             dataset = CO.DataWrangling.ECCO.ECCO4Monthly(),
-            date = start_date,
+            date = start_date;
+            dir_kw...,
         )
 
         OC.set!(ice.model.ice_concentration, sic_metadata)


### PR DESCRIPTION
## Purpose 

Partially completes #1533

See the corresponding [PR in ClimaArtifacts](https://github.com/CliMA/ClimaArtifacts/pull/160).

## To-do

- [x] Add `ecco4_SIarea_SIheff_2010_01` artifact to `Artifacts.toml`
- [x] Make sure the artifact is loaded in `ext/ClimaCouplerCMIPExt/clima_seaice.jl` when `start_date` is January 1, 2010, otherwise revert to downloading the data

In #1533 the EN4 T and S datasets were also mentioned, but I'll do that in a separate PR (or skip if no longer needed?).