### PR TITLE
shorten github actions runtime

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,9 +91,9 @@ steps:
           slurm_gpus: 1
           slurm_mem: 24GB
 
-  - group: "Experiment tests"
+  - group: "Experiment unit tests"
     steps:
-      - label: "AMIP runtests"
+      - label: "Experiments runtests"
         command: "julia -O0 --color=yes --project=experiments/AMIP/ experiments/test/runtests.jl"
         retry: *retry_policy
         agents:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,3 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: lcov.info
-      - run: |
-          julia -O0 --color=yes --project=experiments/AMIP -e 'using Pkg; Pkg.instantiate()'
-          julia -O0 --color=yes --project=experiments/AMIP -e 'using Pkg; Pkg.develop(; path = ".")'
-          julia -O0 --color=yes --project=experiments/AMIP experiments/test/runtests.jl


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
After #1937, buildkite now runs in < 1 hour, and GHA has become the bottleneck to merge PRs.

Following Henry's comment on that PR https://github.com/CliMA/ClimaCoupler.jl/pull/1937#issuecomment-4512451686 I realized that we run the experiments runtests.jl in both GHA and buildkite. It's sufficient to test it on one platform, and on buildkite we have more resources available to parallelize across, so in this PR I remove that test set from the GHA CI workflow.