### PR TITLE
add to docs

### DIFF
--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -24,7 +24,13 @@ abstractions), see [`docs/clima_coupler_specific.md`](https://github.com/CliMA/C
     the vendored copy here. The subtree is synced monthly via
     `.github/workflows/update_dev_guides.yml`.
 
-## Some useful tips
+## Modern Julia Workflows (general development advice)
+For tips on writing, sharing, and optimizing Julia packages — including development workflows,
+testing, documentation, and performance — see [Modern Julia Workflows](https://modernjuliaworkflows.org).
+The site includes general tips on everything from setting up your editor and managing environments,
+to registering your package and reducing compilation latency.
+
+## Other useful tips
 - When developing code it's best to work on a branch off of the most recent main.
 This can be done by running the following commands, where "initials" corresponds to the first and last initial of the person starting the branch.
 ```

--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -179,6 +179,15 @@ The `Plotting.debug` function handles both field types automatically when the
 
 ## Software errors
 
+### Julia REPL help mode
+
+Type `?` at the REPL prompt to enter help mode, then type any function, type,
+macro, or other Julia object to display its documentation. This includes docstrings,
+which is another reason why writing clear, expressive docstrings is important.
+
+For more details about help mode and the other Julia REPL modes,
+please see the [Julia documentation](https://docs.julialang.org/en/v1/stdlib/REPL/#The-different-prompt-modes).
+
 ### Identifying which method is being dispatched
 
 A common source of subtle bugs is a function being called with an unexpected type,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add two new sections to docs:
- under "Debugging tips", explain the REPL help mode
- on the "Contributing" page, link to Modern Julia Workflows

Closes #1869

~~I'll merge this without running buildkite since it only touches docs.~~ Update: I added a step to the buildkite pipline to skip running if we modify only `.md` or `.github` files.