### PR TITLE
Update usage of radiation_obs artifact

### DIFF
--- a/src/CalibrationTools.jl
+++ b/src/CalibrationTools.jl
@@ -443,7 +443,7 @@ CERES name to CliMA name.
 """
 function CERESDataLoader(; ceres_to_clima_names = CERES_TO_CLIMA_NAMES)
     artifact_dir = @clima_artifact("radiation_obs")
-    ceres_file = joinpath(artifact_dir, "CERES_EBAF_Ed4.2_Subset_200003-201910.nc")
+    ceres_file = joinpath(artifact_dir, "CERES_EBAF_Ed4.2.1_Subset_200003-202512.nc")
 
     catalog = NCCatalog()
     ClimaAnalysis.add_file!(catalog, ceres_file, ceres_to_clima_names...)

--- a/src/SimOutput/sim_obs_data.jl
+++ b/src/SimOutput/sim_obs_data.jl
@@ -174,7 +174,7 @@ function get_obs_var_dict()
                 obs_var = ClimaAnalysis.OutputVar(
                     joinpath(
                         @clima_artifact("radiation_obs"),
-                        "CERES_EBAF_Ed4.2_Subset_200003-201910.nc",
+                        "CERES_EBAF_Ed4.2.1_Subset_200003-202512.nc",
                     ),
                     obs_name,
                     new_start_date = start_date,


### PR DESCRIPTION
The `radiation_obs` artifact is updated in https://github.com/CliMA/ClimaArtifacts/pull/166. This should be merged after the ClimaArtifacts PR is merged and the artifacts are synced between the clusters.