### PR TITLE
Prevent dependabot from pushing doc previews

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -86,7 +86,10 @@ makedocs(
 
 deploydocs(
     repo = "github.com/CliMA/ClimaCoupler.jl.git",
-    push_preview = true,
+    push_preview = all(
+        !isempty,
+        (get(ENV, "GITHUB_TOKEN", ""), get(ENV, "DOCUMENTER_KEY", "")),
+    ),
     devbranch = "main",
     forcepush = true,
     versions = ["stable" => "v^", "v#.#.#", "dev" => "main"],


### PR DESCRIPTION
See [issue](JuliaDocs/Documenter.jl#2048) in
Documenter.jl. This is the solution suggested there.

This implements a change made in [this])https://github.com/CliMA/ClimaAtmos.jl/pull/4501) ClimaAtmos PR.

There are a few dependabot PRs that cannot merge because docbuild fails on push.

