### PR TITLE
re-enable central longruns [skip ci]

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -15,26 +15,26 @@ env:
 timeout_in_minutes: 1800 # 30 hours
 
 steps:
-  # - label: "init :computer:"
-  #   key: "init_cpu_env"
-  #   command:
-  #     - "echo $$JULIA_DEPOT_PATH"
+  - label: "init :computer:"
+    key: "init_cpu_env"
+    command:
+      - "echo $$JULIA_DEPOT_PATH"
 
-      # - echo "--- Instantiate AMIP env"
-      # - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      # - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'"
-      # - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.status()'"
+      - echo "--- Instantiate AMIP env"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.status()'"
 
-      # - echo "--- Instantiate CMIP env"
-      # - "julia --project=experiments/CMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      # - "julia --project=experiments/CMIP/ -e 'using Pkg; Pkg.precompile()'"
-      # - "julia --project=experiments/CMIP/ -e 'using Pkg; Pkg.status()'"
+      - echo "--- Instantiate CMIP env"
+      - "julia --project=experiments/CMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project=experiments/CMIP/ -e 'using Pkg; Pkg.precompile()'"
+      - "julia --project=experiments/CMIP/ -e 'using Pkg; Pkg.status()'"
 
-  #   agents:
-  #     slurm_cpus_per_task: 8
-  #   env:
-  #     JULIA_NUM_PRECOMPILE_TASKS: 8
-  #     JULIA_MAX_NUM_PRECOMPILE_FILES: 50
+    agents:
+      slurm_cpus_per_task: 8
+    env:
+      JULIA_NUM_PRECOMPILE_TASKS: 8
+      JULIA_MAX_NUM_PRECOMPILE_FILES: 50
 
   - label: "init clima :computer:"
     key: "init_cpu_env_clima"
@@ -59,22 +59,22 @@ steps:
 
   - wait
 
-  # - group: "Coupler integration and conservation tests"
+  - group: "Coupler integration and conservation tests"
 
-    # steps:
-    #   - label: "Aquaplanet: evolving slab ocean"
-    #     key: "slabplanet_aqua_evolve_ocean"
-    #     command: "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/slabplanet_aqua_evolve_ocean.yml --job_id slabplanet_aqua_evolve_ocean"
-    #     artifact_paths: "output/slabplanet_aqua_evolve_ocean/artifacts/*"
-    #     agents:
-    #       slurm_mem: 32GB
+    steps:
+      - label: "Aquaplanet: evolving slab ocean"
+        key: "slabplanet_aqua_evolve_ocean"
+        command: "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/slabplanet_aqua_evolve_ocean.yml --job_id slabplanet_aqua_evolve_ocean"
+        artifact_paths: "output/slabplanet_aqua_evolve_ocean/artifacts/*"
+        agents:
+          slurm_mem: 32GB
 
-    #   - label: "Slabplanet: evolving slab ocean, bucket"
-    #     key: "slabplanet_evolve_ocean"
-    #     command: "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/slabplanet_evolve_ocean.yml --job_id slabplanet_evolve_ocean"
-    #     artifact_paths: "output/slabplanet_evolve_ocean/artifacts/*"
-    #     agents:
-    #       slurm_mem: 32GB
+      - label: "Slabplanet: evolving slab ocean, bucket"
+        key: "slabplanet_evolve_ocean"
+        command: "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/slabplanet_evolve_ocean.yml --job_id slabplanet_evolve_ocean"
+        artifact_paths: "output/slabplanet_evolve_ocean/artifacts/*"
+        agents:
+          slurm_mem: 32GB
 
   - group: "AMIP simulations"
 
@@ -120,7 +120,7 @@ steps:
           slurm_cpus_per_task: 4
           slurm_ntasks: 1
           slurm_mem: 32GB
-      
+
       - label: "GPU AMIP + prog. EDMF + integrated land + 2K SST"
         key: "amip_progedmf_land_p2k"
         command:
@@ -216,6 +216,8 @@ steps:
             output/amip_progedmf_land_p2k
             output/ecs_analysis
         artifact_paths: "output/ecs_analysis/*"
+        agents:
+          queue: clima
 
       # plot job performance history
       - label: ":chart_with_downwards_trend: build history"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The "Cess climate sensitivity" longrun failed this weekend, which I believe is because the comparison data is downloaded during init (which was done on clima), but the run tries to access it when running on central.

We disabled central longruns a few months ago when we were having module issues on that cluster. The issues have been resolved so I think it's fine to re-enable the central init and two aquaplanets. The downside is that we have to init 4 environments (AMIP + CMIP on central + clima) instead of 2 (AMIP + CMIP on clima only), but I think it's worth it to be able to run on central and to test longer slabplanets.

## Content
- [x] init AMIP and CMIP environments on central
- [x] add back aquaplanet and slabplanet longruns

After review, I'll merge this without running CI because it only changes longruns.