### PR TITLE
Revamp wall time reporter

### DIFF
--- a/docs/src/coupledsimulation.md
+++ b/docs/src/coupledsimulation.md
@@ -94,8 +94,8 @@ how to customise the root path via the `coupler_output_dir` configuration option
 `cs.callbacks` is a `NamedTuple` of `TimeManager.Callback` objects, which each execute
 some operation at predetermined times throughout a simulation. Each callback
 wraps a schedule and a function, and is triggered at the appropriate time during
-`step!`. The default callbacks include a walltime progress reporter and, if enabled,
-a checkpointing callback. See [TimeManager](@ref) for the `Callback` API and
+`step!`. The default callbacks include a checkpointing callback, a walltime reporter,
+and, if enabled, component model progress-reporting callbacks. See [TimeManager](@ref) for the `Callback` API and
 [Checkpointer](@ref) for how to add a checkpointing callback.
 
 ## Conservation checks (`cs.conservation_checks`)

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -114,6 +114,7 @@ Note: the `mode_name` determines which Julia environment to use. Use `experiment
 | `--dt_ocean` | String | `nothing` | `"Nsecs"`, `"Nmins"`, `"Nhours"`, `"Ndays"`, `"Inf"` | Ocean simulation time step (alternative to `dt`) |
 | `--dt_seaice` | String | `nothing` | `"Nsecs"`, `"Nmins"`, `"Nhours"`, `"Ndays"`, `"Inf"` | Sea ice simulation time step (alternative to `dt`) |
 | `--checkpoint_dt` | String | `"90days"` | `"Nsecs"`, `"Nmins"`, `"Nhours"`, `"Ndays"`, `"Inf"` | Time interval for checkpointing |
+| `--walltime_dt` | String | `nothing` | `"Nsecs"`, `"Nmins"`, `"Nhours"`, `"Ndays"`, `"Nmonths"`, `"never"` | Time interval for walltime reporting. Defaults to a quarter of the simulation length, at most 1 day. Set to `"never"` to disable. |
 
 Note: If any component model-specific timestep is specified, _all_ component-model
 specific timesteps should be specified, rather than only `dt`.
@@ -160,7 +161,6 @@ specific timesteps should be specified, rather than only `dt`.
 |----------|------|---------|---------------|-------------|
 | `--surface_setup` | String | `"PrescribedSurface"` | `PrescribedSurface`, `DefaultMoninObukhov` | Triggers ClimaAtmos into coupled mode |
 | `--atmos_config_file` | String | `nothing` | Any valid file path | Optional YAML file used to overwrite default model parameters |
-| `--atmos_log_progress` | Bool | `false` | `true`, `false` | Use ClimaAtmos walltime logging callback instead of default ClimaCoupler one |
 | `--atmos_progress_interval` | String | `"never"` | `"Nsecs"`, `"Nmins"`, `"Nhours"`, `"Ndays"`, `"Nmonths"`, `"never"` | Time interval for printing atmosphere progress information. Set to `"never"` to disable. |
 | `--albedo_model` | String | `"CouplerAlbedo"` | `ConstantAlbedo`, `RegressionFunctionAlbedo`, `CouplerAlbedo` | Type of albedo model |
 | `--extra_atmos_diagnostics` | Vector{Dict{Any, Any}} | `[]` | List of dictionaries | List of dictionaries containing information about additional atmosphere diagnostics to output |

--- a/docs/src/timemanager.md
+++ b/docs/src/timemanager.md
@@ -8,6 +8,7 @@ functions from Julia's [Dates](https://docs.julialang.org/en/v1/stdlib/Dates/) m
 
 ```@docs
 TimeManager.maybe_trigger_callback
