### PR TITLE
Replace calibration scalar covariance with SVDPlusD, set shared NaN mask for covariance data

### DIFF
--- a/experiments/calibration/amip/config/pipeline_test.jl
+++ b/experiments/calibration/amip/config/pipeline_test.jl
@@ -25,6 +25,11 @@ sample_date_ranges =
 # directory (e.g. "/glade/derecho/scratch")
 output_dir = joinpath(pkgdir(ClimaCoupler), "amip_calibration")
 
+# Interannual sample dates used to estimate the SVDplusDCovariance. Every entry
+# of sample_date_ranges must be contained in these.
+const COVARIANCE_DATE_RANGES =
+    [(Dates.DateTime(y, 10, 1), Dates.DateTime(y, 10, 1)) for y in 2006:2010]
+
 # spinup and sample_date_ranges are chosen to match the only dates
 # available in the wxquest_initial_conditions artifact
 const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
@@ -46,6 +51,10 @@ const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
 # Used in generate_observations.jl and observation_map.jl
 # Units: Pa (not hPa)
 const PRESSURE_LEVELS = 100.0 .* [200.0, 500.0, 850.0]
+
+# Spatial reduction. An integer block-averages the lon-lat grid by that factor,
+# `nothing` takes a zonal average instead.
+const COARSEN_FACTOR = nothing
 
 # To disable normalization, update generate_observations.jl to not apply the
 # normalization. You may want to do the same in the observation map as well.

--- a/experiments/calibration/amip/config/pressure_levels.jl
+++ b/experiments/calibration/amip/config/pressure_levels.jl
@@ -10,6 +10,11 @@ sample_date_ranges =
 # directory (e.g. "/glade/derecho/scratch")
 output_dir = joinpath(pkgdir(ClimaCoupler), "amip_calibration")
 
+# Interannual sample dates used to estimate the SVDplusDCovariance. Every entry
+# of sample_date_ranges must be contained in these.
+const COVARIANCE_DATE_RANGES =
+    [(Dates.DateTime(y, 10, 1), Dates.DateTime(y, 10, 1)) for y in 2006:2010]
+
 const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
     config_file,
     # Note: Pressure-level variables require model output with
@@ -24,9 +29,21 @@ const CALIBRATE_CONFIG = CalibrationTools.CalibrateConfig(;
     rng_seed = 42,
 )
 
+# Per-group model error floors: the covariance diagonal gets
+# (model_error_scale * field mean)^2, the bias the model keeps at the best
+# parameter values. 0.2 for lwp is validated against interannual spread
+const OBS_NOISE_GROUPS = [
+    (short_names = ["lwp"], model_error_scale = 0.2),
+    (short_names = ["ta", "hur"], model_error_scale = 0.1),
+]
+
 # Used in generate_observations.jl and observation_map.jl
 # Units: Pa (not hPa)
 const PRESSURE_LEVELS = 100.0 .* [200.0, 500.0, 850.0]
+
+# Spatial reduction. An integer block-averages the lon-lat grid by that factor,
+# `nothing` takes a zonal average instead.
+const COARSEN_FACTOR = nothing
 
 # To disable normalization, update generate_observations.jl to not apply the
 # normalization. You may want to do the same in the observation map as well.

