### PR TITLE
Compute sea salt emissions as part of turbulent surface fluxes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -230,7 +230,7 @@ steps:
         agents:
           slurm_mem: 20GB
 
-      - label: "Slabplanet aqua: atmos and slab ocean"
+      - label: "Slabplanet aqua: atmos and slab ocean, prognostic aerosols"
         key: "slabplanet_aqua"
         command: "julia --color=yes --project=experiments/AMIP/ experiments/AMIP/run_simulation.jl --config_file $CONFIG_PATH/slabplanet_aqua.yml --job_id slabplanet_aqua"
         retry: *retry_policy

--- a/config/atmos_configs/climaatmos_wx_progedmf_SSA.yml
+++ b/config/atmos_configs/climaatmos_wx_progedmf_SSA.yml
@@ -1,0 +1,37 @@
+aerosol_radiation: true
+approximate_linear_solve_iters: 2
+cloud_model: "quadrature"
+dt: "40secs"
+dt_cloud_fraction: "1hours"
+dt_rad: "1hours"
+dt_save_state_to_disk: "30days"
+dz_bottom: 30.0
+edmfx_detr_model: "Generalized"
+edmfx_entr_model: "Generalized"
+edmfx_filter: true
+edmfx_nh_pressure: true
+edmfx_sgs_diffusive_flux: true
+edmfx_sgs_mass_flux: true
+edmfx_upwinding: "first_order"
+edmfx_vertical_diffusion: true
+h_elem: 30
+implicit_diffusion: true
+insolation: "timevarying"
+netcdf_output_at_levels: true
+ode_algo: ARS222
+prescribed_aerosols: ["CB1", "CB2", "DST01", "DST02", "DST03", "DST04", "DST05", "OC1", "OC2", "SO4", "SSLT01", "SSLT02", "SSLT03", "SSLT04", "SSLT05"]
+prognostic_aerosols: ["SSLT"]
+prognostic_tke: true
+rad: "allskywithclear"
+rayleigh_sponge: true
+surface_setup: "DefaultMoninObukhov"
+t_end: "120days"
+time_varying_trace_gases: ["CO2", "O3"]
+toml: [toml/prognostic_edmfx_1M.toml]
+turbconv: "prognostic_edmfx"
+viscous_sponge: true
+z_elem: 63
+z_max: 60000.0
+microphysics_model: "1M"
+non_orographic_gravity_wave: true
+orographic_gravity_wave: "raw_topo"

--- a/config/ci_configs/slabplanet_aqua.yml
+++ b/config/ci_configs/slabplanet_aqua.yml
@@ -7,6 +7,7 @@ h_elem: 4
 mode_name: "slabplanet_aqua"
 rad: "gray"
 microphysics_model: "0M"
+prognostic_aerosols: ["SSLT"]
 start_date: "20100101"
 surface_setup: "PrescribedSurface"
 t_end: "400secs"

--- a/config/subseasonal_configs/wxquest_progedmf_SSA.yml
+++ b/config/subseasonal_configs/wxquest_progedmf_SSA.yml
@@ -1,0 +1,51 @@
+FLOAT_TYPE: "Float32"
+albedo_model: "CouplerAlbedo"
+atmos_config_file: "config/atmos_configs/climaatmos_wx_progedmf_SSA.yml"
+coupler_toml: ["toml/amip_progedmf.toml"]
+strict_params: false
+mode_name: "subseasonal"
+era5_initial_condition_dir: "/net/sampo/data1/wxquest_data/initial_conditions/initial_conditions_v1_dev"
+initial_condition: "WeatherModel"
+checkpoint_dt: "1000days"
+dt: "40secs"
+dt_cpl: "40secs"
+dt_seaice: "40secs"
+divergence_damping_factor: 20.0
+energy_check: false
+h_elem: 30
+z_max: 70000.0
+z_elem: 70
+land_fraction_source: "era5"
+binary_area_fraction: false
+
+### integrated land ###
+land_model: "integrated"
+lai_source: "modis_monthly_climatology"
+
+### bucket land ###
+# land_model: "bucket"
+# bucket_albedo_type: "map_temporal"
+
+land_spun_up_ic: false
+land_temperature_anomaly: "nothing"
+use_land_diagnostics: true
+radiation_reset_rng_seed: true
+start_date: "20100101"
+surface_setup: "PrescribedSurface"
+topo_smoothing: true
+topography: "Earth"
+t_end: "14days"
+netcdf_output_at_levels: true
+use_coupler_diagnostics: true
+output_default_diagnostics: false
+extra_atmos_diagnostics:
+  - short_name: [zg, orog, tas, ta, thetaa, mslp, pr, ua, va, ts, rhoa, pfull, hur, hus, clw, cli, clivi, clwvi, cl, arup, tke, hfss, hfls, evspsbl, hussfc, rsds, rlds, rlus, rsus, rld, wa, waup]
+    period: 24hours
+    reduction_time: average
+  - short_name: [
+      rhoa, hur,
+      loadss,
+      mmrss, mmrsslt01, mmrsslt02, mmrsslt03, mmrsslt04, mmrsslt05
+    ]
+    period: 1hours
+    reduction_time: average

