### PR TITLE
SSA configs and adding ocean_fraction to Interfacer update

### DIFF
--- a/config/atmos_configs/climaatmos_edonly.yml
+++ b/config/atmos_configs/climaatmos_edonly.yml
@@ -12,7 +12,7 @@ implicit_diffusion: true
 insolation: "timevarying"
 netcdf_output_at_levels: true
 ode_algo: ARS343
-prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
+prescribed_aerosols: ["CB", "DST", "OC", "SO4", "SSLT"]
 rad: "allskywithclear"
 rayleigh_sponge: true
 surface_setup: "DefaultMoninObukhov"

--- a/config/atmos_configs/climaatmos_progedmf.yml
+++ b/config/atmos_configs/climaatmos_progedmf.yml
@@ -19,7 +19,7 @@ implicit_diffusion: true
 insolation: "timevarying"
 netcdf_output_at_levels: true
 ode_algo: ARS222
-prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
+prescribed_aerosols: ["CB", "DST", "OC", "SO4", "SSLT"]
 prognostic_tke: true
 rad: "allskywithclear"
 rayleigh_sponge: true

--- a/config/atmos_configs/climaatmos_wx_progedmf_SSA.yml
+++ b/config/atmos_configs/climaatmos_wx_progedmf_SSA.yml
@@ -1,7 +1,7 @@
 aerosol_radiation: true
 approximate_linear_solve_iters: 2
 cloud_model: "quadrature"
-dt: "120secs"
+dt: "40secs"
 dt_cloud_fraction: "1hours"
 dt_rad: "1hours"
 dt_save_state_to_disk: "30days"
@@ -14,12 +14,13 @@ edmfx_sgs_diffusive_flux: true
 edmfx_sgs_mass_flux: true
 edmfx_upwinding: "first_order"
 edmfx_vertical_diffusion: true
-h_elem: 16
+h_elem: 30
 implicit_diffusion: true
 insolation: "timevarying"
 netcdf_output_at_levels: true
 ode_algo: ARS222
-prescribed_aerosols: ["CB", "DST", "OC", "SO4", "SSLT"]
+prescribed_aerosols: ["CB", "DST", "OC", "SO4"]
+prognostic_aerosols: ["SSLT"]
 prognostic_tke: true
 rad: "allskywithclear"
 rayleigh_sponge: true

--- a/config/benchmark_configs/climaatmos.yml
+++ b/config/benchmark_configs/climaatmos.yml
@@ -10,7 +10,7 @@ h_elem: 30
 implicit_diffusion: true
 insolation: "timevarying"
 output_default_diagnostics: false
-prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
+prescribed_aerosols: ["CB", "DST", "OC", "SO4", "SSLT"]
 rad: allskywithclear
 surface_setup: DefaultMoninObukhov
 t_end: 12hours

--- a/config/benchmark_configs/climaatmos_progedmf.yml
+++ b/config/benchmark_configs/climaatmos_progedmf.yml
@@ -20,7 +20,7 @@ insolation: "timevarying"
 microphysics_model: "0M"
 ode_algo: ARS222
 output_default_diagnostics: false
-prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
+prescribed_aerosols: ["CB", "DST", "OC", "SO4", "SSLT"]
 prognostic_tke: true
 rad: allskywithclear
 surface_setup: DefaultMoninObukhov

