### PR TITLE
produce monthly average diagnostics in CMIP longruns

### DIFF
--- a/config/longrun_configs/cmip_diagedmf_land.yml
+++ b/config/longrun_configs/cmip_diagedmf_land.yml
@@ -2,8 +2,8 @@ FLOAT_TYPE: "Float64"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_diagedmf.yml"
 checkpoint_dt: "1months"
-coupler_diagnostics_period: "1days"
-coupler_diagnostics_reduction: "instantaneous"
+coupler_diagnostics_period: "1months"
+coupler_diagnostics_reduction: "average"
 coupler_toml: ["toml/amip_diagedmf.toml"]
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
@@ -15,24 +15,24 @@ dt_seaice: "360secs" # 6 minutes
 energy_check: false
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]
-    period: 1days
-    reduction_time: inst
+    period: 1months
+    reduction_time: average
     pressure_coordinates: true
-    compute_every: 1days
+    compute_every: 6hours
 ice_model: "clima_seaice"
 insolation: "timevarying"
-land_diagnostics_period: "1days"
-land_diagnostics_reduction: "instantaneous"
+land_diagnostics_period: "1months"
+land_diagnostics_reduction: "average"
 land_model: "integrated"
 land_spun_up_ic: false
 mode_name: "cmip"
 ocean_model: "oceananigans"
-ocean_diagnostic_interval: "1days"
-ocean_diagnostic_mode: "instantaneous"
-output_default_diagnostics: false
+ocean_diagnostic_interval: "1months"
+ocean_diagnostic_mode: "average"
+output_default_diagnostics: true
 rmse_check: true
-seaice_diagnostic_interval: "1days"
-seaice_diagnostic_mode: "instantaneous"
+seaice_diagnostic_interval: "1months"
+seaice_diagnostic_mode: "average"
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "186days"

--- a/config/longrun_configs/cmip_edonly_bucket.yml
+++ b/config/longrun_configs/cmip_edonly_bucket.yml
@@ -2,8 +2,8 @@ FLOAT_TYPE: "Float64"
 atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 bucket_albedo_type: "map_temporal"
 checkpoint_dt: "1months"
-coupler_diagnostics_period: "1days"
-coupler_diagnostics_reduction: "instantaneous"
+coupler_diagnostics_period: "1months"
+coupler_diagnostics_reduction: "average"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
 dt_cpl: "360secs" # 6 minutes
@@ -14,15 +14,15 @@ dt_seaice: "360secs" # 6 minutes
 energy_check: false
 ice_model: "clima_seaice"
 insolation: "timevarying"
-land_diagnostics_period: "1days"
-land_diagnostics_reduction: "instantaneous"
+land_diagnostics_period: "1months"
+land_diagnostics_reduction: "average"
 mode_name: "cmip"
 ocean_model: "oceananigans"
-ocean_diagnostic_interval: "1days"
-ocean_diagnostic_mode: "instantaneous"
-output_default_diagnostics: false
-seaice_diagnostic_interval: "1days"
-seaice_diagnostic_mode: "instantaneous"
+ocean_diagnostic_interval: "1months"
+ocean_diagnostic_mode: "average"
+output_default_diagnostics: true
+seaice_diagnostic_interval: "1months"
+seaice_diagnostic_mode: "average"
 rmse_check: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
@@ -31,7 +31,7 @@ topo_smoothing: true
 topography: "Earth"
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]
-    period: 1days
-    reduction_time: inst
+    period: 1months
+    reduction_time: average
     pressure_coordinates: true
-    compute_every: 1days
+    compute_every: 6hours

--- a/config/longrun_configs/cmip_edonly_land.yml
+++ b/config/longrun_configs/cmip_edonly_land.yml
@@ -1,8 +1,8 @@
 FLOAT_TYPE: "Float64"
 atmos_config_file: "config/atmos_configs/climaatmos_edonly.yml"
 checkpoint_dt: "1months"
-coupler_diagnostics_period: "1days"
-coupler_diagnostics_reduction: "instantaneous"
+coupler_diagnostics_period: "1months"
+coupler_diagnostics_reduction: "average"
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
 dt_cpl: "360secs" # 6 minutes
@@ -13,24 +13,24 @@ dt_seaice: "360secs" # 6 minutes
 energy_check: false
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]
-    period: 1days
-    reduction_time: inst
+    period: 1months
+    reduction_time: average
     pressure_coordinates: true
