### PR TITLE
Seed coupler schedules with t_start so restarts keep calendar phase

### DIFF
--- a/src/SimCoordinator.jl
+++ b/src/SimCoordinator.jl
@@ -17,7 +17,6 @@ module SimCoordinator
 
 import ClimaComms
 import ClimaDiagnostics as CD
-import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule
 import ClimaUtilities.TimeManager: ITime
 import ClimaCore as CC
 import ClimaParams as CP
@@ -449,14 +448,16 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
     # TODO: Move callbacks code somewhere else (maybe in TimeManager?) so that it doesn't clutter up the constructor
 
     # checkpoint
+    # Schedules are seeded with t_start so that a restarted simulation stays on
+    # the same calendar boundaries as the original run (see calendar_dt_schedule).
     schedule_checkpoint =
-        EveryCalendarDtSchedule(TimeManager.time_to_period(checkpoint_dt); start_date)
+        TimeManager.calendar_dt_schedule(checkpoint_dt, start_date, t_start)
     checkpoint_cb =
         TimeManager.Callback(schedule_checkpoint, sim -> Checkpointer.checkpoint_sims(sim))
 
     # walltime reporting
     schedule_walltime =
-        TimeManager.walltime_schedule(walltime_dt, walltime_debug, start_date)
+        TimeManager.walltime_schedule(walltime_dt, walltime_debug, start_date, t_start)
     if isnothing(schedule_walltime)
         callbacks = (checkpoint_cb,)
     else
@@ -474,8 +475,7 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
     )
     for (sim_name, interval) in pairs(progress_intervals)
         (haskey(model_sims, sim_name) && interval != "never") || continue