--- a/ext/ClimaCouplerClimaAtmosExt.jl
+++ b/ext/ClimaCouplerClimaAtmosExt.jl
@@ -559,6 +559,42 @@ function FluxCalculator.update_turbulent_fluxes!(sim::ClimaAtmosSimulation, fiel
 end
 
 """
+    FluxCalculator.compute_sslt_emission!(csf, ocean_sim, atmos_sim::ClimaAtmosSimulation, fluxes)
+
+Compute sea salt emission mass flux using ocean `area_fraction` and MOST solution, 
+writing to Atmos cache via`ClimaAtmos.set_sslt_surface_fluxes!`. Called from [`compute_surface_fluxes!`](@ref).
+Requires Atmos to carry prognostic sea salt.
+"""
+function FluxCalculator.compute_sslt_emission!(
+    csf,
+    ocean_sim::Union{Interfacer.AbstractOceanSimulation, Models.PrescribedOceanSimulation},
+    atmos_sim::ClimaAtmosSimulation,
+    fluxes,
+)
+    FT = eltype(atmos_sim.integrator.u)
+    p = atmos_sim.integrator.p
+    hasproperty(p.tracers, :sslt_sfc_fluxes) || return nothing
+    sfp = FluxCalculator.get_surface_params(atmos_sim)
+    area_fraction = Interfacer.get_field(ocean_sim, Val(:area_fraction))
+
+    u₁₀ = csf.scalar_temp3
+    @. u₁₀ = CA.wind_at_height(FT(10), fluxes.ustar, fluxes.L_MO, sfp)
+
+    u₁₀_atmos = p.scratch.ᶠtemp_field_level
+    ocean_fraction_atmos = p.scratch.ᶠtemp_field_level_2
+    Interfacer.remap!(u₁₀_atmos, u₁₀)
+    Interfacer.remap!(ocean_fraction_atmos, area_fraction)
+    
+    CA.set_sslt_surface_fluxes!(
+        atmos_sim.integrator.u,
+        p,
+        u₁₀_atmos,
+        ocean_fraction_atmos,
+    )
+    return nothing
+end
+
+"""
 Extend Interfacer.add_coupler_fields! to add the fields required for ClimaAtmosSimulation.
 
 The fields added are:

--- a/src/FluxCalculator.jl
+++ b/src/FluxCalculator.jl
@@ -273,7 +273,7 @@ function get_surface_fluxes(
         update_q_vap_sfc,
     )
 
-    (; shf, lhf, evaporation, ρτxz, ρτyz, T_sfc, q_vap_sfc) = outputs
+    (; shf, lhf, evaporation, ρτxz, ρτyz, T_sfc, q_vap_sfc, ustar, L_MO) = outputs
 
     return (;
         F_turb_ρτxz = ρτxz,
@@ -282,6 +282,8 @@ function get_surface_fluxes(
         F_lh = lhf,
         F_turb_moisture = evaporation,
         T_sfc_new = T_sfc,
+        ustar = ustar,
+        L_MO = L_MO,
     )
 end
 
@@ -425,8 +427,17 @@ NVTX.@annotate function compute_surface_fluxes!(
 
     # Update the coupler fields and surface simulation with the fluxes
     update_flux_fields!(csf, sim, fluxes, accumulator)
+    compute_sslt_emission!(csf, sim, atmos_sim, fluxes)
     return nothing
 end
+
+"""
+    compute_sslt_emission!(csf, sim, atmos_sim, fluxes)
+
+No-op unless surface emits sea salt (`AbstractOceanSimulation` or
+`PrescribedOceanSimulation`); see full implementation in ClimaAtmosExt
+"""
+compute_sslt_emission!(csf, sim, atmos_sim, fluxes) = nothing
 
 """
     update_flux_fields!(csf, sim::Interfacer.AbstractSurfaceSimulation, fluxes, accumulator = nothing)


### PR DESCRIPTION
Restructure in light of comments on Atmos PR  @https://github.com/CliMA/ClimaAtmos.jl/pull/4756, adding `compute_sslt_emission!` to FluxCalculator, and calling it from `compute_surface_fluxes`. A few MOST variables are added to `get_surface_fluxes` to enable computation of 10m winds.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x ] I have read and checked the items on the review checklist.
