### PR TITLE
Add MAC LWP dataloader

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -81,3 +81,10 @@ git-tree-sha1 = "131153e848325a03139ca7966a1857ac3316b564"
     [[ecco4_SIarea_SIheff_2010_01.download]]
     sha256 = "dfcc6f930fd0d182f1076a4fdd81047aafc522eb433b2c6d5b75446307963044"
     url = "https://caltech.box.com/shared/static/84s5osmyjcpvil5iv4v2qbmyi6i172w2.gz"
+
+[mac_lwp]
+git-tree-sha1 = "edd3265e3be0938821451c24d411f4dc066bbf0e"
+
+    [[mac_lwp.download]]
+    sha256 = "fd24ea0d4491ef95b0a3a362d9f5faf320e5dd6caf3f4fb8683e9ab71357c13f"
+    url = "https://caltech.box.com/shared/static/4ukyc2pn5mq3zou5f7g2mjfkr86s7vdr.gz"

--- a/config/amip_configs/amip_calibration.yml
+++ b/config/amip_configs/amip_calibration.yml
@@ -43,7 +43,7 @@ output_default_diagnostics: false
 use_coupler_diagnostics: false
 use_land_diagnostics: false
 extra_atmos_diagnostics:
-  - short_name: [tas, pr, mslp, rsut, rsutcs, rlut, rlutcs, rsdt]
+  - short_name: [tas, pr, mslp, rsut, rsutcs, rlut, rlutcs, rsdt, lwp]
     period: monthly
     reduction_time: average
   - short_name: [ta, hur, pfull]

--- a/config/amip_configs/amip_calibration.yml
+++ b/config/amip_configs/amip_calibration.yml
@@ -11,6 +11,7 @@ topography: "Earth"
 ### Time and Simulation ###
 start_date: "20100101"
 initial_condition: "WeatherModel"
+era5_initial_condition_dir: "/glade/campaign/univ/ucit0011/cchristo/wxquest_data/initial_conditions/initial_conditions_v1_dev"
 t_end: "39days"
 dt: "180secs"
 dt_cpl: "180secs"

--- a/experiments/calibration/amip/config/pressure_levels.jl
+++ b/experiments/calibration/amip/config/pressure_levels.jl
@@ -14,12 +14,12 @@ const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
     config_file,
     # Note: Pressure-level variables require model output with
     # pressure_coordinates: true in config
-    short_names = ["ta", "hur"],
+    short_names = ["lwp", "ta", "hur"],
     minibatch_size = 1,
     n_iterations = 5,
     sample_date_ranges,
     extend = Dates.Month(1),
-    spinup = Dates.Day(0),
+    spinup = Dates.Day(7),
     output_dir,
     rng_seed = 42,
 )
@@ -35,10 +35,10 @@ const NORMALIZATION_STATS_FP =
 
 const CALIBRATION_PRIORS = [
     PD.constrained_gaussian("rain_autoconversion_timescale", 1800, 300, 300, 3600),
-    PD.constrained_gaussian("Tq_correlation_coefficient", 0.4, 0.4, -1.0, 1.0),
-    PD.constrained_gaussian("mixing_length_eddy_viscosity_coefficient", 0.2, 0.1, 0, 1.0),
-    PD.constrained_gaussian("mixing_length_diss_coeff", 0.22, 0.15, 0.0, 10.0),
-    PD.constrained_gaussian("mixing_length_tke_surf_flux_coeff", 8.0, 4.0, 0, 100.0),
+    # PD.constrained_gaussian("Tq_correlation_coefficient", 0.4, 0.4, -1.0, 1.0),
+    # PD.constrained_gaussian("mixing_length_eddy_viscosity_coefficient", 0.2, 0.1, 0, 1.0),
+    # PD.constrained_gaussian("mixing_length_diss_coeff", 0.22, 0.15, 0.0, 10.0),
+    # PD.constrained_gaussian("mixing_length_tke_surf_flux_coeff", 8.0, 4.0, 0, 100.0),
 ]
 
 const PRIORS = EKP.combine_distributions(CALIBRATION_PRIORS)

--- a/experiments/calibration/amip/config/pressure_levels.jl
+++ b/experiments/calibration/amip/config/pressure_levels.jl
@@ -14,7 +14,7 @@ const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
     config_file,
     # Note: Pressure-level variables require model output with
     # pressure_coordinates: true in config
-    short_names = ["ta", "hur"],
+    short_names = ["lwp"],
     minibatch_size = 1,
     n_iterations = 5,
     sample_date_ranges,