--- a/experiments/calibration/amip/correlated_noise.jl
+++ b/experiments/calibration/amip/correlated_noise.jl
@@ -1,0 +1,225 @@
+# Correlated diagonal noise for SVDplusD covariance
+#
+# The SVDplusD covariance is a low-rank interannual part plus a diagonal D. The
+# diagonal treats every grid point as an independent constraint. On a 2-D grid
+# points are strongly correlated, so a diagonal claims far more information
+# than the field contains and the ensemble collapses.
+#
+# This file splits D into a downweighted diagonal and a spatially correlated
+# term:
+#
+#     f * D + (1 - f) * sqrt(D) * K * sqrt(D),   K_ii = 1,   K_ij = exp(-d_ij / L)
+#
+# where d_ij is the great-circle distance between points i and j and L is the
+# decorrelation length. f is the fraction of the floor variance that stays
+# independent at each point, which is the retrieval noise and the
+# representativeness error of a grid cell. The rest is model bias, which is
+# spatially coherent. Points in different variables, levels, or times stay
+# uncorrelated. Because K_ii = 1 the two terms sum to D on the diagonal, so the
+# diagonal of the covariance is unchanged. A cluster of points inside one
+# L-sized patch then counts as roughly one independent constraint.
+#
+# The result is stored as a dense `LinearAlgebra.Symmetric` matrix instead of an
+# `EKP.SVDplusD` (whose floor must be `Diagonal`). Consumers that only read the
+# covariance diagonal (steering indicators, preflight) are unaffected.
+
+import LinearAlgebra
+import ClimaAnalysis
+import EnsembleKalmanProcesses as EKP
+
+const EARTH_RADIUS = 6.371e6
+
+"""
+    great_circle_distance(lat1, lon1, cos_lat1, lat2, lon2, cos_lat2)
+
+Great-circle distance in meters between two points, from latitudes and
+longitudes in radians and the two latitude cosines. The caller precomputes the
+trigonometry once per point instead of once per pair.
+"""
+function great_circle_distance(lat1, lon1, cos_lat1, lat2, lon2, cos_lat2)
+    # This could use ClimaCore.Geometry.unit_great_circle_distance
+    a = sin((lat2 - lat1) / 2)^2 + cos_lat1 * cos_lat2 * sin((lon2 - lon1) / 2)^2
+    return 2 * EARTH_RADIUS * asin(min(1.0, sqrt(a)))
+end
+
+"""
+    group_indices(group_keys)
+
+Map each distinct entry of `group_keys` to the flattened indices that carry it,
+so the pair loop can walk one level-time slice at a time.
+"""
+function group_indices(group_keys)
+    groups = Dict{eltype(group_keys), Vector{Int}}()
+    for (i, key) in enumerate(group_keys)
+        push!(get!(() -> Int[], groups, key), i)
+    end
+    return groups
+end
+
+"""
+    flattened_point_geometry(metadata)
+
+Return `(lats, lons, group_keys)` for the points kept by the flattening
+described by `metadata` (a `ClimaAnalysis` flatten `Metadata`), in flattened
+order. `group_keys[i]` collects the non-horizontal coordinates (level, time) of
+point `i`; only points with equal keys are correlated.
+"""
+function flattened_point_geometry(metadata)
+    dims = collect(metadata.ordered_dims)
+    conv = ClimaAnalysis.conventional_dim_name.(dims)
+    # Coordinate values along each dimension, in flattening order
+    axes_vals = [collect(metadata.dims[d]) for d in dims]
+    sz = Tuple(length.(axes_vals))
+    # Turns a linear index into the full grid into one index per dimension
+    ci = CartesianIndices(sz)
+    # Linear indices of the points that the flattening keeps
+    kept = findall(!, metadata.drop_mask)
+
+    lat_index = findfirst(==("latitude"), conv)
+    isnothing(lat_index) && error("Correlated floor needs a latitude dimension; got $conv")
+    lon_index = findfirst(==("longitude"), conv)
+
+    # Positions of the non-horizontal dimensions (level and time)
+    other_is = [i for i in eachindex(dims) if i != lat_index && i != lon_index]
+
+    # For each kept point, read its latitude index out of ci, then its value
+    lats = [axes_vals[lat_index][ci[k][lat_index]] for k in kept]
+    # Assume zonal mean if there is no longitude dimension
+    lons =
+        isnothing(lon_index) ? zeros(length(kept)) :
+        [axes_vals[lon_index][ci[k][lon_index]] for k in kept]
+    # One tuple of level and time values per kept point
+    group_keys = [Tuple(axes_vals[i][ci[k][i]] for i in other_is) for k in kept]
+    return lats, lons, group_keys
+end
+
+"""
+    add_correlated_floor!(
+        total_cov, floor_sd, offset, metadata, decorrelation_length;
+        identity_fraction,
+    )
+
+Add `f * D + (1 - f) * sqrt(D) * K * sqrt(D)` for one variable block into
+`total_cov`, starting at row and column `offset + 1`, and return the number of
+points added. `f` is `identity_fraction`, and `floor_sd` holds `sqrt(D)` for the
+whole covariance.
+
+`K` is the correlation kernel, with `d_ij` the great-circle distance in meters:
+
+    K_ii = 1
+    K_ij = exp(-d_ij / decorrelation_length)
+    K_ij = 0     for i and j on different levels or at different times
+
+`f` is the share of the floor variance that stays independent at each point.
+Because `K_ii = 1`, the two terms sum to `D` on the diagonal, so `total_cov`
+gains exactly `D` there. `f` also holds the smallest eigenvalue of the floor at
+or above `f * D`, which keeps the covariance invertible at large
+`decorrelation_length`, where the correlated term on its own approaches rank 1.
+"""
+function add_correlated_floor!(
+    total_cov,
+    floor_sd,
+    offset,
+    metadata,
+    decorrelation_length;
+    identity_fraction,
+)
+    lats, lons, group_keys = flattened_point_geometry(metadata)
+    m = length(lats)
+    # Per-point trigonometry, reused by every pair the point takes part in
+    lats_rad = deg2rad.(lats)
+    lons_rad = deg2rad.(lons)
+    cos_lats = cos.(lats_rad)
+    scale = 1.0 - identity_fraction
+
+    # f * D from the first term plus (1 - f) * D from the second, since K_ii = 1
+    for i in 1:m
+        total_cov[offset + i, offset + i] += floor_sd[offset + i]^2
+    end
+
+    # Only points within one level/time slice correlate, so walk the pairs of
+    # each slice
+    for idxs in values(group_indices(group_keys))
+        for (p, a) in enumerate(idxs), b in view(idxs, (p + 1):lastindex(idxs))
+            d = great_circle_distance(
+                lats_rad[a],
+                lons_rad[a],
+                cos_lats[a],
+                lats_rad[b],
+                lons_rad[b],
+                cos_lats[b],
+            )
+            ga = offset + a
+            gb = offset + b
+            c = scale * exp(-d / decorrelation_length) * floor_sd[ga] * floor_sd[gb]
+            total_cov[ga, gb] += c
+            total_cov[gb, ga] += c
+        end
+    end
+    return m
+end
+
+"""
+    correlate_noise_floor(cov, metadata_vec, decorrelation_length; identity_fraction)
+
+Split the diagonal floor D of an `EKP.SVDplusD` covariance into
+`f * D + (1 - f) * sqrt(D) * K * sqrt(D)` and return the full covariance as a
+dense `LinearAlgebra.Symmetric` matrix. `metadata_vec` holds one flatten
+`Metadata` per variable, in the same order as the covariance blocks. The
+covariance diagonal is unchanged.
+"""
+function correlate_noise_floor(
+    cov::EKP.SVDplusD,
+    metadata_vec,
+    decorrelation_length;
+    identity_fraction,
+)
+    n = first(size(cov))
+    # Reconstruct the low-rank interannual part as a dense matrix, then
+    # accumulate the floor blocks into it
+    svd_cov = EKP.get_svd_cov(cov)
+    total_cov = svd_cov.U * LinearAlgebra.Diagonal(svd_cov.S) * svd_cov.Vt
+    floor_sd = sqrt.(EKP.get_diag_cov(cov).diag)
+
+    off = 0
+    for md in metadata_vec
+        off += add_correlated_floor!(
+            total_cov,
+            floor_sd,
+            off,
+            md,
+            decorrelation_length;
+            identity_fraction,
+        )
+    end
+    off == n || error("Metadata blocks cover $off points but the covariance has $n rows")
+    return LinearAlgebra.Symmetric(total_cov)
+end
+
+"""
+    apply_floor_correlation(obs_vec, decorrelation_length; identity_fraction)
+
+Rebuild every `EKP.Observation` in `obs_vec` with a correlated noise floor.
+All observations share one covariance.
+
+This is the entry point, so it carries the only `identity_fraction` default.
+The functions it calls require the value.
+"""
+function apply_floor_correlation(obs_vec, decorrelation_length; identity_fraction = 0.05)
+    corr_cov = correlate_noise_floor(
+        only(EKP.get_covs(first(obs_vec))),
+        EKP.get_metadata(first(obs_vec)),
+        decorrelation_length;
+        identity_fraction,
+    )
+    return map(obs_vec) do obs
+        EKP.Observation(
+            Dict(
+                "samples" => EKP.get_obs(obs),
+                "covariances" => corr_cov,
+                "names" => first(EKP.get_names(obs)),
+                "metadata" => EKP.get_metadata(obs),
+            ),
+        )
+    end
+end

