### PR TITLE
change resolution of nightly amip

### DIFF
--- a/config/nightly_configs/amip_coarse_progedmf_1m_land.yml
+++ b/config/nightly_configs/amip_coarse_progedmf_1m_land.yml
@@ -5,7 +5,6 @@ checkpoint_dt: "1months"
 coupler_toml: ["toml/amip_progedmf_1m.toml"]
 dt: "180secs"
 dt_cpl: "180secs"
-dz_bottom: 100.0
 energy_check: false
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]
@@ -13,7 +12,7 @@ extra_atmos_diagnostics:
     reduction_time: average
     pressure_coordinates: true
     compute_every: 6hours
-h_elem: 8
+h_elem: 12
 land_model: "integrated"
 mode_name: "amip"
 netcdf_output_at_levels: true
@@ -21,7 +20,6 @@ output_default_diagnostics: true
 radiation_reset_rng_seed: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "366days"
+t_end: "124days"
 topo_smoothing: true
 topography: "Earth"
-z_elem: 39

--- a/config/nightly_configs/amip_coarse_progedmf_land.yml
+++ b/config/nightly_configs/amip_coarse_progedmf_land.yml
@@ -5,7 +5,6 @@ checkpoint_dt: "1months"
 coupler_toml: ["toml/amip_progedmf.toml"]
 dt: "180secs"
 dt_cpl: "180secs"
-dz_bottom: 100.0
 energy_check: false
 extra_atmos_diagnostics:
   - short_name: [hur, hus, ta]
@@ -13,7 +12,7 @@ extra_atmos_diagnostics:
     reduction_time: average
     pressure_coordinates: true
     compute_every: 6hours
-h_elem: 8
+h_elem: 12
 land_model: "integrated"
 mode_name: "amip"
 netcdf_output_at_levels: true
@@ -21,7 +20,6 @@ output_default_diagnostics: true
 radiation_reset_rng_seed: true
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
-t_end: "465days"
+t_end: "366days"
 topo_smoothing: true
 topography: "Earth"
-z_elem: 39


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Use the same vertical resolution and a lower horizontal resolution than our target. We can only run it for a shorter period overnight, but I think this setup is more useful for diagnosing problems.

These nightly amips will probably break with the latest ClimaAtmos. We will look into it.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
