### PR TITLE
Switch to warn when coupler debug fields contain NaNs.

### DIFF
--- a/ext/ClimaCouplerMakieExt/debug_plots.jl
+++ b/ext/ClimaCouplerMakieExt/debug_plots.jl
@@ -203,7 +203,7 @@ function Plotting.debug(cs_fields::CC.Fields.Field, dir, cs_fields_ref = nothing
 
     # Check for NaN errors after plots are saved
     if has_nan
-        error("NaN values found in coupler fields extrema")
+        @warn "NaN values found in coupler fields extrema"
     end
 end
 


### PR DESCRIPTION
Switch to warn when coupler debug fields (which contain masked scratch fields which may contain NaNs. 
Still generates error message when component model fields contain NaNs.
