### PR TITLE
Use ClimaCalibrate v0.4.0

### DIFF
--- a/experiments/AMIP/Manifest-v1.11.toml
+++ b/experiments/AMIP/Manifest-v1.11.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.9"
 manifest_format = "2.0"
-project_hash = "77d0d359e6a9567416c247e03be22322c49ad439"
+project_hash = "faff4f9ee58da26dbad07ec879d20dbbba44fe05"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "9b38b82a9fe131f3d331a53b7203d9d1a2a4602c"
@@ -414,9 +414,9 @@ version = "0.42.4"
 
 [[deps.ClimaCalibrate]]
 deps = ["ArnoldiMethod", "Dates", "Distributed", "EnsembleKalmanProcesses", "JLD2", "LinearAlgebra", "LinearMaps", "Logging", "OrderedCollections", "Reexport", "Statistics", "TOML", "YAML"]
-git-tree-sha1 = "529ceb644d09184bdf591c7ab4cbb0b2b554f947"
+git-tree-sha1 = "27ced647f790d43ace5e0c7df20efad5ffb05f77"
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
-version = "0.3.2"
+version = "0.4.0"
 weakdeps = ["ClimaAnalysis", "Makie", "NaNStatistics"]
 
     [deps.ClimaCalibrate.extensions]

--- a/experiments/AMIP/Manifest.toml
+++ b/experiments/AMIP/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.11"
 manifest_format = "2.0"
-project_hash = "e709abc243cc619dbfc32966a3a4675d5156af51"
+project_hash = "0cc721fa2c42ff43a5d73dad692fc8dc4e16764f"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "9b38b82a9fe131f3d331a53b7203d9d1a2a4602c"
@@ -411,9 +411,9 @@ version = "0.42.4"
 
 [[deps.ClimaCalibrate]]
 deps = ["ArnoldiMethod", "Dates", "Distributed", "EnsembleKalmanProcesses", "JLD2", "LinearAlgebra", "LinearMaps", "Logging", "OrderedCollections", "Reexport", "Statistics", "TOML", "YAML"]
-git-tree-sha1 = "529ceb644d09184bdf591c7ab4cbb0b2b554f947"
+git-tree-sha1 = "27ced647f790d43ace5e0c7df20efad5ffb05f77"
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
-version = "0.3.2"
+version = "0.4.0"
 weakdeps = ["ClimaAnalysis", "Makie", "NaNStatistics"]
 
     [deps.ClimaCalibrate.extensions]

--- a/experiments/AMIP/Project.toml
+++ b/experiments/AMIP/Project.toml
@@ -37,7 +37,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 CUDA = "5"
-ClimaCalibrate = "0.3.1"
+ClimaCalibrate = "0.4"
 ClimaLand = "1.11"
 ClimaParams = "1.0"
 ClimaTimeSteppers = "0.8.11, 0.9, 0.10"

--- a/experiments/calibration/amip/generate_observations.jl
+++ b/experiments/calibration/amip/generate_observations.jl
@@ -1,6 +1,7 @@
 import ClimaAnalysis
 import ClimaAnalysis: OutputVar
 import ClimaCalibrate
+import ClimaCalibrate: ObservationRecipe, SampleBuilder
 import ClimaCoupler
 import ClimaCoupler: CalibrationTools
 import JLD2
@@ -31,10 +32,15 @@ include(
         scalar = 1.0,
         use_latitude_weights = true,
         min_cosd_lat = 0.1,
+        FT = Float32,
     )
 
