### PR TITLE
Import Dates in Plotting

### DIFF
--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -10,6 +10,7 @@ module Plotting
 
 import ClimaComms
 import ClimaAnalysis as CAN
+import Dates
 
 import ..Interfacer
 import ..SimOutput


### PR DESCRIPTION
The longruns [are failing at the end](https://buildkite.com/clima/climacoupler-longruns/builds/1160/canvas?sid=019f314b-b820-46ad-ab9a-55cab7bf6626&tab=output) due to `Dates` not being imported.