### PR TITLE
update ecco v4 sea-ice artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -76,5 +76,8 @@ git-tree-sha1 = "c1c0a16127bd547124cdf7288140002d74846efe"
 git-tree-sha1 = "85b1e3654fb88f19a715ea6c235e1d66f254d2e6"
 
 [ecco4_SIarea_SIheff_2010_01]
-git-tree-sha1 = "889d7209b1a3b066e2dd5b0dbf7a674e32e4a589"
+git-tree-sha1 = "131153e848325a03139ca7966a1857ac3316b564"
 
+    [[ecco4_SIarea_SIheff_2010_01.download]]
+    sha256 = "dfcc6f930fd0d182f1076a4fdd81047aafc522eb433b2c6d5b75446307963044"
+    url = "https://caltech.box.com/shared/static/84s5osmyjcpvil5iv4v2qbmyi6i172w2.gz"


### PR DESCRIPTION
The ECCO sea-ice artifact was made downloadable by https://github.com/CliMA/ClimaArtifacts/pull/163 so our `Artifacts.toml` had to be updated.