### PR TITLE
Create weekly buildkite calibration pipeline 

### DIFF
--- a/.buildkite/calibrate/pipeline.yml
+++ b/.buildkite/calibrate/pipeline.yml
@@ -1,0 +1,52 @@
+agents:
+  queue: derecho
+  modules: climacommon/2025_02_25
+  pbs_l_select: "1:ncpus=1"
+
+env:
+  CONFIG_PATH: "config/nightly_configs"
+  BENCHMARK_CONFIG_PATH: "config/benchmark_configs"
+
+steps:
+  - label: "init"
+    key: "init_env"
+    command:
+      - "echo $$JULIA_DEPOT_PATH"
+
+      - echo "--- Instantiate AMIP env"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+
+      # For this pipeline, use the main branches of certain upstream packages
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaAtmos\", rev=\"main\"))'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaCore\", rev=\"main\"))'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaTimeSteppers\", rev=\"main\"))'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"Thermodynamics\", rev=\"main\"))'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"SurfaceFluxes\", rev=\"main\"))'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"RRTMGP\", rev=\"main\"))'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.resolve()'"
+
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.status()'"
+
+    env:
+      JULIA_NUM_PRECOMPILE_TASKS: 8
+      JULIA_MAX_NUM_PRECOMPILE_FILES: 50
+
+  - wait
+  - group: "Flagship AMIP calibration"
+    steps:
+    - label: "Generate observations"
+      key: "gen_obs"
+      command:
+      - julia --project=experiments/AMIP/ experiments/calibration/amip/generate_observations.jl
+
+    - label: "Run calibration"
+      depends_on: "gen_obs"
+      command:
+        - julia --project=experiments/AMIP/ experiments/calibration/amip/run_calibration.jl
+      agents:
+        pbs_l_walltime: "12:00:00"
+      retry:
+        automatic:
+          - exit_status: -1
+            limit: 3

--- a/.buildkite/calibrate/pipeline.yml
+++ b/.buildkite/calibrate/pipeline.yml
@@ -3,10 +3,6 @@ agents:
   modules: climacommon/2025_02_25
   pbs_l_select: "1:ncpus=1"
 
-env:
-  CONFIG_PATH: "config/nightly_configs"
-  BENCHMARK_CONFIG_PATH: "config/benchmark_configs"
-
 steps:
   - label: "init"
     key: "init_env"
@@ -14,19 +10,20 @@ steps:
       - "echo $$JULIA_DEPOT_PATH"
 
       - echo "--- Instantiate AMIP env"
-      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'
 
       # For this pipeline, use the main branches of certain upstream packages
-      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaAtmos\", rev=\"main\"))'"
-      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaCore\", rev=\"main\"))'"
-      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaTimeSteppers\", rev=\"main\"))'"
-      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"Thermodynamics\", rev=\"main\"))'"
-      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"SurfaceFluxes\", rev=\"main\"))'"
-      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"RRTMGP\", rev=\"main\"))'"
-      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.resolve()'"
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="ClimaAtmos", rev="main"))'
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="ClimaCore", rev="main"))'
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="ClimaTimeSteppers", rev="main"))'
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="Thermodynamics", rev="main"))'
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="SurfaceFluxes", rev="main"))'
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="RRTMGP", rev="main"))'
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="ClimaCalibrate", rev="ne/fix"))'
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.resolve()'
 
-      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'"
-      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.status()'"
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.status()'
 
     env:
       JULIA_NUM_PRECOMPILE_TASKS: 8

--- a/.buildkite/calibrate/pipeline.yml
+++ b/.buildkite/calibrate/pipeline.yml
@@ -1,29 +1,14 @@
 agents:
   queue: derecho
   modules: climacommon/2025_02_25
-  pbs_l_select: "1:ncpus=1"
+  pbs_l_select: "1:ncpus=1:ngpus=1"
 
 steps:
   - label: "init"
     key: "init_env"
     command:
-      - "echo $$JULIA_DEPOT_PATH"
-
       - echo "--- Instantiate AMIP env"
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'
-
-      # For this pipeline, use the main branches of certain upstream packages
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="ClimaAtmos", rev="main"))'
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="ClimaCore", rev="main"))'
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="ClimaTimeSteppers", rev="main"))'
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="Thermodynamics", rev="main"))'
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="SurfaceFluxes", rev="main"))'
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="RRTMGP", rev="main"))'
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name="ClimaCalibrate", rev="ne/fix"))'
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.resolve()'
-
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'
-      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.status()'
+      - julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true); Pkg.status()'
 
     env:
       JULIA_NUM_PRECOMPILE_TASKS: 8

