### PR TITLE
Shorten t_end for 2 ci cases

### DIFF
--- a/config/longrun_configs/slabplanet_aqua_evolve_ocean.yml
+++ b/config/longrun_configs/slabplanet_aqua_evolve_ocean.yml
@@ -16,5 +16,5 @@ h_elem: 8
 mode_name: "slabplanet_aqua"
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "10days"
+t_end: "5days"
 use_land_diagnostics: false

--- a/config/longrun_configs/slabplanet_evolve_ocean.yml
+++ b/config/longrun_configs/slabplanet_evolve_ocean.yml
@@ -16,4 +16,4 @@ h_elem: 8
 mode_name: "slabplanet"
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "10days"
+t_end: "5days"


### PR DESCRIPTION
Shorten t_end for Aquaplanet: evolving slab ocean and Slabplanet: evolving slab ocean, bucket (ci completion)

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
