### PR TITLE
Fix error from ocean's output writer

### DIFF
--- a/ext/ClimaCouplerCMIPExt/climaocean_helpers.jl
+++ b/ext/ClimaCouplerCMIPExt/climaocean_helpers.jl
@@ -8,12 +8,18 @@ Extract the top boundary conditions for the given field.
 """
 function surface_flux(f::OC.AbstractField)
     top_bc = f.boundary_conditions.top
-    if top_bc isa OC.BoundaryCondition{<:OC.BoundaryConditions.Flux}
-        return top_bc.condition
-    else
+    if !(top_bc isa OC.BoundaryCondition{<:OC.BoundaryConditions.Flux})
         return nothing
     end
+    return flux_field(top_bc.condition)
 end
+
+flux_field(condition) = condition
+flux_field(bc::OC.BoundaryConditions.DiscreteBoundaryFunction) = flux_field(bc.func)
+
+# `MultipleFluxes` is internal to NumericalEarth, once we detach completely and restore 
+# real salinity fluxes, we will add `MultipleFluxes` that follows this path
+flux_field(func::Function) = func.flux_field
 
 """
     set_from_extrinsic_vector!(vector, grid, u_cc, v_cc)

--- a/ext/ClimaCouplerCMIPExt/ocean_simulation.jl
+++ b/ext/ClimaCouplerCMIPExt/ocean_simulation.jl
@@ -1,8 +1,8 @@
 import Oceananigans.BoundaryConditions: DefaultBoundaryCondition
 import Oceananigans.DistributedComputations: all_reduce
-import Oceananigans.Architectures: ReactantState, AbstractArchitecture
+import Oceananigans.Architectures: ReactantState, AbstractArchitecture, architecture
 import Oceananigans.Operators: ℑxyᶠᶜᵃ, ℑxyᶜᶠᵃ, ∂xᶠᶜᶜ, ∂yᶜᶠᶜ
-import Oceananigans.TimeSteppers: AdaptiveVerticallyImplicitDiscretization
+import Oceananigans.TimeSteppers: AdaptiveVerticallyImplicitDiscretization, Clock
 import Oceananigans.Units: hours, minutes
 import Oceananigans.OrthogonalSphericalShellGrids:
     TripolarGridOfSomeKind, north_fold_boundary_condition


### PR DESCRIPTION
`CO` is still wired in which means that temperature and salinity top bcs pick from NumericalEarth where we use real fluxes for salinity and temperature, which in turn means that T and S top boundary conditions are `DiscreteBoundaryFunctions` which we need to extract.

This correction will not be needed after #2059, but is propaedeutic to when we will need to implement real fluxes