### PR TITLE
precompile CMIP with strict bounds checking

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,10 +29,12 @@ steps:
       - "julia -O0 --project=experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'"
       - "julia -O0 --project=experiments/AMIP/ -e 'using Pkg; Pkg.status()'"
 
-      - echo "--- Instantiate CMIP experiments env"
-      - "julia -O0 --project=experiments/CMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia -O0 --project=experiments/CMIP/ -e 'using Pkg; Pkg.precompile()'"
-      - "julia -O0 --project=experiments/CMIP/ -e 'using Pkg; Pkg.status()'"
+      # Precompile CMIP with strict bounds checking to avoid precompilation in individual
+      # runs that use strict bounds checking.
+      - echo "--- Instantiate CMIP experiments env with strict bounds checking"
+      - "julia -O0 --check-bounds=yes --project=experiments/CMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia -O0 --check-bounds=yes --project=experiments/CMIP/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia -O0 --check-bounds=yes --project=experiments/CMIP/ -e 'using Pkg; Pkg.status()'"
 
       - echo "--- Instantiate test env"
       - "julia -O0 --project=test/ -e 'using Pkg; Pkg.develop(path=\".\")'"
@@ -323,7 +325,6 @@ steps:
 
   - group: "CMIP"
     steps:
-      # Enforce strict bounds checking to avoid silent out of bounds errors
       - label: "GPU CMIP: ClimaAtmos + bucket land + Oceananigans + ClimaSeaIce"
         key: "gpu_cmip_oceananigans_climaseaice_bucket"
         command: "julia -O0 --check-bounds=yes --color=yes --project=experiments/CMIP/ experiments/CMIP/run_simulation.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice_bucket.yml --job_id gpu_cmip_oceananigans_climaseaice_bucket"
@@ -337,7 +338,7 @@ steps:
 
       - label: "GPU CMIP: ClimaAtmos + integrated land + Oceananigans + ClimaSeaIce"
         key: "gpu_cmip_oceananigans_climaseaice"
-        command: "julia -O0 --color=yes --project=experiments/CMIP/ experiments/CMIP/run_simulation.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice.yml --job_id gpu_cmip_oceananigans_climaseaice"
+        command: "julia -O0 --check-bounds=yes --color=yes --project=experiments/CMIP/ experiments/CMIP/run_simulation.jl --config_file $CONFIG_PATH/cmip_oceananigans_climaseaice.yml --job_id gpu_cmip_oceananigans_climaseaice"
         artifact_paths: "output/gpu_cmip_oceananigans_climaseaice/artifacts/*"
         env:
           CLIMACOMMS_DEVICE: "CUDA"

--- a/config/ci_configs/cmip_oceananigans_climaseaice.yml
+++ b/config/ci_configs/cmip_oceananigans_climaseaice.yml
@@ -22,7 +22,7 @@ rayleigh_sponge: true
 simple_ocean: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "1days"
+t_end: "12hours"
 topo_smoothing: true
 topography: "Earth"
 viscous_sponge: true

--- a/config/ci_configs/cmip_oceananigans_climaseaice_bucket.yml
+++ b/config/ci_configs/cmip_oceananigans_climaseaice_bucket.yml
@@ -21,7 +21,7 @@ rayleigh_sponge: true
 simple_ocean: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "1days"
+t_end: "12hours"
 topo_smoothing: true
 topography: "Earth"
 viscous_sponge: true


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
~~#1935 added strict bounds checking to a CMIP run in CI, but that run now takes 2 hours 🤯 This PR adds a run to CI that only runs CMIP for one timestep with strict bounds checking.~~

~~If this is still too slow (> 40 minutes?), another solution is to add a run that only initializes CMIP with strict bounds checking, and then add a run to the longrun pipeline that takes a few steps. The bug that was fixed in #1935 would have been caught by the initialization alone.~~

~~Update: now each of the CMIP runs takes <= 30 minutes (and are not the longest runs in CI), so I think this is a good solution~~

Update 2:
#1935 added strict bounds checking to a CMIP run in CI, and the first run of that simulation took 2 hours.
The first run of the new strictly-bounded run took 2 hours (see [here](https://buildkite.com/clima/climacoupler-ci/builds/8895)), but the second took only ~38 mins (see [here](https://buildkite.com/clima/climacoupler-ci/builds/8896#019e41f2-4d3d-46f0-aa95-c278231d66de)). This is because the depot we use to avoid precompiling in each build/run includes the `check-bounds` flag in its hash. So when we changed that flag for a single run, precompilation got triggered for that run (which you can see in the logs). The second run was much shorter because it was a cache hit and didn't have to precompile again.

I'm keeping the run, but changing both CMIP runs in the CI pipeline to use `check-bounds=yes`. This way we don't need to precompile CMIP with both `check-bounds` options, and we can still test the behavior with strict bounds. The runs seem to be about 35% slower with `check-bounds=yes`, so to offset this slowdown I decreased the run length of the CMIP runs in regular CI. I think this is fine because these are not physically-meaningful runs anyway - their primary purpose is to exercise the software pipes of the simulations.