### PR TITLE
Always use zstar grid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ ClimaCoupler.jl Release Notes
 `main`
 -------
 
+#### Always use the mutable (z*) ocean vertical grid.
+`simple_ocean = true` (used in CI and software testing) previously used a
+linear free surface, which turned out to dramatically violate energy
+conservation.
+
 #### Exchange (intersection) grid for CMIP surface fractions and fluxes. PR [#2051](https://github.com/CliMA/ClimaCoupler.jl/pull/2051)
 When coupling to an Oceananigans ocean, ClimaCoupler now builds the exchange
 grid — the polygons where the cubed-sphere spectral elements intersect the

--- a/ext/ClimaCouplerCMIPExt/oceananigans.jl
+++ b/ext/ClimaCouplerCMIPExt/oceananigans.jl
@@ -118,7 +118,7 @@ function ocean_simulation(
     substeps = simple_ocean ? 70 : 150
 
     active_cells_map = !simple_ocean
-    zstar = !simple_ocean
+    zstar = true
 
     z = OC.ExponentialDiscretization(Nz, -depth, 0; mutable = zstar)
     grid = horizontal_ocean_grid(arch, ocean_grid; z, Nz, active_cells_map)


### PR DESCRIPTION
`simple_ocean = true` (used in CI and software testing) previously used a linear free surface, which turned out to dramatically violate energy conservation.