### PR TITLE
Land zenith angle update

### DIFF
--- a/ext/ClimaCouplerClimaLandExt.jl
+++ b/ext/ClimaCouplerClimaLandExt.jl
@@ -19,6 +19,7 @@ import ClimaUtilities.TimeVaryingInputs:
     LinearInterpolation, PeriodicCalendar, TimeVaryingInput
 import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
+import ClimaUtilities.TimeManager: ITime
 import ClimaCoupler:
     Checkpointer, FieldExchanger, FluxCalculator, Interfacer, Utilities, Plotting
 import ClimaTimeSteppers as CTS

--- a/ext/ClimaCouplerClimaLandExt/climaland_bucket.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_bucket.jl
@@ -65,6 +65,7 @@ function BucketSimulation(
     era5_albedo_file_path::Union{Nothing, String} = nothing,
     coupled_param_dict = CP.create_toml_dict(FT),
     gustiness::FT = FT(1),
+    dt_drivers::ITime = ITime(3600),
     extra_kwargs...,
 ) where {FT, TT <: Union{Float64, ITime}}
     # Get default land parameters from ClimaLand.LandParameters
@@ -205,6 +206,7 @@ function BucketSimulation(
         user_callbacks = (),
         diagnostics,
         timestepper,
+        updateat = dt_drivers,
     )
 
     # Scratch buffer for `turbulent_fluxes_at_a_point` output when the bucket is a slow

--- a/ext/ClimaCouplerClimaLandExt/climaland_integrated.jl
+++ b/ext/ClimaCouplerClimaLandExt/climaland_integrated.jl
@@ -46,7 +46,8 @@ end
         land_ic_path::Union{Nothing,String} = nothing,
         lai_source::String = "modis_monthly",
         gustiness::FT = FT(1),
-    ) where {FT, TT <: Union{Float64, ITime}}
+        dt_drivers::TT = ITime(3600),
+    ) where {FT, ITime <: Union{Float64, ITime}}
 
 Creates a ClimaLandSimulation object containing a land domain,
 a ClimaLand.LandModel, and an integrator.
@@ -54,6 +55,10 @@ a ClimaLand.LandModel, and an integrator.
 This type of model contains a canopy model, soil model, snow model, and
 soil CO2 model. Specific details about the complexity of the model
 can be found in the ClimaLand.jl documentation.
+
+`dt_drivers` is an ITime type, reflecting the integer number of seconds describing how often to
+update the zenith angle. The CouplerSimulation setup sets this equal to
+the callback period that the atmosphere uses to update radiation.
 
 # Arguments
 - `lai_source::String = "modis_monthly"`: Source for leaf area index data. Options:
@@ -81,6 +86,7 @@ function ClimaLandSimulation(
     land_ic_path::Union{Nothing, String} = nothing,
     lai_source::String = "modis_monthly",
     gustiness::FT = FT(1),
+    dt_drivers::ITime = ITime(3600),
     extra_kwargs...,
 ) where {FT, TT <: Union{Float64, ITime}}
     # Get default land parameters from ClimaLand.LandParameters
@@ -242,6 +248,7 @@ function ClimaLandSimulation(
         set_ic!,
         user_callbacks = (),
         diagnostics,
+        updateat = dt_drivers,
     )
 
     # Initialize the surface emissivity so the atmosphere can compute radiation.

--- a/src/SimCoordinator.jl
+++ b/src/SimCoordinator.jl
@@ -18,6 +18,7 @@ module SimCoordinator
 import ClimaComms
 import ClimaDiagnostics as CD
 import ClimaDiagnostics.Schedules: EveryCalendarDtSchedule
+import ClimaUtilities.TimeManager: ITime
 import ClimaCore as CC
 import ClimaParams as CP
 import Thermodynamics.Parameters as TDP
@@ -335,6 +336,7 @@ function Interfacer.CoupledSimulation(config_dict::AbstractDict)
         land_spun_up_ic,
         land_ic_path,
         lai_source,
+        dt_drivers = ITime(Utilities.time_to_seconds(config_dict["dt_rad"])),
     )
 
     ocean_sim = Interfacer.OceanSimulation(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The land updates the zenith angle via a DriverCallback. This is set in the CL.Simulations.LandSimulation function call. The default is 3 hours (defined in ClimaLand.jl's definition of CL.Simulations.LandSimulation). This led to a situation where the zenith angle in land was only being updated every 3 hours, while SW_d, diffuse fraction, LW_d are updated every hour by RRTMGP in ClimaAtmos. In turn this led to some weird discrepancies in SW_net, because the canopy albedo depends on zenith angle. See plot below for an example at one pixel. In this case, costheta = 0 for 2 hours while SW_d grows to ~150 W/m^2. I think the issue is that the albedo becomes very small when costheta is 0, so there is a spike of absorption, and then the zenith angle updates, and the SW_n drops back to the correct value.
<img width="1200" height="900" alt="sw_n" src="https://github.com/user-attachments/assets/12600aef-74fe-4dba-83b4-212986dd8c12" />

With this fix, I see this:
<img width="1200" height="900" alt="sw_n_fixed" src="https://github.com/user-attachments/assets/ef073d94-a4a0-4980-96c4-36d36396da97" />


This fix also makes this column stable:
before:
<img width="1200" height="900" alt="energyfluxes" src="https://github.com/user-attachments/assets/e975fd01-cc6d-4238-9157-3565f74539f2" />
After:
<img width="1200" height="900" alt="energyfluxes_fixed" src="https://github.com/user-attachments/assets/219c19b4-acf0-404f-b37d-b311621255c6" />

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
