### PR TITLE
Fix command formatting for Buildkite pipeline

### DIFF
--- a/.buildkite/longruns/pipeline.yml
+++ b/.buildkite/longruns/pipeline.yml
@@ -183,12 +183,8 @@ steps:
 
       - label: ":thermometer: Cess climate sensitivity approximation from p2K runs"
         key: "cess_from_p2k"
-        command: >-
-          julia --color=yes --project=experiments/AMIP/
-            test/cess_climate_sensitivity.jl
-            output/amip_progedmf_land
-            output/amip_progedmf_land_p2k
-            output/ecs_analysis
+        command:
+          - "julia --color=yes --project=experiments/AMIP/ test/cess_climate_sensitivity.jl output/amip_progedmf_land output/amip_progedmf_land_p2k output/ecs_analysis"
         artifact_paths: "output/ecs_analysis/*"
         agents:
           queue: clima


### PR DESCRIPTION
The formatting of the command leads to opening a Julia REPL.