### PR TITLE
don't crop benchmark table [skip ci]

### DIFF
--- a/experiments/AMIP/benchmarks.jl
+++ b/experiments/AMIP/benchmarks.jl
@@ -66,5 +66,7 @@ open(joinpath(table_output_dir, "table.txt"), "w") do f
         table_format = PrettyTables.TextTableFormat(
             horizontal_lines_at_data_rows = [2, 4, 6, 8, 10, 12, 14],
         ),
+        fit_table_in_display_horizontally = false,
+        fit_table_in_display_vertically = false,
     )
 end

--- a/experiments/CMIP/benchmarks.jl
+++ b/experiments/CMIP/benchmarks.jl
@@ -66,5 +66,7 @@ open(joinpath(table_output_dir, "table.txt"), "w") do f
         table_format = PrettyTables.TextTableFormat(
             horizontal_lines_at_data_rows = [2, 4, 6, 8, 10, 12, 14],
         ),
+        fit_table_in_display_horizontally = false,
+        fit_table_in_display_vertically = false,
     )
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The benchmark table has been getting cropped so it doesn't display correctly. This PR disables cropping and display size limit.

From the PrettyTables.jl docs:
- fit_table_in_display_horizontally::Bool: If true, the table will be cropped to fit the display horizontally. (Default = true)
- fit_table_in_display_vertically::Bool: If true, the table will be cropped to fit the display vertically. (Default = true)

These are both set to false here.


Since this only affects the benchmarks pipeline, I'll merge without running CI after it's approved.