--- a/experiments/AMIP/Manifest-v1.11.toml
+++ b/experiments/AMIP/Manifest-v1.11.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.9"
+julia_version = "1.11.3"
 manifest_format = "2.0"
 project_hash = "3cd138cabaaff51c2ac59c93a155174299570e00"
 
@@ -2278,7 +2278,7 @@ version = "2.5.5+0"
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.8.5+0"
+version = "0.8.1+2"
 
 [[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]

--- a/experiments/AMIP/Manifest-v1.11.toml
+++ b/experiments/AMIP/Manifest-v1.11.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.3"
+julia_version = "1.11.9"
 manifest_format = "2.0"
 project_hash = "3cd138cabaaff51c2ac59c93a155174299570e00"
 
@@ -2278,7 +2278,7 @@ version = "2.5.5+0"
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.8.1+2"
+version = "0.8.5+0"
 
 [[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]

--- a/experiments/AMIP/Project.toml
+++ b/experiments/AMIP/Project.toml
@@ -37,7 +37,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 CUDA = "5"
-ClimaCalibrate = "0.3"
+ClimaCalibrate = "0.3.1"
 ClimaLand = "1.7"
 ClimaParams = "1.0"
 ClimaTimeSteppers = "0.8.11, 0.9"

--- a/experiments/calibration/amip/config/pressure_levels.jl
+++ b/experiments/calibration/amip/config/pressure_levels.jl
@@ -1,6 +1,6 @@
 # Define which coupler file to use
 config_file =
-    joinpath(pkgdir(ClimaCoupler), "config", "benchmark_configs", "amip_progedmf_1m_land_he16.yml")
+    joinpath(pkgdir(ClimaCoupler), "config", "amip_configs", "amip_calibration.yml")
 
 # Calibrate only on Jan 1 2010
 sample_date_ranges =
@@ -34,7 +34,7 @@ const NORMALIZATION_STATS_FP =
     joinpath(CALIBRATE_CONFIG.output_dir, "normalization_stats.jld2")
 
 const CALIBRATION_PRIORS = [
-    # PD.constrained_gaussian("precipitation_timescale", 1200, 300, 300, 2400),
+    PD.constrained_gaussian("precipitation_timescale", 1200, 300, 300, 2400),
     PD.constrained_gaussian("Tq_correlation_coefficient", 0.4, 0.4, -1.0, 1.0),
     PD.constrained_gaussian("mixing_length_eddy_viscosity_coefficient", 0.2, 0.1, 0, 1.0),
     PD.constrained_gaussian("mixing_length_diss_coeff", 0.22, 0.15, 0.0, 10.0),

--- a/experiments/calibration/amip/config/pressure_levels.jl
+++ b/experiments/calibration/amip/config/pressure_levels.jl
@@ -1,6 +1,6 @@
 # Define which coupler file to use
 config_file =
-    joinpath(pkgdir(ClimaCoupler), "config", "amip_configs", "amip_calibration.yml")
+    joinpath(pkgdir(ClimaCoupler), "config", "benchmark_configs", "amip_progedmf_1m_land_he16.yml")
 
 # Calibrate only on Jan 1 2010
 sample_date_ranges =
@@ -34,7 +34,7 @@ const NORMALIZATION_STATS_FP =
     joinpath(CALIBRATE_CONFIG.output_dir, "normalization_stats.jld2")
 
 const CALIBRATION_PRIORS = [
-    PD.constrained_gaussian("precipitation_timescale", 1200, 300, 300, 2400),
+    # PD.constrained_gaussian("precipitation_timescale", 1200, 300, 300, 2400),
     PD.constrained_gaussian("Tq_correlation_coefficient", 0.4, 0.4, -1.0, 1.0),
     PD.constrained_gaussian("mixing_length_eddy_viscosity_coefficient", 0.2, 0.1, 0, 1.0),
     PD.constrained_gaussian("mixing_length_diss_coeff", 0.22, 0.15, 0.0, 10.0),

--- a/experiments/calibration/amip/config/pressure_levels.jl
+++ b/experiments/calibration/amip/config/pressure_levels.jl
@@ -16,10 +16,10 @@ const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
     # pressure_coordinates: true in config
     short_names = ["ta", "hur"],
     minibatch_size = 1,
-    n_iterations = 6,
+    n_iterations = 5,
     sample_date_ranges,
     extend = Dates.Month(1),
-    spinup = Dates.Day(7),
+    spinup = Dates.Day(0),
     output_dir,
     rng_seed = 42,
 )

--- a/experiments/calibration/amip/model_interface.jl
+++ b/experiments/calibration/amip/model_interface.jl
@@ -49,7 +49,7 @@ function ClimaCalibrate.forward_model(interface::CouplerModelInterface, iter, me
     # Ensure the simulation restarts automatically
     config_dict["detect_restart_file"] = true
     config_dict["output_dir_style"] = "activelink"
-    config_dict["checkpoint_dt"] = "1days"
+    config_dict["checkpoint_dt"] = "10days"
 
     @info "Simulation dates" start_date end_date
 

--- a/experiments/calibration/amip/model_interface.jl
+++ b/experiments/calibration/amip/model_interface.jl
@@ -46,6 +46,10 @@ function ClimaCalibrate.forward_model(interface::CouplerModelInterface, iter, me
     member_output_dir =
         ClimaCalibrate.path_to_ensemble_member(output_dir_root, iter, member)
     config_dict["coupler_output_dir"] = member_output_dir
+    # Ensure the simulation restarts automatically
+    config_dict["detect_restart_file"] = true
+    config_dict["output_dir_style"] = "activelink"
+    config_dict["checkpoint_dt"] = "1days"
 
     @info "Simulation dates" start_date end_date
 

--- a/experiments/calibration/amip/run_calibration.jl
+++ b/experiments/calibration/amip/run_calibration.jl
@@ -96,12 +96,12 @@ if abspath(PROGRAM_FILE) == @__FILE__
             directives = [
                 # Options include "premium", "regular", "economy", "preempt"
                 :job_priority => "regular",
-                :time => 360,
+                :time => 720,
                 :ntasks => 1,
                 :cpus_per_task => 12,
                 :gpus_per_task => 1,
             ],
-            modules,
+            modules = ["climacommon/2025_02_25"],
             env_vars,
         )
     elseif ClimaCalibrate.get_backend() == ClimaCalibrate.GCPBackend

--- a/experiments/calibration/amip/run_calibration.jl
+++ b/experiments/calibration/amip/run_calibration.jl
@@ -96,8 +96,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
             directives = [
                 # Options include "premium", "regular", "economy", "preempt"
                 :job_priority => "regular",
-                # 720 minutes is 12 hours
-                :time => 720,
+                :time => 360,
                 :ntasks => 1,
                 :cpus_per_task => 12,
                 :gpus_per_task => 1,

--- a/ext/ClimaCouplerClimaAtmosExt.jl
+++ b/ext/ClimaCouplerClimaAtmosExt.jl
@@ -671,8 +671,7 @@ function get_atmos_config_dict(
     # Honor the coupler's output_dir_style if set (e.g. "activelink" so atmos
     # can auto-detect a restart file across runs); otherwise default to
     # RemovePreexisting.
-    atmos_config["output_dir_style"] =
-        get(coupler_config, "output_dir_style", "RemovePreexisting")
+    get!(atmos_config, "output_dir_style", "RemovePreexisting")
     atmos_config["output_dir"] = atmos_output_dir
 
     # Add all extra atmos diagnostic entries into the vector of atmos diagnostics

--- a/ext/ClimaCouplerClimaAtmosExt.jl
+++ b/ext/ClimaCouplerClimaAtmosExt.jl
@@ -667,8 +667,12 @@ function get_atmos_config_dict(
     atmos_toml = CP.create_toml_dict(FT; override_file)
     toml_dict = CP.merge_override_default_values(coupled_param_dict, atmos_toml)
 
-    # Specify atmos output directory to be inside the coupler output directory
-    atmos_config["output_dir_style"] = "RemovePreexisting"
+    # Specify atmos output directory to be inside the coupler output directory.
+    # Honor the coupler's output_dir_style if set (e.g. "activelink" so atmos
+    # can auto-detect a restart file across runs); otherwise default to
+    # RemovePreexisting.
+    atmos_config["output_dir_style"] =
+        get(coupler_config, "output_dir_style", "RemovePreexisting")
     atmos_config["output_dir"] = atmos_output_dir
 
     # Add all extra atmos diagnostic entries into the vector of atmos diagnostics


### PR DESCRIPTION
This PR adds a buildkite pipeline to run the existing calibration config in `pressure_levels.jl` on a weekly schedule. The goal is to automate calibration results and ensure that we can restart and run many iterations.

See build here: https://buildkite.com/clima/climacoupler-calibration/builds/20#019eab48-e4c3-4ca3-9637-497eb820d218