--- a/experiments/calibration/amip/generate_observations.jl
+++ b/experiments/calibration/amip/generate_observations.jl
@@ -1,9 +1,10 @@
 import ClimaAnalysis
 import ClimaAnalysis: OutputVar
 import ClimaCalibrate
-import ClimaCalibrate: ObservationRecipe, SampleBuilder
+import ClimaCalibrate: ObservationRecipe
 import ClimaCoupler
 import ClimaCoupler: CalibrationTools
+import EnsembleKalmanProcesses as EKP
 import JLD2
 
 include(
@@ -24,47 +25,83 @@ include(
         "preprocessing.jl",
     ),
 )
+include(
+    joinpath(
+        pkgdir(ClimaCoupler),
+        "experiments",
+        "calibration",
+        "amip",
+        "correlated_noise.jl",
+    ),
+)
 
 """
-    make_scalar_covariance_observation_vector(
+    make_data_informed_observation_vector(
         vars,
-        sample_date_ranges;
-        scalar = 1.0,
+        sample_date_ranges,
+        covariance_date_ranges;
+        model_error_scale = 0.1,
+        regularization = ClimaCalibrate.ObservationRecipe.QuantileRegularization(0.05),
         use_latitude_weights = true,
         min_cosd_lat = 0.1,
-        FT = Float32,
+        rank = nothing,
     )
 
-Make a vector of `EKP.Observation`s with a scalar covariance matrix, one for
-each sample corresponding to the dates in `sample_date_ranges`.
+Make one `EKP.Observation` per entry of `sample_date_ranges`, all sharing one
+`SVDplusDCovariance` estimated from the interannual spread over
+`covariance_date_ranges`.
 
-The `OutputVar`s in `vars` are windowed by the date ranges in
-`sample_date_ranges` to build the samples, and each sample in turn is used as
-the observation. The matrix of samples has element type `FT`.
+`sample_date_ranges` defines the date range of the sample data, while
+`covariance_date_ranges` defines the date range used to estimate the
+covariance.. Every sample entry must be contained in the covariance entries.
+
+Keyword arguments:
+- `model_error_scale`: adds `(model_error_scale * mean_sample)^2` to the
+  covariance diagonal, the error a perfect parameter set can not reduce.
+- `regularization`: conditioning floor, quantile-based so it scales per variable
+  in physical units.
+- `rank`: SVD rank, `nothing` infers it (at most n_covariance_dates - 1).
+- `decorrelation_length`: if set (meters), splits the diagonal floor D into
+  `f * D + (1 - f) * sqrt(D) * K * sqrt(D)` with `K_ij = exp(-d_ij / L)`, so a
+  patch of correlated points counts as one constraint rather than one per point.
+  See correlated_noise.jl.
 """
