### PR TITLE
Pin JuliaFormatter to v2.10.1

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: julia-actions/julia-format@v4
         with:
-          version: '1' # Set `version` to '1.0.62' if you run into issues
-          # To use the same JuliaFormatter version locally, run: `julia -e 'using Pkg; Pkg.add(PackageSpec("JuliaFormatter", v"1.0.62"))'`
+          version: '2.10.1' # Pinned JuliaFormatter version
+          # To use the same JuliaFormatter version locally, run: `julia -e 'using Pkg; Pkg.add(PackageSpec("JuliaFormatter", v"2.10.1"))'`
           suggestion-label: 'format-suggest' # leave this unset or empty to show suggestions for all PRs

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -64,7 +64,7 @@ been discontinued in favor of using the JuliaFormatter package directly.
 To format your code, first add JuliaFormatter to your base environment:
 
 ```sh
-julia -e 'using Pkg; Pkg.add(PackageSpec("JuliaFormatter", v"1.0.62"))'
+julia -e 'using Pkg; Pkg.add(PackageSpec("JuliaFormatter", v"2.10.1"))'
 ```
 
 Then, in a Julia REPL, run:

--- a/experiments/test/fluxes_test.jl
+++ b/experiments/test/fluxes_test.jl
@@ -129,8 +129,7 @@ import ClimaCoupler: FluxCalculator
 
     # Combine component fluxes by area-weighted sum (incl. bucket sign convention):
     combined_fluxes =
-        .-land_fraction .* land_flux .+ ice_fraction .* ice_rad_flux .+
-        ocean_fraction .* ocean_rad_flux
+        .-land_fraction .* land_flux .+ ice_fraction .* ice_rad_flux .+ ocean_fraction .* ocean_rad_flux
 
     @info "Combined fluxes: $(combined_fluxes)"
     @info "Atmos flux: $(atmos_flux)"

