### PR TITLE
Use main branch of ClimaCoreMakie for nightly run

### DIFF
--- a/.buildkite/nightly/pipeline.yml
+++ b/.buildkite/nightly/pipeline.yml
@@ -25,6 +25,7 @@ steps:
       # For this pipeline, use the main branches of certain upstream packages
       - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaAtmos\", rev=\"main\"))'"
       - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaCore\", rev=\"main\"))'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaCoreMakie\", rev=\"main\"))'"
       - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaTimeSteppers\", rev=\"main\"))'"
       - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"Thermodynamics\", rev=\"main\"))'"
       - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.add(Pkg.PackageSpec(;name=\"ClimaLand\", rev=\"main\"))'"


### PR DESCRIPTION
For the error in https://buildkite.com/clima/climacoupler-coarse-nightly-amip/builds/1354#019fa545-4164-4edf-a997-555f3ec12685/L357, this happens because the nightly pipeline is using the main branch of ClimaCore, but not the main branch of ClimaCoreMakie. With the main branch of ClimaCore, `size(ClimaCore.Spaces.local_geometry_data(space))` returns a tuple of length 4 while the latest release of ClimaCoreMakie expects a tuple of length 5.

This issue is fixed by also using the main branch of ClimaCoreMakie.