-function make_scalar_covariance_observation_vector(
+function make_data_informed_observation_vector(
     vars,
-    sample_date_ranges;
-    scalar = 1.0,
+    sample_date_ranges,
+    covariance_date_ranges;
+    model_error_scale = 0.1,
+    regularization = ClimaCalibrate.ObservationRecipe.QuantileRegularization(0.05),
     use_latitude_weights = true,
     min_cosd_lat = 0.1,
-    FT = Float32,
+    rank = nothing,
+    decorrelation_length = nothing,
 )
-    @info "Using scalar covariance matrix with"
-    @info "Scalar: $scalar"
+    @info "Using SVDplusD data-informed covariance with"
+    @info "Model error scale: $model_error_scale"
     @info "Latitude weighting: $use_latitude_weights"
-    @info "Min cosd lat: $min_cosd_lat"
-    covar_estimator =
-        ObservationRecipe.ScalarCovariance(; scalar, use_latitude_weights, min_cosd_lat)
-
-    # Each date range becomes one sample (one column of the sample collection)
-    sample_collection = SampleBuilder.build_samples_by_times(vars, sample_date_ranges; FT)
-    @info "Built samples" sample_collection
-
-    obs_vec = map(1:SampleBuilder.num_samples(sample_collection)) do i
-        ObservationRecipe.observation(covar_estimator, sample_collection, i)
+    @info "Covariance estimated from $(length(covariance_date_ranges)) dates"
+    covar_estimator = ClimaCalibrate.ObservationRecipe.SVDplusDCovariance(
+        covariance_date_ranges;
+        model_error_scale,
+        regularization,
+        use_latitude_weights,
+        min_cosd_lat,
+        rank,
+    )
+    obs_vec = map(sample_date_ranges) do sample_date_range
+        start_date = first(sample_date_range)
+        end_date = last(sample_date_range)
+        ClimaCalibrate.ObservationRecipe.observation(
+            covar_estimator,
+            vars,
+            start_date,
+            end_date,
+        )
     end
-    return obs_vec
+    isnothing(decorrelation_length) && return obs_vec
+    @info "Correlating the noise floor with decorrelation length $(decorrelation_length) m"
+    return apply_floor_correlation(obs_vec, decorrelation_length)
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__
@@ -106,26 +143,60 @@ if abspath(PROGRAM_FILE) == @__FILE__
     lat_right = 90
     vars = apply_lat_window.(vars, lat_left, lat_right)
 
-    # Normalize data
-    normalization_stats = Dict()
-    compute_normalization!.(Ref(normalization_stats), vars)
-    apply_normalization!.(Ref(normalization_stats), vars)
+    # Harmonize each variable's NaN pattern across the covariance dates so all
+    # SVDplusD samples have equal length.
+    foreach(v -> harmonize_nan_mask_over_dates!(v, COVARIANCE_DATE_RANGES), vars)
+
+    # Reduction
+    vars = reduce_spatial.(vars, COARSEN_FACTOR)
+
+    # No normalization: the SVDplusD covariance carries physical scales.
     (; output_dir) = CALIBRATE_CONFIG
-    JLD2.save_object(NORMALIZATION_STATS_FP, normalization_stats)
+    isfile(NORMALIZATION_STATS_FP) && rm(NORMALIZATION_STATS_FP)
 
-    # Create observation vector
     (; sample_date_ranges) = CALIBRATE_CONFIG
-    observation_vec = make_scalar_covariance_observation_vector(
-        vars,
-        sample_date_ranges;
-        scalar = 1.0,
-        use_latitude_weights = true,
-        min_cosd_lat = 0.1,
-    )
 
-    # Save observation vector
-    output_path = joinpath(pkgdir(ClimaCoupler), "experiments", "calibration", "amip")
-    JLD2.save_object(joinpath(output_path, "observation_vec.jld2"), observation_vec)
+    # A config may define OBS_NOISE_GROUPS to give variable groups their own
+    # model error floors. A floor should reflect the bias the model keeps at the
+    # best parameter values, which differs per observable.
+    noise_groups =
+        @isdefined(OBS_NOISE_GROUPS) ? OBS_NOISE_GROUPS :
+        [(short_names = short_names, model_error_scale = 0.2)]
+
+    grouped_obs_vecs = map(noise_groups) do group
+        group_vars =
+            filter(v -> ClimaAnalysis.short_name(v) in group.short_names, collect(vars))
+        isempty(group_vars) && error(
+            "OBS_NOISE_GROUPS entry $(group.short_names) matches no loaded variables",
+        )
+        make_data_informed_observation_vector(
+            group_vars,
+            sample_date_ranges,
+            COVARIANCE_DATE_RANGES;
+            model_error_scale = group.model_error_scale,
+            use_latitude_weights = true,
+            min_cosd_lat = 0.1,
+            decorrelation_length = hasproperty(group, :decorrelation_length) ?
+                                   group.decorrelation_length : nothing,
+        )
+    end
+    observation_vec = [
+        length(grouped_obs_vecs) == 1 ? grouped_obs_vecs[1][k] :
+        EKP.combine_observations([gv[k] for gv in grouped_obs_vecs]) for
+        k in eachindex(sample_date_ranges)
+    ]
+
+    # Saved observations and coverage masks 
+    coverage_masks = Dict{String, Any}(
+        ClimaAnalysis.short_name(v) => coverage_mask(v, COVARIANCE_DATE_RANGES) for
+        v in vars
+    )
+    JLD2.save_object(joinpath(output_dir, "observation_vec.jld2"), observation_vec)
+    JLD2.save_object(coverage_mask_path(output_dir), coverage_masks)
+    for (name, (dims, mask)) in coverage_masks
+        @info "Coverage mask for $name" dims missing_fraction =
+            round(count(mask) / length(mask); digits = 3)
+    end
 
     # Reconstruct the variables from the observation and show them for debugging
     for (i, obs) in enumerate(observation_vec)

--- a/experiments/calibration/amip/observation_map.jl
+++ b/experiments/calibration/amip/observation_map.jl
@@ -43,6 +43,26 @@ function preprocess_sim_vars(vars)
     lat_right = 90
     vars = apply_lat_window.(vars, lat_left, lat_right)
 
+    # Mask the simulation to the observation's coverage, so both sides average
+    # over the same points.
+    coverage_fp = coverage_mask_path(CALIBRATE_CONFIG.output_dir)
+    if isfile(coverage_fp)
+        coverage_masks = JLD2.load_object(coverage_fp)
+        vars = map(vars) do var
+            entry = get(coverage_masks, ClimaAnalysis.short_name(var), nothing)
+            isnothing(entry) && return var
+            return apply_coverage_mask(var, entry...)
+        end
+    else
+        @warn "No coverage masks found; simulation zonal means will average all \
+               longitudes even where the observation has no data. Regenerate the \
+               observations to create them." coverage_fp
+    end
+
+    # Must match the reduction in generate_observations.jl so G aligns with
+    # the observation vector
+    vars = reduce_spatial.(vars, COARSEN_FACTOR)
+
     if isfile(NORMALIZATION_STATS_FP)
         # Note: This should not be used with SVDplusDCovariance matrix
         normalization_stats = JLD2.load_object(NORMALIZATION_STATS_FP)

--- a/experiments/calibration/amip/preprocessing.jl
+++ b/experiments/calibration/amip/preprocessing.jl
@@ -43,6 +43,207 @@ function apply_lat_window(var, lat_left, lat_right)
     return var
 end
 
+#Reduce `var` to a NaN-aware zonal (longitude) mean.
+function zonal_average(var)
+    ClimaAnalysis.has_longitude(var) || return var
+    @info "Zonal (longitude) averaging $(ClimaAnalysis.short_name(var))"
+    return ClimaAnalysis.average_lon(var; ignore_nan = true)
+end
+
+# Path of the saved observational coverage mask (see `coverage_mask` /
+# `apply_coverage_mask`).
+coverage_mask_path(output_dir) = joinpath(output_dir, "coverage_masks.jld2")
+
+# Dimension names of `var` in the order of its data axes.
+function ordered_dim_names(var)
+    idx_name = sort([(idx, name) for (name, idx) in var.dim2index])
+    return [name for (_, name) in idx_name]
+end
+
+"""
+    date_range_nan_mask(var, date_ranges)
+
+Union of `var`'s NaN points over the time slices in `date_ranges`: `true`
+where the value is missing at any of those dates. Restricted to `date_ranges`
+because a union over a decades-long record saturates to everything-missing.
+"""
+function date_range_nan_mask(var, date_ranges)
+    tname = ClimaAnalysis.time_name(var)
+    tidx = var.dim2index[tname]
+    all_dates = ClimaAnalysis.dates(var)
+
+    sel = Int[]
+    for (s, e) in date_ranges
+        idxs = findall(d -> s <= d <= e, all_dates)
+        isempty(idxs) && error(
+            "Date range ($s, $e) not found in $(ClimaAnalysis.short_name(var)); " *
+            "check the date ranges against the observational data.",
+        )
+        append!(sel, idxs)
+    end
+
+    nanmask = falses(size(selectdim(var.data, tidx, first(sel)))...)
+    for i in sel
+        nanmask .|= isnan.(selectdim(var.data, tidx, i))
+    end
+    return nanmask
+end
+
+"""
+    coverage_mask(var, date_ranges)
+
+Return `(dim_names, mask)` marking where `var` has no data over `date_ranges`.
+`mask` is a `Bool` array over the non-time dimensions (`true` = missing) and
+`dim_names` are those dimensions in mask axis order. `apply_coverage_mask`
+uses it to sample the simulation at the same points as the observation.
+"""
+function coverage_mask(var, date_ranges)
+    tname = ClimaAnalysis.time_name(var)
+    names = ordered_dim_names(var)
+    if isnothing(tname) || !(tname in names)
+        return (names, isnan.(Array(var.data)))
+    end
+    return (filter(!=(tname), names), date_range_nan_mask(var, date_ranges))
+end
+
+"""
+    apply_coverage_mask(var, dim_names, mask)
+
+Set `var` to NaN wherever `mask` (over `dim_names`, from `coverage_mask`) says
+the observation has no data, broadcast over time.
+
+Retrievals are not global (MAC `lwp` is ocean-only), so the observed zonal
+mean covers only the observed points. Masking the simulation first makes the
+two zonal means average over the same sample; without it the lwp bias flips
+sign. A no-op when the observation covers every point.
+"""
+function apply_coverage_mask(var, dim_names, mask)
+    tname = ClimaAnalysis.time_name(var)
+    var_names = filter(!=(tname), ordered_dim_names(var))
+    # Compare on conventional names: obs and sim may spell the same axis
+    # differently (e.g. `height` vs `z`).
+    var_canon = ClimaAnalysis.conventional_dim_name.(var_names)
+    mask_canon = ClimaAnalysis.conventional_dim_name.(dim_names)
+    if Set(var_canon) != Set(mask_canon)
+        @warn "coverage mask dimensions do not match variable; skipping mask" short_name =
+            ClimaAnalysis.short_name(var) var_names dim_names
+        return var
+    end
+    # Reorder the mask axes to match this variable's axis order.
+    perm = [findfirst(==(n), mask_canon) for n in var_canon]
+    m = permutedims(mask, perm)
+
+    data = copy(Array(var.data))
+    if isnothing(tname) || !(tname in ordered_dim_names(var))
+        size(m) == size(data) || (@warn "mask size mismatch; skipping"; return var)
+        data[m] .= NaN
+    else
+        tidx = var.dim2index[tname]
+        size(m) == size(selectdim(data, tidx, 1)) ||
+            (@warn "mask size mismatch; skipping"; return var)
+        for i in axes(data, tidx)
+            selectdim(data, tidx, i)[m] .= NaN
+        end
+    end
+    @info "Applied observational coverage mask to $(ClimaAnalysis.short_name(var))" masked_fraction =
+        round(count(m) / length(m); digits = 3)
+    return ClimaAnalysis.remake(var; data)
+end
+
+"""
+    block_mean(values, factor)
+
+Mean of each consecutive block of `factor` entries of `values`. Trailing
+entries that do not fill a block are dropped.
+"""
+block_mean(values, factor) = [
+    Statistics.mean(values[((k - 1) * factor + 1):(k * factor)]) for
+    k in 1:div(length(values), factor)
+]
+
+"""
+    coarsen_lonlat(var, factor)
+
+Block-average `var` onto a coarse longitude-latitude grid: each output cell
+is the cosd(latitude)-weighted mean of a `factor` x `factor` block of input
+cells, skipping NaNs. Block coordinates are the centers of the input
+coordinates; other dimensions pass through. The lon and lat sizes must divide
+by `factor`.
+
+This is the 2D counterpart of `zonal_average` for calibrations that keep
+geography. `ClimaAnalysis.resampled_as` is not suitable: it interpolates
+point values at the coarse nodes, which discards most of the data and
+spreads NaN from masked cells. A fully-NaN block stays NaN.
+"""
+function coarsen_lonlat(var, factor)
+    ClimaAnalysis.has_longitude(var) || return var
+    lonname = ClimaAnalysis.longitude_name(var)
+    latname = ClimaAnalysis.latitude_name(var)
+    # Extract longitude and latitude dimensions
+    lon_axis = var.dim2index[lonname]
+    lat_axis = var.dim2index[latname]
+    nlon = length(var.dims[lonname])
+    nlat = length(var.dims[latname])
+    (nlon % factor == 0 && nlat % factor == 0) ||
+        error("coarsen_lonlat: grid $(nlon)x$(nlat) does not divide by factor $factor")
+    @info "Coarsening $(ClimaAnalysis.short_name(var)) by $factor: " *
+          "$(nlon)x$(nlat) -> $(div(nlon, factor))x$(div(nlat, factor))"
+
+    # Latitude cosine weighting
+    lats = collect(var.dims[latname])
+    lat_weights = cosd.(lats)
+
+    # The output has the shape of the input with the two horizontal axes
+    # divided by factor
+    out_size = collect(size(var.data))
+    out_size[lon_axis] = div(nlon, factor)
+    out_size[lat_axis] = div(nlat, factor)
+    out = fill(NaN, out_size...)
+
+    for out_idx in CartesianIndices(Tuple(out_size))
+        # Input cells that this output cell covers
+        out_lon = out_idx[lon_axis]
+        out_lat = out_idx[lat_axis]
+        lon_block = ((out_lon - 1) * factor + 1):(out_lon * factor)
+        lat_block = ((out_lat - 1) * factor + 1):(out_lat * factor)
+
+        weighted_sum = 0.0
+        weight_sum = 0.0
+        for i_lon in lon_block, i_lat in lat_block
+            # Follow out_idx on every axis except the two horizontal ones,
+            # which walk the block
+            src_idx = ntuple(ndims(var.data)) do d
+                d == lon_axis ? i_lon : d == lat_axis ? i_lat : out_idx[d]
+            end
+            x = var.data[src_idx...]
+            # Leave masked cells out of both sums
+            isfinite(x) || continue
+            weighted_sum += lat_weights[i_lat] * x
+            weight_sum += lat_weights[i_lat]
+        end
+        # A fully masked block collects no weight and keeps its NaN
+        weight_sum > 0 && (out[out_idx] = weighted_sum / weight_sum)
+    end
+
+    # A coarse coordinate is the mean of the input coordinates it covers
+    new_dims = copy(var.dims)
+    new_dims[lonname] = block_mean(collect(var.dims[lonname]), factor)
+    new_dims[latname] = block_mean(lats, factor)
+    return ClimaAnalysis.remake(var; data = out, dims = new_dims)
+end
+
+"""
+    reduce_spatial(var, coarsen_factor)
+
+Apply the configured spatial reduction: `coarsen_lonlat` by `coarsen_factor`,
+or `zonal_average` when `coarsen_factor` is `nothing`. Apply identically to
+obs and sim so the flattened vectors stay aligned.
+"""
+function reduce_spatial(var, coarsen_factor)
+    isnothing(coarsen_factor) && return zonal_average(var)
+    return coarsen_lonlat(var, coarsen_factor)
+end
+
 """
     get_lonlat_regridder(config_file)
 
@@ -66,6 +267,31 @@ function get_lonlat_regridder(config_file)
 end
 
 """
+    harmonize_nan_mask_over_dates!(var, date_ranges)
+
+Force one shared NaN pattern across the dates in `date_ranges`: a point
+missing at any of those dates becomes NaN at every time slice.
+
+`SVDplusDCovariance` drops NaNs per sample and errors when the samples differ
+in length; satellite coverage varies year to year, so each covariance date
+would otherwise drop a different number of points.
+"""
+function harmonize_nan_mask_over_dates!(var, date_ranges)
+    tname = ClimaAnalysis.time_name(var)
+    isnothing(tname) && return var
+    tidx = var.dim2index[tname]
+
+    # Same mask construction as coverage_mask, so the observation and the
+    # simulation are restricted to the same points.
+    nanmask = date_range_nan_mask(var, date_ranges)
+
+    for i in axes(var.data, tidx)
+        selectdim(var.data, tidx, i)[nanmask] .= NaN
+    end
+    return var
+end
+
+"""
     set_unitless_units!(var)
 
 Set the units of `var` to "unitless" if the units is the empty string.
@@ -82,11 +308,13 @@ end
     compute_mean_and_stddev(normalization_stas, var::ClimaAnalysis.OutputVar)
 
 Generate normalization statistics by computing a single mean and standard
-deviation for `var`.
+deviation for `var`. Skips NaNs.
 """
 function compute_mean_and_stddev(var::ClimaAnalysis.OutputVar)
-    mean_of_var = Statistics.mean(var.data)
-    std_of_var = Statistics.std(var.data)
+    finite_data = filter(isfinite, var.data)
+    isempty(finite_data) && error("No finite data to normalize; check your data")
+    mean_of_var = Statistics.mean(finite_data)
+    std_of_var = Statistics.std(finite_data)
     std_of_var ≈ 0.0 && error("Standard deviation is zero; check your data")
     return (mean_of_var, std_of_var)
 end


### PR DESCRIPTION
Currently we just use `ScalarCovariance(1.0)`, which is not useful for calibration. This PR updates the scalar covariance with SVDPlusD and applies a shared NaN mask to the data used to estimate the covariance.

Changes
- Add `COVARIANCE_DATE_RANGES` to define the dataset ranges from which to estimate the covariances
- Add `make_data_informed_observation_vector`, which replaces `make_scalar_covariance_observation_vector` and creates observations with an SVDPlusD covariance.
- Add `harmonize_nan_mask_over_dates!` to set one shared NaN pattern across the covariance dates, so all SVD samples have equal length. `coverage_mask` / `apply_coverage_mask` define and apply the NaN mask respectively
- Add `apply_floor_correlation`, which adds an off-diagonal component to the SVDPlusD covariance, making it effectively SVDPlusMatrix. This is needed to use higher-resolution grids, since they are spatially correlated but treated as independent constraints by the diagonal in the SVDPlusD.
- Add `reduce_spatial` which reduces observations per variable, either with a coarse grid or zonal average.