@@ -35,10 +35,10 @@ const NORMALIZATION_STATS_FP =
 
 const CALIBRATION_PRIORS = [
     PD.constrained_gaussian("rain_autoconversion_timescale", 1800, 300, 300, 3600),
-    PD.constrained_gaussian("Tq_correlation_coefficient", 0.4, 0.4, -1.0, 1.0),
-    PD.constrained_gaussian("mixing_length_eddy_viscosity_coefficient", 0.2, 0.1, 0, 1.0),
-    PD.constrained_gaussian("mixing_length_diss_coeff", 0.22, 0.15, 0.0, 10.0),
-    PD.constrained_gaussian("mixing_length_tke_surf_flux_coeff", 8.0, 4.0, 0, 100.0),
+    # PD.constrained_gaussian("Tq_correlation_coefficient", 0.4, 0.4, -1.0, 1.0),
+    # PD.constrained_gaussian("mixing_length_eddy_viscosity_coefficient", 0.2, 0.1, 0, 1.0),
+    # PD.constrained_gaussian("mixing_length_diss_coeff", 0.22, 0.15, 0.0, 10.0),
+    # PD.constrained_gaussian("mixing_length_tke_surf_flux_coeff", 8.0, 4.0, 0, 100.0),
 ]
 
 const PRIORS = EKP.combine_distributions(CALIBRATION_PRIORS)

--- a/experiments/calibration/amip/config/pressure_levels.jl
+++ b/experiments/calibration/amip/config/pressure_levels.jl
@@ -19,7 +19,7 @@ const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
     n_iterations = 5,
     sample_date_ranges,
     extend = Dates.Month(1),
-    spinup = Dates.Day(0),
+    spinup = Dates.Day(7),
     output_dir,
     rng_seed = 42,
 )

--- a/experiments/calibration/amip/generate_observations.jl
+++ b/experiments/calibration/amip/generate_observations.jl
@@ -74,10 +74,15 @@ if abspath(PROGRAM_FILE) == @__FILE__
     era5_pl_data_loader = CalibrationTools.ERA5PressureLevelDataLoader()
     ceres_data_loader = CalibrationTools.CERESDataLoader()
     modis_data_loader = CalibrationTools.ModisDataLoader()
+    mac_data_loader = CalibrationTools.MACDataLoader()
+    # Both MODIS and MAC provide `lwp`, so disambiguate to get `lwp` from MAC.
+    # MODIS is kept for its ice water path (`clivi`).
     data_loader = CalibrationTools.CompositeDataLoader(
         era5_pl_data_loader,
         ceres_data_loader,
         modis_data_loader,
+        mac_data_loader;
+        varname_to_loader = Dict("lwp" => mac_data_loader),
     )
 
     (; short_names) = CALIBRATE_CONFIG

--- a/src/CalibrationTools.jl
+++ b/src/CalibrationTools.jl
@@ -948,4 +948,73 @@ function emulate_diagnostics!(sim, t_end)
     return nothing
 end
 
+
+"""
+    MACDataLoader
+
+A struct for loading preprocessed MAC data on pressure levels as `OutputVar`s.
+"""
+struct MACDataLoader <: AbstractDataLoader
+    catalog::NCCatalog
+    available_vars::Set{String}
+end
+
+const MAC_TO_CLIMA_NAMES = ["lwp" => "lwp", "iwp" => "iwp"]
+
+"""
+    MACDataLoader(;
+        mac_to_clima_names = MAC_TO_CLIMA_NAMES,
+    )
+
+Construct a data loader which you can used to load preprocessed monthly time-averaged
+MAC data on single levels in `OutputVar`, where
+- the short name and sign of the data match CliMA conventions,
+- the latitudes are shifted to be -180 to 180 degrees,
+- the times are at the start of the time period (e.g. the time average of
+  January is on the first of January instead of January 15th).
+
+For `lwp` and `iwp`, there are `NaN`s in the data. These `NaN`s was imputted
+with mean of the non-`NaN` data for the dataset.
+
+The MAC data comes from the `mac_lwp` artifact. See
+[ClimaArtifacts](https://github.com/CliMA/ClimaArtifacts/tree/main/mac_lwp/)
+for more information about this artifact.
+
+The keyword argument `mac_to_clima_names` is a vector of pairs mapping
+MAC name to CliMA name.
+"""
+function MACDataLoader(; mac_to_clima_names = MODIS_TO_CLIMA_NAMES)
+    artifact_dir = @clima_artifact"mac_lwp"
+    mac_file = joinpath(artifact_dir, "mac_lwp.nc")
+
+    catalog = NCCatalog()
+    ClimaAnalysis.add_file!(catalog, mac_file, mac_to_clima_names...)
+    return MACDataLoader(catalog, Set(last.(mac_to_clima_names)))
+end
+
+"""
+    get(loader::MACDataLoader, short_name::String)
+
+Get the preprocessed `OutputVar` with the name `short_name` from the MAC
+dataset.
+"""
+function Base.get(loader::MACDataLoader, short_name::String)
+    (; catalog, available_vars) = loader
+    short_name in available_vars || error(
+        "$short_name is not available to load. To add this variable, pass it to mac_to_clima_names as a pair mapping var name to CliMA name and create a new MACDataLoader",
+    )
+    var = get(catalog, short_name; var_kwargs = (shift_by = Dates.firstdayofmonth,))
+    return preprocess(loader, var, Val(Symbol(short_name)))
+end
+
+function preprocess(::MACDataLoader, var, ::Union{Val{:iwp}, Val{:lwp}})
+    var = _preprocess_var(var)
+    not_nans = filter(!isnan, var.data)
+    global_mean = sum(not_nans) / length(not_nans)
+    @info "$(ClimaAnalysis.short_name(var)): Imputing global mean $global_mean for NaNs"
+    replace!(x -> isnan(x) ? global_mean : x, var)
+    var = ClimaAnalysis.convert_units(var, "kg m^-2", conversion_function = x -> 0.001 * x)
+    return var
+end
+
 end

