### PR TITLE
don't apply polar mask for ocean/ice interactions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -346,9 +346,10 @@ steps:
 
   - group: "CMIP"
     steps:
+      # Enforce strict bounds checking to avoid silent out of bounds errors
       - label: "GPU CMIP: ClimaAtmos + bucket land + Oceananigans + ClimaSeaIce"
         key: "gpu_cmip_oceananigans_climaseaice_bucket"
-        command: "julia -O0 --color=yes --project=experiments/CMIP/ experiments/CMIP/run_simulation.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice_bucket.yml --job_id gpu_cmip_oceananigans_climaseaice_bucket"
+        command: "julia -O0 --check-bounds=yes --color=yes --project=experiments/CMIP/ experiments/CMIP/run_simulation.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice_bucket.yml --job_id gpu_cmip_oceananigans_climaseaice_bucket"
         artifact_paths: "output/gpu_cmip_oceananigans_climaseaice_bucket/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"

--- a/ext/ClimaCouplerCMIPExt/clima_seaice.jl
+++ b/ext/ClimaCouplerCMIPExt/clima_seaice.jl
@@ -539,11 +539,6 @@ function FluxCalculator.ocean_seaice_fluxes!(
     ρτxio = ice_sim.ocean_ice_interface.fluxes.x_momentum # sea_ice - ocean zonal momentum flux
     ρτyio = ice_sim.ocean_ice_interface.fluxes.y_momentum # sea_ice - ocean meridional momentum flux
 
-    # mask out the poles
-    polar_mask = ocean_sim.remapping.polar_mask
-    @. ρτxio = polar_mask * ρτxio
-    @. ρτyio = polar_mask * ρτyio
-
     # Update the momentum flux contributions from ocean/sea ice fluxes
     arch = OC.Architectures.architecture(grid)
     OC.Utils.launch!(
@@ -565,15 +560,11 @@ function FluxCalculator.ocean_seaice_fluxes!(
     oc_flux_T = surface_flux(ocean_sim.ocean.model.tracers.T)
     heat_flux = OC.interior(ocean_sim.remapping.scratch_cc1, :, :, 1)
     heat_flux .= OC.interior(Qi, :, :, 1) .* ρₒ⁻¹ ./ cₒ
-    # mask out the poles
-    @. heat_flux = polar_mask * heat_flux
     OC.interior(oc_flux_T, :, :, 1) .+= heat_flux
 
     oc_flux_S = surface_flux(ocean_sim.ocean.model.tracers.S)
     salt_contrib = OC.interior(ocean_sim.remapping.scratch_cc2, :, :, 1)
     salt_contrib .= OC.interior(ice_sim.ocean_ice_interface.fluxes.salt, :, :, 1)
-    # mask out the poles
-    @. salt_contrib = polar_mask * salt_contrib
     OC.interior(oc_flux_S, :, :, 1) .+= salt_contrib
 
     return nothing


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Running CMIP on main with strict bounds checking enforced results in an out-of-bounds memory access error. This comes from applying the polar mask to the momentum fluxes between ocean and sea ice. Because ocean and sea ice exist on the same grid, we don't need to apply the polar mask to their interactions (only to atmos-surface interactions).

This PR removes the polar mask from the ocean/sea ice interactions, and adds `check-bounds=yes` to one CMIP run in CI, so that we can catch similar errors in the future.