### PR TITLE
update prescribed ocean/sea ice every 1 day

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@ ClimaCoupler.jl Release Notes
 `main`
 -------
 
+#### Update SST, SIC at monthly frequency PR[#1926](https://github.com/CliMA/ClimaCoupler.jl/pull/1926)
+For prescribed ocean and sea ice models, read in SST and SIC
+data monthly instead of at the model timestep. These data have
+monthly averages, so it doesn't make sense to interpolate them
+to more than daily.
+
 #### Remove perfect model calibration experiment PR[#1835](https://github.com/CliMA/ClimaCoupler.jl/pull/1835)
 Remove some GPU jobs from CI to reduce impact of long wait times.
 Also deletes the perfect model calibration altogether, which is

--- a/src/Models/prescr_ocean.jl
+++ b/src/Models/prescr_ocean.jl
@@ -13,7 +13,8 @@ import Dates
 import ClimaAtmos as CA # for albedo calculation
 import LinearAlgebra
 import ClimaComms
-import ..Checkpointer, ..FieldExchanger, ..Interfacer
+import ClimaDiagnostics as CD
+import ..Checkpointer, ..FieldExchanger, ..Interfacer, ..TimeManager
 
 """
     PrescribedOceanSimulation{C}
@@ -128,6 +129,13 @@ function PrescribedOceanSimulation(
     t_start = first(tspan)
     evaluate!(SST_init, SST_timevaryinginput, t_start)
 
+    # Create a schedule to update the SST daily. The data provides monthly
+    # averages, so it doesn't make sense to update the SST more frequently than daily.
+    SST_schedule = CD.Schedules.EveryCalendarDtSchedule(
+        TimeManager.time_to_period("1days");
+        start_date,
+    )
+
     # COARE3 roughness params (allocated once, reused each timestep)
     coare3_roughness_params = CC.Fields.Field(SF.COARE3RoughnessParams{FT}, boundary_space)
     coare3_roughness_params .= SF.COARE3RoughnessParams{FT}()
@@ -143,9 +151,10 @@ function PrescribedOceanSimulation(
         v_int = zeros(boundary_space),
         area_fraction = ones(boundary_space),
         phase = TD.Liquid(),
-        thermo_params = thermo_params,
-        SST_timevaryinginput = SST_timevaryinginput,
-        start_date = start_date,
+        thermo_params,
+        SST_timevaryinginput,
+        SST_schedule,
+        start_date,
         t = Ref(t_start),
         coare3_roughness_params,
     )
@@ -184,14 +193,20 @@ end
     Interfacer.step!(sim::PrescribedOceanSimulation, t)
 
 Update the cached surface temperature field using the prescribed data
-at each timestep.
+at the frequency specified by the schedule (daily by default).
+Also updates the current time in the simulation cache.
+
+`EveryCalendarDtSchedule` expects an integrator-like object with a `.t` field
+so we wrap `t` in a NamedTuple.
 """
 function Interfacer.step!(sim::PrescribedOceanSimulation, t::Float64)
-    evaluate!(sim.cache.T_sfc, sim.cache.SST_timevaryinginput, t)
+    sim.cache.SST_schedule((; t)) &&
+        evaluate!(sim.cache.T_sfc, sim.cache.SST_timevaryinginput, t)
     sim.cache.t[] = t
 end
 function Interfacer.step!(sim::PrescribedOceanSimulation, t::ITime)
-    evaluate!(sim.cache.T_sfc, sim.cache.SST_timevaryinginput, t)
+    sim.cache.SST_schedule((; t)) &&
+        evaluate!(sim.cache.T_sfc, sim.cache.SST_timevaryinginput, t)
     sim.cache.t[] = t
 end
 

--- a/src/Models/prescr_seaice.jl
+++ b/src/Models/prescr_seaice.jl
@@ -5,9 +5,10 @@ import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput, evaluate!
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
 import Interpolations # triggers InterpolationsExt in ClimaUtilities
 import Thermodynamics as TD
-import ..Checkpointer, ..FluxCalculator, ..Interfacer, ..Utilities
+import ..Checkpointer, ..FluxCalculator, ..Interfacer, ..Utilities, ..TimeManager
 import ClimaComms
 import NCDatasets
+import ClimaDiagnostics as CD
 
 """
     PrescribedIceSimulation{P, I}
@@ -309,14 +310,41 @@ function PrescribedIceSimulation(
         tspan = Float64.(tspan)
         saveat = Float64.(saveat)
     end
+
+    # Create a schedule to update the SIC daily. The data provides monthly
+    # averages, so it doesn't make sense to update the SIC more frequently than daily.
+    SIC_schedule = CD.Schedules.EveryCalendarDtSchedule(
+        TimeManager.time_to_period("1days");
+        start_date,
+    )
+    SIC_update_cb =
+        CTS.DiscreteCallback((_, _, integrator) -> SIC_schedule(integrator), read_sic_data!)
+
     problem = CTS.ODEProblem(ode_function, Y, tspan, (; cache..., params = params))
-    integrator = CTS.init(problem, ode_algo, dt = dt, saveat = saveat, adaptive = false)
+    integrator = CTS.init(
+        problem,
+        ode_algo,
+        dt = dt,
+        saveat = saveat,
+        adaptive = false,
+        callback = CTS.CallbackSet(SIC_update_cb),
+    )
 
     sim = PrescribedIceSimulation(params, integrator)
 
     # DSS state to ensure we have continuous fields
     dss_state!(sim)
     return sim
+end
+
+"""
+    read_sic_data!(integrator)
+
+Read in the sea ice concentration data at the current time.
+This function is intended to be used within a callback.
+"""
+function read_sic_data!(integrator)
+    evaluate!(integrator.p.area_fraction, integrator.p.SIC_timevaryinginput, integrator.t)
 end
 
 # extensions required by Interfacer
@@ -430,7 +458,6 @@ function ice_rhs!(dY, Y, p, t)
     if p.domain_type == "column"
         @. p.area_fraction = FT(1)
     else
-        evaluate!(p.area_fraction, p.SIC_timevaryinginput, t)
         @. p.area_fraction = ifelse(isfinite(p.area_fraction), p.area_fraction, FT(0))
         # binary ice fraction (threshold at 0.5)
         if p.binary_area_fraction


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Update SST and SIC at daily frequency for prescribed ocean/sea ice models.  The energy equation solved by prescribed sea ice is still computed at the model dt.

Revived version of #1219

Buildkite results look unchanged