### PR TITLE
Fix output path detection

### DIFF
--- a/experiments/calibration/amip/model_interface.jl
+++ b/experiments/calibration/amip/model_interface.jl
@@ -46,10 +46,10 @@ function ClimaCalibrate.forward_model(interface::CouplerModelInterface, iter, me
     member_output_dir =
         ClimaCalibrate.path_to_ensemble_member(output_dir_root, iter, member)
     config_dict["coupler_output_dir"] = member_output_dir
-    # Ensure the simulation restarts automatically
-    config_dict["detect_restart_file"] = true
-    config_dict["output_dir_style"] = "activelink"
+    config_dict["detect_restart_files"] = true
     config_dict["checkpoint_dt"] = "10days"
+
+    ClimaCoupler.Input.update_t_start_for_restarts!(config_dict)
 
     @info "Simulation dates" start_date end_date
 

--- a/ext/ClimaCouplerClimaAtmosExt.jl
+++ b/ext/ClimaCouplerClimaAtmosExt.jl
@@ -668,10 +668,7 @@ function get_atmos_config_dict(
     toml_dict = CP.merge_override_default_values(coupled_param_dict, atmos_toml)
 
     # Specify atmos output directory to be inside the coupler output directory.
-    # Honor the coupler's output_dir_style if set (e.g. "activelink" so atmos
-    # can auto-detect a restart file across runs); otherwise default to
-    # RemovePreexisting.
-    get!(atmos_config, "output_dir_style", "RemovePreexisting")
+    atmos_config["output_dir_style"] = "RemovePreexisting"
     atmos_config["output_dir"] = atmos_output_dir
 
     # Add all extra atmos diagnostic entries into the vector of atmos diagnostics


### PR DESCRIPTION
Fixes issue with extra nested "ActiveLink" output directory (i.e. `output_0000/clima_atmos/output_0000` -> `output_0000/clima_atmos/`)