--- a/src/CalibrationTools.jl
+++ b/src/CalibrationTools.jl
@@ -782,6 +782,70 @@ function preprocess(::CalipsoDataLoader, var, ::Val{:cl})
 end
 
 """
+    MACDataLoader
+
+A struct for loading preprocessed MAC data on pressure levels as `OutputVar`s.
+"""
+struct MACDataLoader <: AbstractDataLoader
+    catalog::NCCatalog
+    available_vars::Set{String}
+end
+
+const MAC_TO_CLIMA_NAMES = ["lwp" => "lwp", "iwp" => "iwp"]
+
+"""
+    MACDataLoader(;
+        mac_to_clima_names = MAC_TO_CLIMA_NAMES,
+    )
+
+Construct a data loader which you can used to load preprocessed monthly time-averaged
+MAC data on single levels in `OutputVar`, where
+- the short name and sign of the data match CliMA conventions,
+- the latitudes are shifted to be -180 to 180 degrees,
+- the times are at the start of the time period (e.g. the time average of
+  January is on the first of January instead of January 15th).
+
+For `lwp` and `iwp`, there are `NaN`s in the data. These `NaN`s was imputted
+with mean of the non-`NaN` data for the dataset.
+
+The MAC data comes from the `mac_lwp` artifact. See
+[ClimaArtifacts](https://github.com/CliMA/ClimaArtifacts/tree/main/mac_lwp/)
+for more information about this artifact.
+
+The keyword argument `mac_to_clima_names` is a vector of pairs mapping
+MAC name to CliMA name.
+"""
+function MACDataLoader(; mac_to_clima_names = MAC_TO_CLIMA_NAMES)
+    artifact_dir = @clima_artifact"mac_lwp"
+    mac_file = joinpath(artifact_dir, "mac_lwp.nc")
+
+    catalog = NCCatalog()
+    ClimaAnalysis.add_file!(catalog, mac_file, mac_to_clima_names...)
+    return MACDataLoader(catalog, Set(last.(mac_to_clima_names)))
+end
+
+"""
+    get(loader::MACDataLoader, short_name::String)
+
+Get the preprocessed `OutputVar` with the name `short_name` from the MAC
+dataset.
+"""
+function Base.get(loader::MACDataLoader, short_name::String)
+    (; catalog, available_vars) = loader
+    short_name in available_vars || error(
+        "$short_name is not available to load. To add this variable, pass it to mac_to_clima_names as a pair mapping var name to CliMA name and create a new MACDataLoader",
+    )
+    var = get(catalog, short_name; var_kwargs = (shift_by = Dates.firstdayofmonth,))
+    return preprocess(loader, var, Val(Symbol(short_name)))
+end
+
+function preprocess(::MACDataLoader, var, ::Union{Val{:iwp}, Val{:lwp}})
+    var = _preprocess_var(var)
+    var = ClimaAnalysis.convert_units(var, "kg m^-2", conversion_function = x -> 0.001 * x)
+    return var
+end
+
+"""
     regrid_to_model_levels(obs_var, model_altitudes)
 
 Regrid `obs_var` from dataset altitude levels to `model_altitudes` using a


### PR DESCRIPTION
This PR adds a dataloader for the MAC LWP dataset and updates the `pressure_levels.jl` calibration config to use LWP. 