### PR TITLE
Remove -O0 flag for AMIP environment in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,8 +25,10 @@ steps:
       - "julia -O0 --project -e 'using Pkg; Pkg.status()'"
 
       - echo "--- Instantiate AMIP experiments env"
-      - "julia -O0 --project=experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia -O0 --project=experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'"
+      # Precompile AMIP at the default optimization level since some runs use it. Runs using
+      # the -O0 flag can also reuse the cache generated here.
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project=experiments/AMIP/ -e 'using Pkg; Pkg.precompile()'"
       - "julia -O0 --project=experiments/AMIP/ -e 'using Pkg; Pkg.status()'"
 
       # Precompile CMIP with strict bounds checking to avoid precompilation in individual


### PR DESCRIPTION
From https://docs.julialang.org/en/v1/devdocs/pkgimg/, it states that for the optimization flag, it "reject package images generated for a lower optimization level, but allow for higher optimization levels to be loaded". This should stop the precompilation during runs as seen below. 

```julia
Precompiling ClimaCoupler...
  14253.0 ms  ✓ ClimaCoupler
  1 dependency successfully precompiled in 24 seconds. 238 already precompiled.
Precompiling ClimaCouplerMakieExt...
  22943.7 ms  ✓ ClimaCoupler → ClimaCouplerMakieExt
  1 dependency successfully precompiled in 33 seconds. 462 already precompiled.
Precompiling ClimaCouplerClimaLandExt...
   7925.1 ms  ✓ ClimaCoupler → ClimaCouplerClimaLandExt
  1 dependency successfully precompiled in 13 seconds. 241 already precompiled.
```

You can see it working here: https://buildkite.com/clima/climacoupler-ci/builds/9478#01a01bf5-dbc3-48af-b446-fa0fbe596eb9