--- a/config/subseasonal_configs/wxquest_progedmf_SSA.yml
+++ b/config/subseasonal_configs/wxquest_progedmf_SSA.yml
@@ -1,0 +1,50 @@
+FLOAT_TYPE: "Float32"
+albedo_model: "CouplerAlbedo"
+atmos_config_file: "config/atmos_configs/climaatmos_wx_progedmf_SSA.yml"
+coupler_toml: ["toml/amip_progedmf.toml"]
+strict_params: false
+mode_name: "subseasonal"
+era5_initial_condition_dir: "/net/sampo/data1/wxquest_data/initial_conditions/initial_conditions_v1_dev"
+initial_condition: "WeatherModel"
+checkpoint_dt: "1000days"
+dt: "40secs"
+dt_cpl: "40secs"
+dt_seaice: "40secs"
+divergence_damping_factor: 20.0
+energy_check: false
+h_elem: 30
+z_max: 70000.0
+z_elem: 70
+land_fraction_source: "era5"
+binary_area_fraction: false
+
+### integrated land ###
+land_model: "integrated"
+lai_source: "modis_monthly_climatology"
+
+### bucket land ###
+# land_model: "bucket"
+# bucket_albedo_type: "map_temporal"
+
+land_spun_up_ic: false
+land_temperature_anomaly: "nothing"
+use_land_diagnostics: true
+radiation_reset_rng_seed: true
+start_date: "20100101"
+surface_setup: "PrescribedSurface"
+topo_smoothing: true
+topography: "Earth"
+t_end: "14days"
+netcdf_output_at_levels: true
+use_coupler_diagnostics: true
+extra_atmos_diagnostics:
+  - short_name: [zg, orog, tas, ta, thetaa, mslp, pr, ua, va, ts, rhoa, pfull, hur, hus, clw, cli, clivi, clwvi, cl, arup, tke, hfss, hfls, evspsbl, hussfc, rsds, rlds, rlus, rsus, rld, wa, waup]
+    period: 24hours
+    reduction_time: average
+  - short_name: [
+      rhoa, hur,
+      loadss,
+      mmrss, mmrsslt01, mmrsslt02, mmrsslt03, mmrsslt04, mmrsslt05
+    ]
+    period: 1hours
+    reduction_time: average

--- a/ext/ClimaCouplerClimaAtmosExt.jl
+++ b/ext/ClimaCouplerClimaAtmosExt.jl
@@ -407,6 +407,13 @@ end
 Interfacer.get_field(sim::ClimaAtmosSimulation, ::Val{:water}) =
     ρq_tot(sim.integrator.p.atmos.microphysics_model, sim.integrator)
 
+
+function Interfacer.update_field!(sim::ClimaAtmosSimulation, ::Val{:ocean_fraction}, field)
+    # warn and skip when no ocean_fraction cache field
+    hasproperty(sim.integrator.p, :ocean_fraction) ||
+        return Interfacer.update_field_warning(sim, Val(:ocean_fraction))
+    Interfacer.remap!(sim.integrator.p.ocean_fraction, field)
+end
 function Interfacer.update_field!(
     sim::ClimaAtmosSimulation,
     ::Val{:surface_temperature},

--- a/src/FieldExchanger.jl
+++ b/src/FieldExchanger.jl
@@ -228,6 +228,7 @@ function update_sim!(atmos_sim::Interfacer.AbstractAtmosSimulation, csf)
         csf.surface_diffuse_albedo,
     )
     Interfacer.update_field!(atmos_sim, Val(:emissivity), csf.emissivity)
+    Interfacer.update_field!(atmos_sim, Val(:ocean_fraction), csf.ocean_area_fraction)
     Interfacer.update_field!(atmos_sim, Val(:surface_temperature), csf.T_sfc)
     Interfacer.update_field!(atmos_sim, Val(:surface_humidity), csf)
     return nothing

--- a/src/Interfacer.jl
+++ b/src/Interfacer.jl
@@ -341,6 +341,7 @@ update_field!(
     sim::AbstractAtmosSimulation,
     val::Union{
         Val{:emissivity},
+        Val{:ocean_fraction},
         Val{:surface_direct_albedo},
         Val{:surface_diffuse_albedo},
         Val{:surface_temperature},


### PR DESCRIPTION
## PR Dependency
 - Associated with [ClimaAtmos.jl #4713](https://github.com/CliMA/ClimaAtmos.jl/pull/4713) which adds the `p.ocean_fraction` cache field and `interactive_aerosols` config option in service of interactive sea salt aerosol implementation.

## Wiring changes
 - New `Interfacer.update_field!` method in `ClimaCouplerClimaAtmosExt.jl` maps ClimaCoupler's `ocean_area_fraction` onto ClimaAtmos's `p.ocean_fraction` cache, called from `FieldExchanger.update_sim!` to refresh ocean fraction every coupling step (allowing for changing sea ice)
 - `update_field!` added to Interfacer warn-and-skip fallbacks

## Config changes
 - New atmos_config `climaatmos_wx_progedmf_SSA.yml`: wxquest PrognosticEDMFX atmosphere config with interactive sea salt, prescribed MERRA-2 aerosols for the remaining species, and aerosol radiation enabled
 - New subseasonal_config `wxquest_progedmf_SSA.yml`: subseasonal coupled driver for the above, with per-bin mass mixing ratio (`mmrsslt0X`), column load (`loadss`), and emission flux (`emiss`, `emisslt0X`) diagnostics