-    compute_every: 1days
+    compute_every: 6hours
 ice_model: "clima_seaice"
 insolation: "timevarying"
-land_diagnostics_period: "1days"
-land_diagnostics_reduction: "instantaneous"
+land_diagnostics_period: "1months"
+land_diagnostics_reduction: "average"
 land_model: "integrated"
 land_spun_up_ic: false
 mode_name: "cmip"
 ocean_model: "oceananigans"
-ocean_diagnostic_interval: "1days"
-ocean_diagnostic_mode: "instantaneous"
-output_default_diagnostics: false
+ocean_diagnostic_interval: "1months"
+ocean_diagnostic_mode: "average"
+output_default_diagnostics: true
 rmse_check: true
-seaice_diagnostic_interval: "1days"
-seaice_diagnostic_mode: "instantaneous"
+seaice_diagnostic_interval: "1months"
+seaice_diagnostic_mode: "average"
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "366days"

--- a/config/longrun_configs/cmip_progedmf_land.yml
+++ b/config/longrun_configs/cmip_progedmf_land.yml
@@ -2,8 +2,8 @@ FLOAT_TYPE: "Float64"
 albedo_model: "CouplerAlbedo"
 atmos_config_file: "config/atmos_configs/climaatmos_progedmf.yml"
 checkpoint_dt: "1months"
-coupler_diagnostics_period: "1days"
-coupler_diagnostics_reduction: "instantaneous"
+coupler_diagnostics_period: "1months"
+coupler_diagnostics_reduction: "average"
 coupler_toml: ["toml/amip_progedmf.toml"]
 dt_atmos: "120secs" # 2 minutes
 dt_cloud_fraction: "1hours"
@@ -15,24 +15,24 @@ dt_seaice: "360secs" # 6 minutes
 energy_check: false
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]
-    period: 1days
-    reduction_time: inst
+    period: 1months
+    reduction_time: average
     pressure_coordinates: true
-    compute_every: 1days
+    compute_every: 6hours
 ice_model: "clima_seaice"
 insolation: "timevarying"
-land_diagnostics_period: "1days"
-land_diagnostics_reduction: "instantaneous"
+land_diagnostics_period: "1months"
+land_diagnostics_reduction: "average"
 land_model: "integrated"
 land_spun_up_ic: false
 mode_name: "cmip"
 ocean_model: "oceananigans"
-ocean_diagnostic_interval: "1days"
-ocean_diagnostic_mode: "instantaneous"
-output_default_diagnostics: false
+ocean_diagnostic_interval: "1months"
+ocean_diagnostic_mode: "average"
+output_default_diagnostics: true
 rmse_check: true
-seaice_diagnostic_interval: "1days"
-seaice_diagnostic_mode: "instantaneous"
+seaice_diagnostic_interval: "1months"
+seaice_diagnostic_mode: "average"
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "186days"

--- a/ext/ClimaCouplerMakieExt/leaderboard/leaderboard.jl
+++ b/ext/ClimaCouplerMakieExt/leaderboard/leaderboard.jl
@@ -79,6 +79,12 @@ function Plotting.compute_leaderboard(
         )
     end
 
+    # If there is no monthly data available, skip the leaderboard
+    if isempty(sim_obs_comparsion_dict)
+        @warn "No monthly data available. Leaderboard will not be made."
+        return nothing
+    end
+
     # Filter seasons to remove seasons with no dates
     _, var = first(sim_obs_comparsion_dict)
     filter!(season -> !ClimaAnalysis.isempty(var[season][1]), seasons)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This week's [CMIP longruns](https://buildkite.com/clima/climacoupler-longruns/builds/1113#019e5900-a46e-4be7-99ab-97dd67404610) failed because monthly atmospheric diagnostics were not available to produce the leaderboard, after the changes from #1939. This PR switches the configs for these runs back to monthly average diagnostics, and also adds a check in the leaderboard code to give a more informative error if something like this happens in the future.

## To-do
- [x] check if no monthly diagnostics are available for leaderboard -- if so, produce a warning and skip the leaderboard
- [x] revert back to monthly average atmosphere diagnostics in CMIP longruns
- [x] use monthly average diagnostics for all components in CMIP longruns so they're all consistent (we can still change this as needed for debugging, but we'll keep monthly for the scheduled longruns)

After review, I'll merge this PR without running CI because it only touches code exercised in longruns.