-        schedule_progress =
-            EveryCalendarDtSchedule(TimeManager.time_to_period(interval); start_date)
+        schedule_progress = TimeManager.calendar_dt_schedule(interval, start_date, t_start)
         progress_cb = TimeManager.Callback(
             schedule_progress,
             let sim_name = sim_name

--- a/src/SimOutput/diagnostics.jl
+++ b/src/SimOutput/diagnostics.jl
@@ -93,10 +93,13 @@ function diagnostics_setup(
         end,
     )
 
-    # Schedule the turbulent energy fluxes to save at every step and output at the configured period
+    # Schedule the turbulent energy fluxes to save at every step and output at the configured period.
+    # All schedules here are seeded with t_start so that a restarted simulation
+    # stays on the same calendar boundaries as the original run (see
+    # TimeManager.calendar_dt_schedule).
     compute_sched = CD.Schedules.EveryStepSchedule()  # Note that these are stateful, so we create new ones for each diagnostic
     output_sched =
-        CD.Schedules.EveryCalendarDtSchedule(coupler_diagnostics_period; start_date)
+        TimeManager.calendar_dt_schedule(coupler_diagnostics_period, start_date, t_start)
     reduction_time_func = get_reduction(Val(reduction))
     # `pre_output_hook!` is only needed to finalize the running mean for `:average`;
     # all other reductions don't require post-processing.
@@ -163,9 +166,9 @@ function diagnostics_setup(
     # Schedule the ocean fraction to save and output at diagnostic frequency
     # since it can change in time with evolving sea ice
     compute_sched =
-        CD.Schedules.EveryCalendarDtSchedule(coupler_diagnostics_period; start_date)
+        TimeManager.calendar_dt_schedule(coupler_diagnostics_period, start_date, t_start)
     output_sched =
-        CD.Schedules.EveryCalendarDtSchedule(coupler_diagnostics_period; start_date)
+        TimeManager.calendar_dt_schedule(coupler_diagnostics_period, start_date, t_start)
     ocean_fraction_diag_sched = CD.ScheduledDiagnostic(
         variable = ocean_fraction_diag,
         output_writer = netcdf_writer,
@@ -195,9 +198,9 @@ function diagnostics_setup(
 
     # Schedule the ice fraction to save and output at diagnostic frequency
     compute_sched =
-        CD.Schedules.EveryCalendarDtSchedule(coupler_diagnostics_period; start_date)
+        TimeManager.calendar_dt_schedule(coupler_diagnostics_period, start_date, t_start)
     output_sched =
-        CD.Schedules.EveryCalendarDtSchedule(coupler_diagnostics_period; start_date)
+        TimeManager.calendar_dt_schedule(coupler_diagnostics_period, start_date, t_start)
     ice_fraction_diag_sched = CD.ScheduledDiagnostic(
         variable = ice_fraction_diag,
         output_writer = netcdf_writer,

--- a/src/TimeManager.jl
+++ b/src/TimeManager.jl
@@ -194,7 +194,25 @@ function CD.Schedules.long_name(schedule::OrSchedule)
 end
 
 """
-    walltime_schedule(walltime_dt, walltime_debug, start_date)
+    calendar_dt_schedule(period, start_date, t_start)
+
+Build an `EveryCalendarDtSchedule` for `period` (a time string or a
+`Dates.Period`) whose `date_last` is seeded from `t_start`.
+
+Without the seeding, a schedule built at `t_start > 0` believes it is overdue and
+fires on the first step of a restarted simulation, staying one coupling step out
+of phase from then on. Seeding `date_last` keeps a restarted schedule on the same
+calendar boundaries as the original run. For a fresh simulation `t_start` is 0 and
+the behavior is unchanged.
+"""
+function calendar_dt_schedule(period, start_date, t_start)
+    period isa Dates.Period || (period = time_to_period(period))
+    date_last = start_date + Dates.Millisecond(round(Int64, 1000 * float(t_start)))
+    return CD.Schedules.EveryCalendarDtSchedule(period; start_date, date_last)
+end
+
+"""
+    walltime_schedule(walltime_dt, walltime_debug, start_date, t_start = 0)
 
 Return the schedule to be used for walltime reporting, or `nothing` if walltime
 reporting is disabled.
@@ -206,12 +224,11 @@ If `walltime_debug` is `true`, reporting also happens on every coupling step who
 number is a power of two (see [`PowerOfTwoSchedule`](@ref)). Note that this is the
 only reporting if `walltime_dt` is `"never"`.
 """
-function walltime_schedule(walltime_dt, walltime_debug, start_date)
+function walltime_schedule(walltime_dt, walltime_debug, start_date, t_start = 0)
     if walltime_dt == "never"
         return walltime_debug ? PowerOfTwoSchedule() : nothing
     end
-    schedule_periodic =
-        CD.Schedules.EveryCalendarDtSchedule(time_to_period(walltime_dt); start_date)
+    schedule_periodic = calendar_dt_schedule(walltime_dt, start_date, t_start)
     walltime_debug || return schedule_periodic
     return OrSchedule(schedule_periodic, PowerOfTwoSchedule())
 end

--- a/src/TimeManager.jl
+++ b/src/TimeManager.jl
@@ -7,6 +7,7 @@ module TimeManager
 
 import Dates
 import ClimaDiagnostics as CD
+import ClimaUtilities.TimeManager: ITime, date
 import ..Interfacer
 import ..Utilities: time_to_seconds
 
@@ -196,18 +197,25 @@ end
 """
     calendar_dt_schedule(period, start_date, t_start)
 
-Build an `EveryCalendarDtSchedule` for `period` (a time string or a
-`Dates.Period`) whose `date_last` is seeded from `t_start`.
+Build an `EveryCalendarDtSchedule` for `period`, which is either a `Dates.Period`
+or a string of the form `<NUM><unit>` accepted by [`time_to_period`](@ref), such
+as `"6hours"`.
 
-Without the seeding, a schedule built at `t_start > 0` believes it is overdue and
-fires on the first step of a restarted simulation, staying one coupling step out
-of phase from then on. Seeding `date_last` keeps a restarted schedule on the same
-calendar boundaries as the original run. For a fresh simulation `t_start` is 0 and
-the behavior is unchanged.
+`t_start` is the time the simulation starts from, either an `ITime` or a number of
+seconds since `start_date`. It is used to seed the schedule's `date_last`.
+
+!!! note "Use this instead of `EveryCalendarDtSchedule` directly"
+    A schedule built directly at `t_start > 0` has no record of the time that
+    already elapsed, so it considers itself overdue and fires on the first step of
+    a restarted simulation, remaining one coupling step out of phase from then on.
+    Seeding `date_last` keeps a restarted run on the same calendar boundaries as
+    the original one. A fresh simulation starts at `t_start = 0` and is unaffected.
 """
 function calendar_dt_schedule(period, start_date, t_start)
     period isa Dates.Period || (period = time_to_period(period))
-    date_last = start_date + Dates.Millisecond(round(Int64, 1000 * float(t_start)))
+    date_last =
+        t_start isa ITime ? date(t_start) :
+        start_date + Dates.Millisecond(round(Int64, 1000 * float(t_start)))
     return CD.Schedules.EveryCalendarDtSchedule(period; start_date, date_last)
 end
 

--- a/test/timemanager_tests.jl
+++ b/test/timemanager_tests.jl
@@ -5,6 +5,7 @@ import Test: @testset, @test, @test_logs, @test_throws
 import Dates
 import ClimaDiagnostics as CD
 import ClimaCoupler: TimeManager
+import ClimaUtilities.TimeManager: ITime
 
 @testset "time_to_period" begin
     @test TimeManager.time_to_period("2months") == Dates.Month(2)
@@ -135,6 +136,19 @@ end
     # A Dates.Period is accepted as well as a time string
     periodic = TimeManager.calendar_dt_schedule(Dates.Day(1), start_date, 0.0)
     @test periodic((; t = 86400.0))
+
+    # ITime times behave the same way, with the date taken from the ITime itself
+    day = ITime(86400, epoch = start_date)
+    t0 = ITime(0, epoch = start_date)
+    fresh_itime = TimeManager.calendar_dt_schedule("1days", start_date, t0)
+    @test !fresh_itime((; t = 0 * day))
+    @test fresh_itime((; t = day))
+
+    restarted_itime = TimeManager.calendar_dt_schedule("1days", start_date, 2 * day)
+    step = ITime(180, epoch = start_date)
+    @test !restarted_itime((; t = 2 * day + step))
+    @test restarted_itime((; t = 3 * day))
+    @test !restarted_itime((; t = 3 * day + step))
 end
 
 @testset "walltime_schedule" begin

--- a/test/timemanager_tests.jl
+++ b/test/timemanager_tests.jl
@@ -116,6 +116,27 @@ end
     @test CD.Schedules.long_name(named) == "every power-of-two iteration or never"
 end
 
+@testset "calendar_dt_schedule" begin
+    start_date = Dates.DateTime(2010)
+
+    # A fresh simulation is unchanged: nothing fires at t = 0, first firing at day 1
+    fresh = TimeManager.calendar_dt_schedule("1days", start_date, 0.0)
+    @test !fresh((; t = 0.0))
+    @test fresh((; t = 86400.0))
+
+    # A simulation restarted at day 2 stays on the calendar boundaries of the
+    # original run: nothing fires one coupling step after the restart, the first
+    # firing is at day 3 exactly, and not again one step later
+    restarted = TimeManager.calendar_dt_schedule("1days", start_date, 172800.0)
+    @test !restarted((; t = 172980.0))
+    @test restarted((; t = 259200.0))
+    @test !restarted((; t = 259380.0))
+
+    # A Dates.Period is accepted as well as a time string
+    periodic = TimeManager.calendar_dt_schedule(Dates.Day(1), start_date, 0.0)
+    @test periodic((; t = 86400.0))
+end
+
 @testset "walltime_schedule" begin
     start_date = Dates.DateTime(2010)
     periodic = CD.Schedules.EveryCalendarDtSchedule(


### PR DESCRIPTION
This PR adds the function `calendar_dt_schedule`, which returns a schedule that works for restarted simulations. This function could probably live in ClimaDiagnostics. Previously, restarted simulations did not pass `t_start` to the diagnostic schedule, causing it to immediately trigger, as the simulation starts after `t_start`.