### PR TITLE
Reduce AMIP pipeline limit to 36hours

### DIFF
--- a/.buildkite/amip/pipeline.yml
+++ b/.buildkite/amip/pipeline.yml
@@ -1,6 +1,5 @@
 agents:
   queue: central
-  slurm_time: 96:00:00
   modules: climacommon/2025_05_15
 
 env:
@@ -47,6 +46,7 @@ steps:
           CLIMACOMMS_DEVICE: "CUDA"
           CLIMACOMMS_CONTEXT: "SINGLETON"
         agents:
+          slurm_time: 36:00:00
           slurm_gres: gpu:nvidia_l40s:1
           slurm_cpus_per_task: 4
           slurm_ntasks: 1


### PR DESCRIPTION
This PR removes the global time limit from the AMIP pipeline and reduces the actual run's time limit to 36 hours.