--- a/ext/ClimaCouplerCMIPExt/clima_seaice.jl
+++ b/ext/ClimaCouplerCMIPExt/clima_seaice.jl
@@ -329,17 +329,16 @@ NVTX.@annotate function FluxCalculator.compute_surface_fluxes!(
     T_sfc = csf.scalar_temp1
 
     # Surface humidity
-    ρ_sfc =
-        SF.surface_density.(
-            surface_fluxes_params,
-            csf.T_atmos,
-            csf.ρ_atmos,
-            T_sfc,
-            csf.height_int .- csf.height_sfc,
-            csf.q_tot_atmos,
-            0,
-            0,
-        )
+    ρ_sfc = SF.surface_density.(
+        surface_fluxes_params,
+        csf.T_atmos,
+        csf.ρ_atmos,
+        T_sfc,
+        csf.height_int .- csf.height_sfc,
+        csf.q_tot_atmos,
+        0,
+        0,
+    )
     csf.scalar_temp2 .= TD.q_vap_saturation.(thermo_params, T_sfc, ρ_sfc, 0, 0)
     q_sfc = csf.scalar_temp2
 
@@ -348,46 +347,43 @@ NVTX.@annotate function FluxCalculator.compute_surface_fluxes!(
     roughness_params = FluxCalculator.get_roughness_params(csf, sim)
     config = SF.SurfaceFluxConfig.(roughness_params, SF.ConstantGustinessSpec.(gustiness))
 
-    fluxes =
-        FluxCalculator.get_surface_fluxes.(
-            surface_fluxes_params,
-            uv_int,
-            csf.T_atmos,
-            csf.q_tot_atmos,
-            csf.q_liq_atmos,
-            csf.q_ice_atmos,
-            csf.ρ_atmos,
-            csf.height_int,
-            uv_int .* FT(0),
-            T_sfc,
-            q_sfc,
-            csf.height_sfc,
-            FT(0),
-            config,
-            update_T_sfc_cb,
-        )
+    fluxes = FluxCalculator.get_surface_fluxes.(
+        surface_fluxes_params,
+        uv_int,
+        csf.T_atmos,
+        csf.q_tot_atmos,
+        csf.q_liq_atmos,
+        csf.q_ice_atmos,
+        csf.ρ_atmos,
+        csf.height_int,
+        uv_int .* FT(0),
+        T_sfc,
+        q_sfc,
+        csf.height_sfc,
+        FT(0),
+        config,
+        update_T_sfc_cb,
+    )
 
     FluxCalculator.update_flux_fields!(csf, sim, fluxes, accumulator)
     area_fraction = Interfacer.get_field(sim, Val(:area_fraction))
 
     # Write diagnosed T_sfc back to ClimaSeaIce (Kelvin → Celsius, only where ice exists)
-    csf.scalar_temp2 .=
-        ifelse.(
-            area_fraction .≈ 0,
-            zero(FT),
-            fluxes.T_sfc_new .- FT(sim.ice_properties.C_to_K),
-        )
+    csf.scalar_temp2 .= ifelse.(
+        area_fraction .≈ 0,
+        zero(FT),
+        fluxes.T_sfc_new .- FT(sim.ice_properties.C_to_K),
+    )
     Interfacer.remap!(sim.remapping.scratch_field_oc1, csf.scalar_temp2, sim.remapping)
     remapped_T_sfc = OC.interior(sim.remapping.scratch_field_oc1, :, :, 1)
 
     ice_concentration = sim.ice.model.ice_concentration
     top_sfc_T = top_thermodynamics(sim).top_surface_temperature
-    OC.interior(top_sfc_T, :, :, 1) .=
-        ifelse.(
-            OC.interior(ice_concentration, :, :, 1) .> 0,
-            remapped_T_sfc,
-            OC.interior(top_sfc_T, :, :, 1),
-        )
+    OC.interior(top_sfc_T, :, :, 1) .= ifelse.(
+        OC.interior(ice_concentration, :, :, 1) .> 0,
+        remapped_T_sfc,
+        OC.interior(top_sfc_T, :, :, 1),
+    )
 
     return nothing
 end

--- a/ext/ClimaCouplerClimaAtmosExt.jl
+++ b/ext/ClimaCouplerClimaAtmosExt.jl
@@ -308,14 +308,14 @@ function Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:diffuse_fraction
     else
         direct_flux_dn = radiation_model.face_sw_direct_flux_dn[1, :]
         FT = eltype(total_flux_dn)
-        diffuse_fraction =
-            clamp.(
-                (
-                    (x, y) -> y > zero(y) ? x / y : zero(y)
-                ).(total_flux_dn .- direct_flux_dn, total_flux_dn),
-                zero(FT),
-                one(FT),
-            )
+        diffuse_fraction = clamp.(
+            ((x, y) -> y > zero(y) ? x / y : zero(y)).(
+                total_flux_dn .- direct_flux_dn,
+                total_flux_dn,
+            ),
+            zero(FT),
+            one(FT),
+        )
     end
     return CC.Fields.array2field(diffuse_fraction, lowest_face_space)
 end
@@ -386,17 +386,16 @@ function Interfacer.update_field!(sim::ClimaAtmosSimulation, ::Val{:surface_humi
 
     # TODO: Is csf.height_int .- csf.height_sfc allocating?
     # TODO: Add two scratch fields for q_liq_atmos and q_ice_atmos
-    csf.scalar_temp4 .=
-        SF.surface_density.(
-            surface_fluxes_params,
-            T_atmos,
-            ρ_atmos,
-            csf.T_sfc,
-            csf.height_int .- csf.height_sfc,
-            q_tot_atmos,
-            0, # q_liq
-            0, # q_ice
-        )
+    csf.scalar_temp4 .= SF.surface_density.(
+        surface_fluxes_params,
+        T_atmos,
+        ρ_atmos,
+        csf.T_sfc,
+        csf.height_int .- csf.height_sfc,
+        q_tot_atmos,
+        0, # q_liq
+        0, # q_ice
+    )
     ρ_sfc = csf.scalar_temp4
 
     thermo_params = get_thermo_params(sim)
@@ -495,8 +494,7 @@ function FluxCalculator.update_turbulent_fluxes!(sim::ClimaAtmosSimulation, fiel
     Interfacer.remap!(temp_field_surface, F_turb_ρτxz) # F_turb_ρτxz_atmos
     F_turb_ρτyz_atmos = Interfacer.remap(atmos_surface_space, F_turb_ρτyz) # F_turb_ρτyz_atmos
     sim.integrator.p.precomputed.sfc_conditions.ρ_flux_uₕ .= (
-        surface_normal .⊗
-        CA.C12.(
+        surface_normal .⊗ CA.C12.(
             temp_field_surface .* vec_ct12_ct1 .+ F_turb_ρτyz_atmos .* vec_ct12_ct2,
             surface_local_geometry,
         )
@@ -826,13 +824,12 @@ function Interfacer.set_albedos!(sim::Models.PrescribedOceanSimulation, t)
 
     # Get the atmospheric wind vector and the cosine of the zenith angle
     surface_coords = CC.Fields.coordinate_field(axes(sim.cache.T_sfc))
-    insolation_tuple =
-        Insolation.insolation.(
-            current_date,
-            surface_coords.lat,
-            surface_coords.long,
-            insolation_params,
-        )
+    insolation_tuple = Insolation.insolation.(
+        current_date,
+        surface_coords.lat,
+        surface_coords.long,
+        insolation_params,
+    )
     cos_zenith_angle = insolation_tuple.μ
     wind_atmos = LinearAlgebra.norm.(CC.Geometry.Covariant12Vector.(p.u_int, p.v_int)) # wind vector from components
     λ = FT(0) # spectral wavelength (not used for now)

--- a/ext/ClimaCouplerClimaLandExt/climaland_bucket.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_bucket.jl
@@ -315,11 +315,10 @@ end
 function Interfacer.update_field!(sim::BucketSimulation, ::Val{:air_velocity}, u_int, v_int)
     Interfacer.remap!(sim.integrator.p.bucket.scratch1, u_int)
     Interfacer.remap!(sim.integrator.p.bucket.scratch2, v_int)
-    sim.integrator.p.drivers.u .=
-        StaticArrays.SVector.(
-            sim.integrator.p.bucket.scratch1,
-            sim.integrator.p.bucket.scratch2,
-        )
+    sim.integrator.p.drivers.u .= StaticArrays.SVector.(
+        sim.integrator.p.bucket.scratch1,
+        sim.integrator.p.bucket.scratch2,
+    )
 end
 function Interfacer.update_field!(sim::BucketSimulation, ::Val{:snow_precipitation}, field)
     ρ_liq = LP.ρ_cloud_liq(sim.model.parameters.earth_param_set)
@@ -407,26 +406,25 @@ function FluxCalculator.compute_surface_fluxes!(
     momentum_fluxes = Val(CL.return_momentum_fluxes(coupled_atmos))
     gustiness = SF.ConstantGustinessSpec(coupled_atmos.gustiness)
 
-    bucket_dest .=
-        CL.turbulent_fluxes_at_a_point.(
-            momentum_fluxes,
-            p.drivers.P,
-            p.drivers.T,
-            p.drivers.q,
-            p.drivers.u,
-            coupled_atmos.h,
-            T_sfc,
-            q_sfc,
-            roughness_model,
-            update_T_sfc,
-            update_q_sfc,
-            h_sfc,
-            displ,
-            update_∂T_sfc∂T,
-            update_∂q_sfc∂T,
-            gustiness,
-            earth_param_set,
-        )
+    bucket_dest .= CL.turbulent_fluxes_at_a_point.(
+        momentum_fluxes,
+        p.drivers.P,
+        p.drivers.T,
+        p.drivers.q,
+        p.drivers.u,
+        coupled_atmos.h,
+        T_sfc,
+        q_sfc,
+        roughness_model,
+        update_T_sfc,
+        update_q_sfc,
+        h_sfc,
+        displ,
+        update_∂T_sfc∂T,
+        update_∂q_sfc∂T,
+        gustiness,
+        earth_param_set,
+    )
 
     # Per-component: remap bucket-space src into `csf.scalar_temp1`, area-mask, add the
     # area-weighted contribution to `csf.F_*`, and (slow case) also add the masked value

--- a/ext/ClimaCouplerMakieExt/diagnostics_plots.jl
+++ b/ext/ClimaCouplerMakieExt/diagnostics_plots.jl
@@ -249,12 +249,11 @@ function make_plots_generic(
     end
 
     # Standardizes grid layout
-    gridlayout() =
-        map(1:MAX_PLOTS_PER_PAGE) do i
-            row = mod(div(i - 1, MAX_NUM_COLS), MAX_NUM_ROWS) + 1
-            col = mod(i - 1, MAX_NUM_COLS) + 1
-            return fig[row, col] = CairoMakie.GridLayout()
-        end
+    gridlayout() = map(1:MAX_PLOTS_PER_PAGE) do i
+        row = mod(div(i - 1, MAX_NUM_COLS), MAX_NUM_ROWS) + 1
+        col = mod(i - 1, MAX_NUM_COLS) + 1
+        return fig[row, col] = CairoMakie.GridLayout()
+    end
 
     fig = makefig()
     grid = gridlayout()

--- a/ext/ClimaCouplerMakieExt/leaderboard/leaderboard.jl
+++ b/ext/ClimaCouplerMakieExt/leaderboard/leaderboard.jl
@@ -105,9 +105,7 @@ function Plotting.compute_leaderboard(
                 sim_var.attributes["short_name"] = "mean $(ClimaAnalysis.short_name(sim_var))"
                 cmap_extrema = get(compare_vars_biases_plot_extrema, short_name) do
                     extrema(
-                        ClimaAnalysis.bias(
-                            sim_obs_comparsion_dict[short_name]["ANN"]...,
-                        ).data,
+                        ClimaAnalysis.bias(sim_obs_comparsion_dict[short_name]["ANN"]...).data,
                     )
                 end
                 ClimaAnalysis.Visualize.plot_bias_on_globe!(

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -385,17 +385,16 @@ NVTX.@annotate function compute_surface_fluxes!(
     T_sfc = csf.scalar_temp1
 
     # TODO: This is not accurate - we shouldn't assume condensate is 0.
-    ρ_sfc =
-        SF.surface_density.(
-            surface_fluxes_params,
-            csf.T_atmos,
-            csf.ρ_atmos,
-            T_sfc,
-            csf.height_int .- csf.height_sfc,
-            csf.q_tot_atmos,
-            0, # q_liq
-            0, # q_ice
-        )
+    ρ_sfc = SF.surface_density.(
+        surface_fluxes_params,
+        csf.T_atmos,
+        csf.ρ_atmos,
+        T_sfc,
+        csf.height_int .- csf.height_sfc,
+        csf.q_tot_atmos,
+        0, # q_liq
+        0, # q_ice
+    )
 
     csf.scalar_temp2 .= TD.q_vap_saturation.(thermo_params, T_sfc, ρ_sfc, 0, 0)
     q_sfc = csf.scalar_temp2
@@ -407,23 +406,22 @@ NVTX.@annotate function compute_surface_fluxes!(
 
     # Set surface velocity to zero for now
     uv_sfc = @lazy @. (uv_int * FT(0))
-    fluxes =
-        FluxCalculator.get_surface_fluxes.(
-            surface_fluxes_params,
-            uv_int,
-            csf.T_atmos,
-            csf.q_tot_atmos,
-            csf.q_liq_atmos,
-            csf.q_ice_atmos,
-            csf.ρ_atmos,
-            csf.height_int, # h_int
-            uv_sfc,
-            T_sfc,
-            q_sfc,
-            csf.height_sfc, # h_sfc
-            FT(0), # d
-            config,
-        )
+    fluxes = FluxCalculator.get_surface_fluxes.(
+        surface_fluxes_params,
+        uv_int,
+        csf.T_atmos,
+        csf.q_tot_atmos,
+        csf.q_liq_atmos,
+        csf.q_ice_atmos,
+        csf.ρ_atmos,
+        csf.height_int, # h_int
+        uv_sfc,
+        T_sfc,
+        q_sfc,
+        csf.height_sfc, # h_sfc
+        FT(0), # d
+        config,
+    )
 
     # Update the coupler fields and surface simulation with the fluxes
     update_flux_fields!(csf, sim, fluxes, accumulator)

--- a/src/SimCoordinator.jl
+++ b/src/SimCoordinator.jl
@@ -422,9 +422,9 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
     slow_surface_keys = Tuple(
         name for (name, sim) in pairs(model_sims) if
         sim isa Interfacer.AbstractSurfaceSimulation &&
-        !(sim isa Interfacer.AbstractImplicitFluxSimulation) &&
-        !(sim isa Interfacer.AbstractSurfaceStub) &&
-        Interfacer.sim_dt(sim) > Δt_cpl_secs
+            !(sim isa Interfacer.AbstractImplicitFluxSimulation) &&
+            !(sim isa Interfacer.AbstractSurfaceStub) &&
+            Interfacer.sim_dt(sim) > Δt_cpl_secs
     )
     flux_accumulators = NamedTuple{slow_surface_keys}(
         Tuple(FluxCalculator.FluxAccumulator(boundary_space) for _ in slow_surface_keys),

--- a/test/flux_calculator_tests.jl
+++ b/test/flux_calculator_tests.jl
@@ -175,11 +175,10 @@ for FT in (Float32, Float64)
         # Compute expected fluxes
         # Get atmosphere properties
         height_int = Interfacer.get_field(atmos_sim, Val(:height_int))
-        uv_int =
-            StaticArrays.SVector.(
-                Interfacer.get_field(atmos_sim, Val(:u_int)),
-                Interfacer.get_field(atmos_sim, Val(:v_int)),
-            )
+        uv_int = StaticArrays.SVector.(
+            Interfacer.get_field(atmos_sim, Val(:u_int)),
+            Interfacer.get_field(atmos_sim, Val(:v_int)),
+        )
         surface_fluxes_params = FluxCalculator.get_surface_params(atmos_sim)
 
         # Get surface properties
@@ -190,42 +189,39 @@ for FT in (Float32, Float64)
 
         T_sfc = Interfacer.get_field(ocean_sim, Val(:surface_temperature))
         q_sfc = zeros(boundary_space)
-        ρ_sfc =
-            SF.surface_density.(
-                surface_fluxes_params,
-                fields.T_atmos,
-                fields.ρ_atmos,
-                T_sfc,
-                height_int .- height_sfc,
-                fields.q_tot_atmos,
-                0, # q_liq
-                0, # q_ice
-            )
+        ρ_sfc = SF.surface_density.(
+            surface_fluxes_params,
+            fields.T_atmos,
+            fields.ρ_atmos,
+            T_sfc,
+            height_int .- height_sfc,
+            fields.q_tot_atmos,
+            0, # q_liq
+            0, # q_ice
+        )
         q_sfc .= TD.q_vap_saturation.(thermo_params, T_sfc, ρ_sfc, 0, 0)
 
-        config =
-            SF.SurfaceFluxConfig.(
-                SF.ConstantRoughnessParams.(z0m, z0b),
-                SF.ConstantGustinessSpec.(gustiness),
-            )
+        config = SF.SurfaceFluxConfig.(
+            SF.ConstantRoughnessParams.(z0m, z0b),
+            SF.ConstantGustinessSpec.(gustiness),
+        )
 
-        fluxes_expected =
-            FluxCalculator.get_surface_fluxes.(
-                surface_fluxes_params,
-                uv_int,
-                atmos_sim.integrator.T,
-                atmos_sim.integrator.q,
-                0, # q_liq
-                0, # q_ice
-                atmos_sim.integrator.ρ,
-                height_int,
-                StaticArrays.SVector.(0, 0), # uv_sfc
-                T_sfc,
-                q_sfc,
-                height_sfc,
-                0, # d
-                Ref(config),
-            )
+        fluxes_expected = FluxCalculator.get_surface_fluxes.(
+            surface_fluxes_params,
+            uv_int,
+            atmos_sim.integrator.T,
+            atmos_sim.integrator.q,
+            0, # q_liq
+            0, # q_ice
+            atmos_sim.integrator.ρ,
+            height_int,
+            StaticArrays.SVector.(0, 0), # uv_sfc
+            T_sfc,
+            q_sfc,
+            height_sfc,
+            0, # d
+            Ref(config),
+        )
 
         # Compare expected and computed fluxes
         @test fields.F_turb_ρτxz ≈ fluxes_expected.F_turb_ρτxz


### PR DESCRIPTION
## Summary
- Pin JuliaFormatter to an exact version (`2.10.1`) in the formatter GitHub Action and `docs/src/contributing.md` so formatting is reproducible across CI and local runs.
- Reformat the codebase with JuliaFormatter v2.10.1 (whitespace/style only, no logic changes).

See [Pinning the JuliaFormatter version](https://juliaeditorsupport.github.io/JuliaFormatter.jl/stable/status/#Pinning-the-JuliaFormatter-version) for why pinning is recommended.

## Test plan
- [x] `git diff` reviewed — formatting-only changes
- [ ] CI passes