### PR TITLE
Increase default walltime dt to 30 days

### DIFF
--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -114,7 +114,7 @@ Note: the `mode_name` determines which Julia environment to use. Use `experiment
 | `--dt_ocean` | String | `nothing` | `"Nsecs"`, `"Nmins"`, `"Nhours"`, `"Ndays"`, `"Inf"` | Ocean simulation time step (alternative to `dt`) |
 | `--dt_seaice` | String | `nothing` | `"Nsecs"`, `"Nmins"`, `"Nhours"`, `"Ndays"`, `"Inf"` | Sea ice simulation time step (alternative to `dt`) |
 | `--checkpoint_dt` | String | `"90days"` | `"Nsecs"`, `"Nmins"`, `"Nhours"`, `"Ndays"`, `"Inf"` | Time interval for checkpointing |
-| `--walltime_dt` | String | `nothing` | `"Nsecs"`, `"Nmins"`, `"Nhours"`, `"Ndays"`, `"Nmonths"`, `"never"` | Time interval for walltime reporting. Defaults to a quarter of the simulation length, at most 1 day. Set to `"never"` to disable. |
+| `--walltime_dt` | String | `nothing` | `"Nsecs"`, `"Nmins"`, `"Nhours"`, `"Ndays"`, `"Nmonths"`, `"never"` | Time interval for walltime reporting. Defaults to a tenth of the simulation length, at most 30 days. Set to `"never"` to disable. |
 
 Note: If any component model-specific timestep is specified, _all_ component-model
 specific timesteps should be specified, rather than only `dt`.

--- a/src/Input.jl
+++ b/src/Input.jl
@@ -546,9 +546,9 @@ function get_coupler_args(config_dict::Dict)
     # Walltime reporting information
     walltime_dt = get(config_dict, "walltime_dt", nothing)
     if isnothing(walltime_dt)
-        # default to a tenth of the simulation length (capped at one day, but never
+        # default to a tenth of the simulation length (capped at 30 days, but never
         # shorter than one coupling step)
-        walltime_dt_secs = max(min(float(t_end - t_start) / 10, 86400.0), float(Δt_cpl))
+        walltime_dt_secs = max(min(float(t_end - t_start) / 10, 2592000.0), float(Δt_cpl))
         walltime_dt = "$(walltime_dt_secs)secs"
     end
 

--- a/test/input_tests.jl
+++ b/test/input_tests.jl
@@ -162,7 +162,7 @@ end
     @test Input.get_coupler_args(config_dict).walltime_dt == "800.0secs"
     # ... capped at 30 days
     config_dict["t_end"] = "3650days"
-    @test Input.get_coupler_args(config_dict).walltime_dt == "2592000.0secs"
+    @test Input.get_coupler_args(config_dict).walltime_dt == "2.592e6secs"
     config_dict["t_end"] = "800secs" # undo
     # If specified, walltime_dt is passed through unchanged
     config_dict["walltime_dt"] = "never"

--- a/test/input_tests.jl
+++ b/test/input_tests.jl
@@ -160,9 +160,9 @@ end
     # ... for a longer simulation, the tenth-of-length rule applies (8000secs / 10)
     config_dict["t_end"] = "8000secs"
     @test Input.get_coupler_args(config_dict).walltime_dt == "800.0secs"
-    # ... capped at one day
+    # ... capped at 30 days
     config_dict["t_end"] = "3650days"
-    @test Input.get_coupler_args(config_dict).walltime_dt == "86400.0secs"
+    @test Input.get_coupler_args(config_dict).walltime_dt == "2592000.0secs"
     config_dict["t_end"] = "800secs" # undo
     # If specified, walltime_dt is passed through unchanged
     config_dict["walltime_dt"] = "never"


### PR DESCRIPTION
So that nightly/longrun simulations are less noisy.