+TimeManager.WalltimeReporter
 ```
 
 ## ITime

--- a/ext/ClimaCouplerCMIPExt/clima_seaice.jl
+++ b/ext/ClimaCouplerCMIPExt/clima_seaice.jl
@@ -212,7 +212,7 @@ function Interfacer.progress(ice_sim::ClimaSeaIceSimulation, cs)
     v_max = maximum(abs, model.velocities.v)
 
     if ClimaComms.iamroot(ClimaComms.context(cs))
-        @info "Sea ice | time: $(Interfacer.current_date(cs, model.clock.time)), iteration: $(OC.iteration(ice)), " *
+        @info "Sea-ice | time: $(Interfacer.current_date(cs, model.clock.time)), iteration: $(OC.iteration(ice)), " *
               "maximum(h): $(round(h_max, digits = 2)) m, maximum(a): $(round(a_max, digits = 2)), " *
               "extrema(T_sfc): ($(round(T_sfc_min, digits = 2)), $(round(T_sfc_max, digits = 2))) ᵒC, " *
               "maximum(u): ($(round(u_max, sigdigits = 2)), $(round(v_max, sigdigits = 2))) m/s"

--- a/ext/ClimaCouplerClimaAtmosExt.jl
+++ b/ext/ClimaCouplerClimaAtmosExt.jl
@@ -727,7 +727,9 @@ function get_atmos_config_dict(
     # can pick up from where we have left. NOTE: This should not be needed, but
     # there is no easy way to initialize ClimaAtmos with a different t_start
     atmos_config["dt_save_state_to_disk"] = coupler_config["checkpoint_dt"]
-    atmos_config["log_progress"] = coupler_config["atmos_log_progress"]
+
+    # disable Atmos's progress logging
+    atmos_config["log_progress"] = false
 
     # The Atmos `get_simulation` function expects the atmos config to contains its timestep size
     # in the `dt` field. If there is a `dt_atmos` field in coupler_config, we add it to the atmos config as `dt`

--- a/src/Input.jl
+++ b/src/Input.jl
@@ -121,6 +121,10 @@ function argparse_settings()
         help = "Time interval for checkpointing [\"90days\" (default)]"
         arg_type = String
         default = "90days"
+        "--walltime_dt"
+        help = "Time interval for walltime reporting [nothing (default): a tenth of the simulation length, at most 1 day and at least one coupling step; allowed formats: \"Nsecs\", \"Nmins\", \"Nhours\", \"Ndays\", \"Nmonths\", \"never\"]"
+        arg_type = String
+        default = nothing
         # Space information
         "--h_elem"
         help = "Number of horizontal elements to use for the atmosphere horizontal space [16 (default)]"
@@ -208,10 +212,6 @@ function argparse_settings()
         help = "An optional YAML file used to overwrite the default model parameters."
         arg_type = String
         default = nothing
-        "--atmos_log_progress"
-        help = "Use the ClimaAtmos walltime logging callback instead of the default ClimaCoupler one [`false` (default), `true`]"
-        arg_type = Bool
-        default = false
         "--atmos_progress_interval"
         help = "Time interval for printing atmosphere progress information [\"never\" (default); allowed formats: \"Nsecs\", \"Nmins\", \"Nhours\", \"Ndays\", \"Nmonths\", \"never\"]"
         arg_type = String
@@ -543,6 +543,15 @@ function get_coupler_args(config_dict::Dict)
     # Checkpointing information
     checkpoint_dt = config_dict["checkpoint_dt"]
 
+    # Walltime reporting information
+    walltime_dt = get(config_dict, "walltime_dt", nothing)
+    if isnothing(walltime_dt)
+        # default to a tenth of the simulation length (capped at one day, but never
+        # shorter than one coupling step)
+        walltime_dt_secs = max(min(float(t_end - t_start) / 10, 86400.0), float(Δt_cpl))
+        walltime_dt = "$(walltime_dt_secs)secs"
+    end
+
     # Atmos progress reporting information
     atmos_progress_interval = config_dict["atmos_progress_interval"]
 
@@ -665,6 +674,7 @@ function get_coupler_args(config_dict::Dict)
         h_elem_coupler,
         saveat,
         checkpoint_dt,
+        walltime_dt,
         atmos_progress_interval,
         detect_restart_files,
         restart_dir,

--- a/src/SimCoordinator.jl
+++ b/src/SimCoordinator.jl
@@ -59,14 +59,17 @@ function run!(
     ## Run garbage collection before solving for more accurate memory comparison to ClimaAtmos
     GC.gc()
 
-    #=
     ## Solving and Timing the Full Simulation
 
-    This is where the full coupling loop, `solve_coupler!` is called for the full timespan of the simulation.
-    We use the `ClimaComms.@elapsed` macro to time the simulation on both CPU and GPU, and use this
-    value to calculate the simulated years per day (SYPD) of the simulation.
-    =#
+    # This is where the full coupling loop is called for the full timespan of the simulation.
+    # We use the `ClimaComms.@elapsed` macro to time the simulation on both CPU and GPU and use this
+    # value to calculate the simulated years per day (SYPD) of the simulation.
     @info "Starting coupling loop"
+    # The precompilation steps above already advanced `cs.t[]`, so the timed loop only covers
+    # `t_timed_start` to `cs.tspan[end]`. Snapshot the start so timing metrics reflect the
+    # simulated time actually spanned during timing (this equals `cs.tspan[begin]` when no
+    # precompilation ran).
+    t_timed_start = float(cs.t[])
     walltime = ClimaComms.@elapsed ClimaComms.device(cs) begin
         while cs.t[] < cs.tspan[end]
             step!(cs)
@@ -74,11 +77,7 @@ function run!(
     end
     @info "Simulation took $(walltime) seconds"
 
-    sypd = simulated_years_per_day(cs, walltime)
-    walltime_per_step = walltime_per_coupling_step(cs, walltime)
-    @info "SYPD: $sypd"
-    @info "Walltime per coupling step: $(walltime_per_step)"
-    save_sypd_walltime_to_disk(cs, walltime)
+    save_sypd_walltime_to_disk(cs, walltime, t_timed_start)
 
     # Close all diagnostics file writers
     isnothing(cs.diags_handler) ||
@@ -129,37 +128,18 @@ function step!(cs::Interfacer.CoupledSimulation)
 end
 
 """
-    simulated_years_per_day(cs, walltime)
+    save_sypd_walltime_to_disk(cs, walltime, t_timed_start = cs.tspan[begin])
 
-Compute the simulated years per walltime day for the given coupled simulation `cs`, assuming
-that the simulation took `walltime`.
+Save the computed `sypd`, `walltime_per_coupling_step`, and memory usage to text files 
+in the `artifacts` directory. `t_timed_start` is the simulated time (in seconds) at which 
+the timed portion of the run began (see the `precompile` flag in [run!](@ref)). 
 """
-function simulated_years_per_day(cs, walltime)
-    simulated_seconds_per_second = float(cs.tspan[end] - cs.tspan[begin]) / walltime
-    return simulated_seconds_per_second / 365.25
-end
-
-"""
-    walltime_per_coupling_step(cs, walltime)
-
-Compute the average walltime needed to take one step for the given coupled simulation `cs`,
-assuming that the simulation took `walltime`. The result is in seconds.
-"""
-function walltime_per_coupling_step(cs, walltime)
-    n_coupling_steps = (cs.tspan[end] - cs.tspan[begin]) / cs.Δt_cpl
-    return walltime / n_coupling_steps
-end
-
-"""
-    save_sypd_walltime_to_disk(cs, walltime)
-
-Save the computed `sypd`, `walltime_per_coupling_step`,
-and memory usage to text files in the `artifacts` directory.
-"""
-function save_sypd_walltime_to_disk(cs, walltime)
+function save_sypd_walltime_to_disk(cs, walltime, t_timed_start = cs.tspan[begin])
     if ClimaComms.iamroot(ClimaComms.context(cs))
-        sypd = simulated_years_per_day(cs, walltime)
-        walltime_per_step = walltime_per_coupling_step(cs, walltime)
+        sypd = TimeManager.simulated_years_per_day(t_timed_start, cs.tspan[end], walltime)
+        walltime_per_step = walltime / ((cs.tspan[end] - t_timed_start) / cs.Δt_cpl)
+        @info "SYPD: $sypd"
+        @info "Walltime per coupling step: $(walltime_per_step)"
 
         open(joinpath(cs.dir_paths.artifacts_dir, "sypd.txt"), "w") do sypd_filename
             println(sypd_filename, "$sypd")
@@ -216,6 +196,7 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
         h_elem_coupler,
         saveat,
         checkpoint_dt,
+        walltime_dt,
         atmos_progress_interval,
         detect_restart_files,
         restart_dir,
@@ -472,10 +453,13 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
         TimeManager.Callback(schedule_checkpoint, sim -> Checkpointer.checkpoint_sims(sim))
 
     # walltime reporting
-    if config_dict["atmos_log_progress"]
+    if walltime_dt == "never"
         callbacks = (checkpoint_cb,)
     else
-        walltime_cb = TimeManager.capped_geometric_walltime_cb(t_start, t_end, Δt_cpl)
+        schedule_walltime =
+            EveryCalendarDtSchedule(TimeManager.time_to_period(walltime_dt); start_date)
+        walltime_cb =
+            TimeManager.Callback(schedule_walltime, TimeManager.WalltimeReporter())
         callbacks = (checkpoint_cb, walltime_cb)
     end
 

--- a/src/SimCoordinator.jl
+++ b/src/SimCoordinator.jl
@@ -65,7 +65,7 @@ function run!(
     # We use the `ClimaComms.@elapsed` macro to time the simulation on both CPU and GPU and use this
     # value to calculate the simulated years per day (SYPD) of the simulation.
     @info "Starting coupling loop"
-    t_timed_start = float(cs.t[]) # get t just before timing (equal to cs.tspan[begin] if `precompile` is false)
+    t_timed_start = cs.t[] # get t just before timing (equal to cs.tspan[begin] if `precompile` is false)
     walltime = ClimaComms.@elapsed ClimaComms.device(cs) begin
         while cs.t[] < cs.tspan[end]
             step!(cs)

--- a/src/SimCoordinator.jl
+++ b/src/SimCoordinator.jl
@@ -65,11 +65,7 @@ function run!(
     # We use the `ClimaComms.@elapsed` macro to time the simulation on both CPU and GPU and use this
     # value to calculate the simulated years per day (SYPD) of the simulation.
     @info "Starting coupling loop"
-    # The precompilation steps above already advanced `cs.t[]`, so the timed loop only covers
-    # `t_timed_start` to `cs.tspan[end]`. Snapshot the start so timing metrics reflect the
-    # simulated time actually spanned during timing (this equals `cs.tspan[begin]` when no
-    # precompilation ran).
-    t_timed_start = float(cs.t[])
+    t_timed_start = float(cs.t[]) # get t just before timing (equal to cs.tspan[begin] if `precompile` is false)
     walltime = ClimaComms.@elapsed ClimaComms.device(cs) begin
         while cs.t[] < cs.tspan[end]
             step!(cs)

--- a/src/TimeManager.jl
+++ b/src/TimeManager.jl
@@ -9,7 +9,6 @@ module TimeManager
 import Dates
 import ..Interfacer
 import ..Utilities: time_to_seconds
-import ClimaUtilities.OnlineLogging: WallTimeInfo, report_walltime
 
 """
     time_to_period(s::String)
@@ -49,6 +48,16 @@ function time_to_period(s::String)
         return Dates.Millisecond(1000 * time_to_seconds(s))
     end
 end
+
+"""
+    simulated_years_per_day(t_start, t_end, walltime)
+
+Compute the simulated years per walltime day for a simulation spanning from
+`t_start` to `t_end` (in seconds), assuming that the simulation took `walltime`
+(in seconds) to run.
+"""
+simulated_years_per_day(t_start, t_end, walltime) =
+    float(t_end - t_start) / walltime / 365.25
 
 """
     Callback
@@ -102,27 +111,86 @@ function (::NeverSchedule)(args...)
 end
 
 """
-    capped_geometric_walltime_cb(t_start, t_end, Δt_cpl)
+    WalltimeReporter()
 
-Create a callback that reports walltime at when the number of steps taken is a power of 2, or
-when the percent of the simulation that is completed is a multiple of 5. This skips the
-first two steps to avoid compilation time noise.
+A callable object that logs the progress of a coupled simulation.
+
+A `WalltimeReporter` is meant to be used as the function of a `Callback`: it is
+called with the `CoupledSimulation` as its only argument and reads the current
+time, start date, time span, and coupling time step from it.
+
+The wall time of the first call is dominated by compilation, so it is not
+measured; instead, the first measurement (between the first and second calls) is 
+scaled up to estimate the compilation-free wall time of the steps before it.
 """
-function capped_geometric_walltime_cb(t_start, t_end, Δt_cpl)
-    tot_steps = Int(ceil(float(t_end - t_start) / float(Δt_cpl)))
-    five_percent_steps = ceil(Int, 0.05 * tot_steps)
-    steps_taken = (integrator) -> float(integrator.t - t_start) / float(Δt_cpl)
-    walltime_report_cond =
-        (integrator) -> begin
-            nsteps = steps_taken(integrator)
-            # skip first two steps for compilation
-            (nsteps <= 2) && return false
-            return nsteps % five_percent_steps == 0 || ispow2(nsteps)
+struct WalltimeReporter
+    n_calls::Base.RefValue{Int}
+    wall_time_last::Base.RefValue{Float64}
+    sim_time_last::Base.RefValue{Float64}
+    wall_time_elapsed::Base.RefValue{Float64}
+end
+WalltimeReporter() = WalltimeReporter(Ref(0), Ref(0.0), Ref(0.0), Ref(0.0))
+
+function (reporter::WalltimeReporter)(cs)
+    # t, t_start, t_end, Δt_cpl, and date from the coupled simulation
+    t = float(cs.t[])
+    t_start, t_end = float.(cs.tspan)
+    Δt_cpl = float(cs.Δt_cpl)
+    date = cs.start_date + Dates.Second(round(Int, t))
+
+    # compute the number of steps completed, total number of steps, and percent complete
+    n_steps = max(1, round(Int, (t - t_start) / Δt_cpl))
+    n_steps_total = ceil(Int, (t_end - t_start) / Δt_cpl) #TODO: This doesn't support t_end = Inf
+    percent_complete = round(100 * (t - t_start) / (t_end - t_start); digits = 1)
+
+    # begin info message
+    msg = """
+        Progress
+          time = $date ($(compact_time_str(t - t_start)))
+          step = $n_steps ($percent_complete%)"""
+
+    reporter.n_calls[] += 1
+    if reporter.n_calls[] > 1
+        Δt_wall = time() - reporter.wall_time_last[]
+        if reporter.wall_time_elapsed[] == 0
+            # Scale the first measurement to also cover the steps before the
+            # previous call, whose wall time was discarded as compilation
+            Δt_wall *= (t - t_start) / (t - reporter.sim_time_last[])
         end
-    walltime_affect! = let wt = WallTimeInfo()
-        (coupled_sim) -> report_walltime(wt, coupled_sim.model_sims.atmos_sim.integrator)
+        reporter.wall_time_elapsed[] += Δt_wall
+
+        wall_time_remaining =
+            reporter.wall_time_elapsed[] / n_steps * (n_steps_total - n_steps)
+        finish_date =
+            trunc(Dates.now() + Dates.Second(round(Int, wall_time_remaining)), Dates.Second)
+        sypd = simulated_years_per_day(t_start, t, reporter.wall_time_elapsed[])
+        msg *= "\n  walltime remaining ≈ $(compact_time_str(wall_time_remaining)) ($finish_date)"
+        msg *= "\n  sypd ≈ $(round(sypd; sigdigits = 4))"
     end
-    return TimeManager.Callback(walltime_report_cond, walltime_affect!)
+    reporter.sim_time_last[] = t
+    reporter.wall_time_last[] = time()
+    @info msg
+    return nothing
+end
+
+"""
+    compact_time_str(seconds)
+
+Return a compact string for a duration given in `seconds` using the two largest nonzero units. 
+
+Example: `compact_time_str(59580.0) == "16 h 33 m"`.
+"""
+function compact_time_str(seconds)
+    remaining = round(Int, seconds)
+    remaining < 1 && return "0 s"
+    parts = String[]
+    for (unit, unit_length) in
+        (("y", 31557600), ("d", 86400), ("h", 3600), ("m", 60), ("s", 1))
+        n, remaining = divrem(remaining, unit_length)
+        n > 0 && push!(parts, "$n $unit")
+        length(parts) == 2 && break
+    end
+    return join(parts, " ")
 end
 
 end

--- a/test/input_tests.jl
+++ b/test/input_tests.jl
@@ -153,16 +153,21 @@ end
     @test haskey(args.component_dt_dict, "dt_atmos")
     @test !haskey(args.component_dt_dict, "dt")
 
-    # If unspecified, walltime_dt defaults to a quarter of the simulation length
-    @test args.walltime_dt == "200.0secs"
+    # If unspecified, walltime_dt defaults to a tenth of the simulation length, but
+    # never shorter than one coupling step. Here a tenth of 800secs is 80secs, which is
+    # below dt_cpl (400secs), so it is set to dt_cpl.
+    @test args.walltime_dt == "400.0secs"
+    # ... for a longer simulation, the tenth-of-length rule applies (8000secs / 10)
+    config_dict["t_end"] = "8000secs"
+    @test Input.get_coupler_args(config_dict).walltime_dt == "800.0secs"
     # ... capped at one day
     config_dict["t_end"] = "3650days"
     @test Input.get_coupler_args(config_dict).walltime_dt == "86400.0secs"
-    config_dict["t_end"] = "800secs"
+    config_dict["t_end"] = "800secs" # undo
     # If specified, walltime_dt is passed through unchanged
     config_dict["walltime_dt"] = "never"
     @test Input.get_coupler_args(config_dict).walltime_dt == "never"
-    delete!(config_dict, "walltime_dt")
+    delete!(config_dict, "walltime_dt") # undo
 end
 
 @testset "get_diag_period" begin

--- a/test/input_tests.jl
+++ b/test/input_tests.jl
@@ -152,6 +152,17 @@ end
     @test args.component_dt_dict isa Dict
     @test haskey(args.component_dt_dict, "dt_atmos")
     @test !haskey(args.component_dt_dict, "dt")
+
+    # If unspecified, walltime_dt defaults to a quarter of the simulation length
+    @test args.walltime_dt == "200.0secs"
+    # ... capped at one day
+    config_dict["t_end"] = "3650days"
+    @test Input.get_coupler_args(config_dict).walltime_dt == "86400.0secs"
+    config_dict["t_end"] = "800secs"
+    # If specified, walltime_dt is passed through unchanged
+    config_dict["walltime_dt"] = "never"
+    @test Input.get_coupler_args(config_dict).walltime_dt == "never"
+    delete!(config_dict, "walltime_dt")
 end
 
 @testset "get_diag_period" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,9 @@ end
 @safetestset "Utilities tests" begin
     include("utilities_tests.jl")
 end
+@safetestset "TimeManager tests" begin
+    include("timemanager_tests.jl")
+end
 @safetestset "FieldExchanger tests" begin
     include("field_exchanger_tests.jl")
 end

--- a/test/timemanager_tests.jl
+++ b/test/timemanager_tests.jl
@@ -1,0 +1,57 @@
+#=
+    Unit tests for ClimaCoupler TimeManager module
+=#
+import Test: @testset, @test, @test_logs, @test_throws
+import Dates
+import ClimaCoupler: TimeManager
+
+@testset "time_to_period" begin
+    @test TimeManager.time_to_period("2months") == Dates.Month(2)
+    @test TimeManager.time_to_period("10secs") == Dates.Millisecond(10_000)
+    @test TimeManager.time_to_period("2.5hours") == Dates.Millisecond(9_000_000)
+    @test_throws ErrorException TimeManager.time_to_period("never")
+end
+
+@testset "Callback triggering" begin
+    n_triggered = Ref(0)
+    cb = TimeManager.Callback(integrator -> integrator.t > 1.0, cs -> n_triggered[] += 1)
+
+    TimeManager.maybe_trigger_callback(cb, (; t = Ref(0.5)))
+    @test n_triggered[] == 0
+    TimeManager.maybe_trigger_callback(cb, (; t = Ref(2.0)))
+    @test n_triggered[] == 1
+
+    never_cb = TimeManager.Callback(TimeManager.NeverSchedule(), cs -> n_triggered[] += 1)
+    TimeManager.maybe_trigger_callback(never_cb, (; t = Ref(2.0)))
+    @test n_triggered[] == 1
+end
+
+@testset "WalltimeReporter" begin
+    @test TimeManager.compact_time_str(0.0) == "0 s"
+    @test TimeManager.compact_time_str(59580.0) == "16 h 33 m"
+    @test TimeManager.compact_time_str(2 * 86400.0) == "2 d"
+
+    reporter = TimeManager.WalltimeReporter()
+    fake_cs(t) = (;
+        t = Ref(t),
+        Δt_cpl = 400.0,
+        tspan = (0.0, 86400.0),
+        start_date = Dates.DateTime(2010),
+    )
+
+    # The first call reports progress but discards the wall time (compilation)
+    @test_logs (:info, r"^Progress\n  time = 2010-01-01T00:06:40") reporter(fake_cs(400.0))
+    @test reporter.wall_time_elapsed[] == 0.0
+
+    # The second call reports timing estimates; its measurement is scaled by
+    # (t - t_start) / (t - t_previous) = 2 to cover the pre-compilation steps
+    sleep(0.1)
+    @test_logs (:info, r"walltime remaining ≈ .*\n  sypd ≈ ") reporter(fake_cs(800.0))
+    @test reporter.wall_time_elapsed[] >= 2 * 0.09
+
+    # Later calls accumulate wall time without scaling
+    elapsed_before = reporter.wall_time_elapsed[]
+    sleep(0.1)
+    @test_logs (:info, r"^Progress") reporter(fake_cs(1200.0))
+    @test 0.09 <= reporter.wall_time_elapsed[] - elapsed_before <= 1.0
+end

--- a/test/utilities_tests.jl
+++ b/test/utilities_tests.jl
@@ -5,7 +5,6 @@ import Test: @testset, @test
 import ClimaComms
 ClimaComms.@import_required_backends
 import ClimaCoupler: Utilities
-import ClimaCoupler: TimeManager
 import ClimaCore as CC
 
 # Initialize MPI context, in case
@@ -71,32 +70,5 @@ for FT in (Float32, Float64)
             rtol = 1e-5,
         )
         @test Utilities.integral(ones(space3d)) == sum(ones(space3d))
-    end
-
-    @testset "WallTime Callback" begin
-        t_start = 0.0
-        t_end = 10.0
-        Δt_cpl = 0.1
-
-        cb = TimeManager.capped_geometric_walltime_cb(t_start, t_end, Δt_cpl)
-
-        # First two steps should not trigger
-        fake_integrator = (; t = t_start + Δt_cpl)
-        @test !cb.schedule(fake_integrator)
-        fake_integrator = (; t = t_start + Δt_cpl * 2)
-        @test !cb.schedule(fake_integrator)
-        # step 4, 8, 16 should trigger
-        fake_integrator = (; t = t_start + Δt_cpl * 4)
-        @test cb.schedule(fake_integrator)
-        fake_integrator = (; t = t_start + Δt_cpl * 8)
-        @test cb.schedule(fake_integrator)
-        fake_integrator = (; t = t_start + Δt_cpl * 14)
-        @test !cb.schedule(fake_integrator)
-        fake_integrator = (; t = t_start + Δt_cpl * 16)
-        @test cb.schedule(fake_integrator)
-
-        # 20% should trigger
-        fake_integrator = (; t = t_start + Δt_cpl * 20)
-        @test cb.schedule(fake_integrator)
     end
 end


### PR DESCRIPTION
Removed `capped_geometric_walltime_cb` in `TimeManager` in favor of a `WalltimeReporter` type that
- prints every `"1days"` or at least `(t_end - t_start) / 10` (but never less than `dt_cpl`) by default,
- prints the *coupler* step (no longer `ClimaAtmos`'s), and
- is more compact and visually pleasing. 