-Make a scalar covariance matrix using `vars` for each sample corresponding to
-the dates in `sample_date_ranges`.
+Make a vector of `EKP.Observation`s with a scalar covariance matrix, one for
+each sample corresponding to the dates in `sample_date_ranges`.
+
+The `OutputVar`s in `vars` are windowed by the date ranges in
+`sample_date_ranges` to build the samples, and each sample in turn is used as
+the observation. The matrix of samples has element type `FT`.
 """
 function make_scalar_covariance_observation_vector(
     vars,
@@ -42,25 +48,21 @@ function make_scalar_covariance_observation_vector(
     scalar = 1.0,
     use_latitude_weights = true,
     min_cosd_lat = 0.1,
+    FT = Float32,
 )
-    obs_vec = map(sample_date_ranges) do sample_date_range
-        start_date = first(sample_date_range)
-        end_date = last(sample_date_range)
-        @info "Using scalar covariance matrix with"
-        @info "Scalar: $scalar"
-        @info "Latitude weighting: $use_latitude_weights"
-        @info "Min cosd lat: $min_cosd_lat"
-        covar_estimator = ClimaCalibrate.ObservationRecipe.ScalarCovariance(;
-            scalar,
-            use_latitude_weights,
-            min_cosd_lat,
-        )
-        ClimaCalibrate.ObservationRecipe.observation(
-            covar_estimator,
-            vars,
-            start_date,
-            end_date,
-        )
+    @info "Using scalar covariance matrix with"
+    @info "Scalar: $scalar"
+    @info "Latitude weighting: $use_latitude_weights"
+    @info "Min cosd lat: $min_cosd_lat"
+    covar_estimator =
+        ObservationRecipe.ScalarCovariance(; scalar, use_latitude_weights, min_cosd_lat)
+
+    # Each date range becomes one sample (one column of the sample collection)
+    sample_collection = SampleBuilder.build_samples_by_times(vars, sample_date_ranges; FT)
+    @info "Built samples" sample_collection
+
+    obs_vec = map(1:SampleBuilder.num_samples(sample_collection)) do i
+        ObservationRecipe.observation(covar_estimator, sample_collection, i)
     end
     return obs_vec
 end
@@ -128,6 +130,6 @@ if abspath(PROGRAM_FILE) == @__FILE__
     # Reconstruct the variables from the observation and show them for debugging
     for (i, obs) in enumerate(observation_vec)
         @info "Observation $i"
-        @info ClimaCalibrate.ObservationRecipe.reconstruct_vars(observation_vec[i])
+        @info ObservationRecipe.reconstruct_vars(obs)
     end
 end

--- a/experiments/calibration/amip/run_calibration.jl
+++ b/experiments/calibration/amip/run_calibration.jl
@@ -8,8 +8,6 @@ import EnsembleKalmanProcesses as EKP
 import EnsembleKalmanProcesses.ParameterDistributions as PD
 import JLD2
 
-using Distributed
-
 model_interface_filepath = joinpath(
     pkgdir(ClimaCoupler),
     "experiments",
@@ -75,54 +73,27 @@ if abspath(PROGRAM_FILE) == @__FILE__
 
     coupler_model_interface = CouplerModelInterface(CALIBRATE_CONFIG)
 
-    modules = ["climacommon"]
-    env_vars = ["CLIMACOMMS_CONTEXT" => "SINGLETON", "CLIMACOMMS_DEVICE" => "CUDA"]
+    (; n_iterations) = CALIBRATE_CONFIG
 
-    if TEST_CALIBRATION
-        addprocs(ClimaCalibrate.SlurmManager())
-        @everywhere include($model_interface_filepath)
-        (; n_iterations, output_dir) = CALIBRATE_CONFIG
-        ClimaCalibrate.calibrate(
-            ClimaCalibrate.WorkerBackend(),
-            ekp,
-            coupler_model_interface,
-            n_iterations,
-            PRIORS,
-            output_dir,
-        )
-        return nothing
-    elseif ClimaCalibrate.get_backend() == ClimaCalibrate.DerechoBackend
-        backend = ClimaCalibrate.DerechoBackend(;
-            directives = [
-                # Options include "premium", "regular", "economy", "preempt"
-                :job_priority => "regular",
-                :time => 720,
-                :ntasks => 1,
-                :cpus_per_task => 12,
-                :gpus_per_task => 1,
-            ],
-            modules = ["climacommon/2025_02_25"],
-            env_vars,
-        )
-    elseif ClimaCalibrate.get_backend() == ClimaCalibrate.GCPBackend
-        backend = ClimaCalibrate.GCPBackend(;
-            directives = [
-                :ntasks => 1,
-                :gpus_per_task => 1,
-                :cpus_per_task => 12,
-                :time => 720,
-                :partition => "a3mega",
-            ],
-            modules,
-            env_vars,
-        )
-    else
-        error("Unsupported backend: $(ClimaCalibrate.get_backend())")
-    end
+    # The smoke test runs on CPU within an existing allocation, while a full
+    # calibration puts one ensemble member on each GPU.
+    device = TEST_CALIBRATION ? :cpu : :gpu
+    walltime = @isdefined(WORKER_WALLTIME) ? WORKER_WALLTIME : TEST_CALIBRATION ? 60 : 720
+    env_vars = [
+        "CLIMACOMMS_CONTEXT" => "SINGLETON",
+        "CLIMACOMMS_DEVICE" => TEST_CALIBRATION ? "CPU" : "CUDA",
+    ]
 
-    (; n_iterations, output_dir) = CALIBRATE_CONFIG
+    ClimaCalibrate.add_workers(
+        EKP.get_N_ens(ekp);
+        device,
+        time = walltime,
+        env = env_vars,
+    )
+    ClimaCalibrate.@worker_setup include($model_interface_filepath)
+
     eki = ClimaCalibrate.calibrate(
-        backend,
+        ClimaCalibrate.WorkerBackend(),
         ekp,
         coupler_model_interface,
         n_iterations,

--- a/experiments/calibration/amip/run_calibration.jl
+++ b/experiments/calibration/amip/run_calibration.jl
@@ -89,6 +89,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
         device,
         time = walltime,
         env = env_vars,
+        mem = TEST_CALIBRATION ? "16GB" : "32GB",
     )
     ClimaCalibrate.@worker_setup include($model_interface_filepath)
 


### PR DESCRIPTION
This PR updates the calibration pipeline to use the latest release of ClimaCalibrate. The most notable change is to pipeline for generating observations. To generate observations, we first create a SampleCollection which is a matrix of samples with metadata, construct a covariance estimator, and combine all of that with an index of the samples to create an EKP.Observation using ClimaCalibrate.ObservationRecipe.observation.

See the NEWS.md of [ClimaCalibrate.jl](https://github.com/CliMA/ClimaCalibrate.jl) for all changes.