### PR TITLE
Use dates instead of floating-point for spinup

### DIFF
--- a/ext/ClimaCouplerMakieExt/leaderboard/leaderboard.jl
+++ b/ext/ClimaCouplerMakieExt/leaderboard/leaderboard.jl
@@ -52,9 +52,9 @@ function Plotting.compute_leaderboard(
         obs_var = obs_var_dict[short_name](sim_var.attributes["start_date"])
 
         # Remove first spin_up_months from simulation
-        spinup_cutoff = spinup * 31 * 86400.0
-        ClimaAnalysis.times(sim_var)[end] >= spinup_cutoff &&
-            (sim_var = ClimaAnalysis.window(sim_var, "time", left = spinup_cutoff))
+        spinup_cutoff_date = first(ClimaAnalysis.dates(sim_var)) + spinup * Dates.Month(1)
+        ClimaAnalysis.dates(sim_var)[end] >= spinup_cutoff_date &&
+            (sim_var = ClimaAnalysis.window(sim_var, "time", left = spinup_cutoff_date))
 
         obs_var = ClimaAnalysis.resampled_as(obs_var, sim_var)
         obs_var_seasons = ClimaAnalysis.split_by_season(obs_var)
@@ -105,9 +105,7 @@ function Plotting.compute_leaderboard(
                 sim_var.attributes["short_name"] = "mean $(ClimaAnalysis.short_name(sim_var))"
                 cmap_extrema = get(compare_vars_biases_plot_extrema, short_name) do
                     extrema(
-                        ClimaAnalysis.bias(
-                            sim_obs_comparsion_dict[short_name]["ANN"]...,
-                        ).data,
+                        ClimaAnalysis.bias(sim_obs_comparsion_dict[short_name]["ANN"]...).data,
                     )
                 end
                 ClimaAnalysis.Visualize.plot_bias_on_globe!(

--- a/ext/ClimaCouplerMakieExt/leaderboard/leaderboard.jl
+++ b/ext/ClimaCouplerMakieExt/leaderboard/leaderboard.jl
@@ -105,7 +105,9 @@ function Plotting.compute_leaderboard(
                 sim_var.attributes["short_name"] = "mean $(ClimaAnalysis.short_name(sim_var))"
                 cmap_extrema = get(compare_vars_biases_plot_extrema, short_name) do
                     extrema(
-                        ClimaAnalysis.bias(sim_obs_comparsion_dict[short_name]["ANN"]...).data,
+                        ClimaAnalysis.bias(
+                            sim_obs_comparsion_dict[short_name]["ANN"]...,
+                        ).data,
                     )
                 end
                 ClimaAnalysis.Visualize.plot_bias_on_globe!(

--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -135,20 +135,46 @@ function postprocess(
     # Plot all model states and coupler fields (useful for debugging)
     ClimaComms.context(cs) isa ClimaComms.SingletonCommsContext && debug(cs, artifacts_dir)
 
+    # Helper function to find a tuple of (short_name, reduction, period, coord_type)
+    # whose period is "1M".
+    function find_first_1M_tuple(simdir)
+        for short_name in CAN.available_vars(simdir)
+            for reduction in CAN.available_reductions(simdir; short_name)
+                for period in CAN.available_periods(simdir; short_name, reduction)
+                    period == "1M" || continue
+                    for coord_type in
+                        CAN.available_coord_types(simdir; short_name, reduction, period)
+                        return (short_name, reduction, period, coord_type)
+                    end
+                end
+            end
+        end
+        return nothing
+    end
+
     # Leaderboard requires global spatial data; skip in column / SCM mode.
     if !Interfacer.is_column_mode(cs)
         simdir = CAN.SimDir(atmos_output_dir)
-        if !isempty(simdir)
+        first_1M_tuple = find_first_1M_tuple(simdir)
+        if !isempty(simdir) && !isnothing(first_1M_tuple)
             # We need pressure to compute the leaderboard.
             pressure_in_output = "pfull" in CAN.available_vars(simdir)
-            t_end = float(cs.t[])
+
             # Make sure we have enough data to compute the leaderboard.
-            if t_end > 84600 * 31 * 3 # 3 months for spin up
+            short_name, reduction, period, coord_type = first_1M_tuple
+            var_1M = get(simdir; short_name, reduction, period, coord_type)
+            start_date = first(CAN.dates(var_1M))
+            end_date = last(CAN.dates(var_1M))
+            spinup = 3
+            if end_date >= start_date + Dates.Month(spinup)
                 leaderboard_base_path = artifacts_dir
-                compute_leaderboard(leaderboard_base_path, atmos_output_dir, 3)
-                rmse_check && SimOutput.test_rmse_thresholds(atmos_output_dir, 3)
-                pressure_in_output &&
-                    compute_pfull_leaderboard(leaderboard_base_path, atmos_output_dir, 3)
+                compute_leaderboard(leaderboard_base_path, atmos_output_dir, spinup)
+                rmse_check && SimOutput.test_rmse_thresholds(atmos_output_dir, spinup)
+                pressure_in_output && compute_pfull_leaderboard(
+                    leaderboard_base_path,
+                    atmos_output_dir,
+                    spinup,
+                )
             end
         end
     end


### PR DESCRIPTION
The spinup was computed using `spinup * 31 * 86400.0` and we rely on `ClimaAnalysis.window` to find the closest month. For most cases, this works, but the [latest Buildkite run](https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/1288#019f208e-f5be-4f7c-a6f0-721e80410b67) shows that for short simulation run, it doesn't work.

To fix this, we use absolute time (dates) instead of relative time (floating-point).