### PR TITLE
Decrease test spatial resolution to reduce ci time

### DIFF
--- a/config/amip_configs/amip_calibration_pipeline_test.yml
+++ b/config/amip_configs/amip_calibration_pipeline_test.yml
@@ -1,0 +1,55 @@
+# Low-resolution copy of amip_calibration.yml for the Buildkite pipeline
+# smoke test (TEST_CALIBRATION). Production calibration keeps h_elem: 12.
+FLOAT_TYPE: "Float32"
+
+### Grid ###
+h_elem: 4
+z_max: 60000.0
+z_elem: 63
+dz_bottom: 30.0
+topo_smoothing: true
+topography: "Earth"
+
+### Time and Simulation ###
+start_date: "20100101"
+initial_condition: "WeatherModel"
+t_end: "39days"
+dt: "180secs"
+dt_cpl: "180secs"
+dt_seaice: "180secs"
+checkpoint_dt: "900days"
+
+### Coupler ###
+mode_name: "subseasonal"
+binary_area_fraction: false
+atmos_config_file: "config/atmos_configs/climaatmos_wx_progedmf.yml"
+coupler_toml: ["toml/wxquest_progedmf.toml"]
+energy_check: false
+
+### Atmosphere ###
+radiation_reset_rng_seed: true
+albedo_model: "CouplerAlbedo"
+surface_setup: "PrescribedSurface"
+strict_params: false
+
+### Land ###
+lai_source: "modis_monthly_climatology"
+land_fraction_source: "era5"
+land_model: "integrated"
+land_spun_up_ic: false
+land_temperature_anomaly: "nothing"
+
+### Diagnostics ###
+netcdf_output_at_levels: true
+output_default_diagnostics: false
+use_coupler_diagnostics: false
+use_land_diagnostics: false
+extra_atmos_diagnostics:
+  - short_name: [tas, pr, mslp, rsut, rsutcs, rlut, rlutcs, rsdt, lwp]
+    period: monthly
+    reduction_time: average
+  - short_name: [ta, hur, pfull]
+    period: monthly
+    reduction_time: average
+    pressure_coordinates: true
+    compute_every: 6hours

--- a/config/ci_configs/amip_component_dts.yml
+++ b/config/ci_configs/amip_component_dts.yml
@@ -8,7 +8,7 @@ dt_rad: "1hours"
 dt_seaice: "90secs"
 dz_bottom: 30
 energy_check: false
-h_elem: 16
+h_elem: 8
 mode_name: "amip"
 rad: "gray"
 microphysics_model: "0M"

--- a/experiments/calibration/amip/config/pipeline_test.jl
+++ b/experiments/calibration/amip/config/pipeline_test.jl
@@ -9,9 +9,13 @@
 # completing one iteration will catch most errors with the full calibration
 # pipeline
 
-# Define which coupler config to use
-config_file =
-    joinpath(pkgdir(ClimaCoupler), "config", "amip_configs", "amip_calibration.yml")
+# Define which coupler config to use (coarse h_elem for CI smoke test only)
+config_file = joinpath(
+    pkgdir(ClimaCoupler),
+    "config",
+    "amip_configs",
+    "amip_calibration_pipeline_test.yml",
+)
 
 # Calibrate only on Jan 1 2010
 sample_date_ranges =

--- a/experiments/test/amip_test.yml
+++ b/experiments/test/amip_test.yml
@@ -6,7 +6,7 @@ dt: "180secs"
 dt_cpl: "180secs"
 dz_bottom: 100.0
 energy_check: false
-h_elem: 8
+h_elem: 4
 checkpoint_dt: "720hours"
 bucket_albedo_type: "map_temporal"
 land_model: "integrated"

--- a/experiments/test/restart_cmip.yml
+++ b/experiments/test/restart_cmip.yml
@@ -12,7 +12,7 @@ dt_seaice: "240secs"
 dt_rad: "120secs"
 dz_bottom: 100.0
 energy_check: false
-h_elem: 6
+h_elem: 4
 checkpoint_dt: "480secs"
 ice_model: "clima_seaice"
 land_model: "integrated"


### PR DESCRIPTION
Component dt test runs at longrun resolution; decrease spatial resolution to facilitate faster ci runs. 
