### PR TITLE
Exchange radiation/precip on intersection grid

### DIFF
--- a/experiments/test/intersection_grid_test.jl
+++ b/experiments/test/intersection_grid_test.jl
@@ -46,7 +46,7 @@ n_elem = 6 * 4^2
 # at 55°N, regular southern boundary at 80°S, folded top row.
 Nx, Ny, Nz = 36, 18, 1
 arch = OC.CPU()
-underlying_tripolar = OC.TripolarGrid(
+tripolar_grid_on(arch) = OC.TripolarGrid(
     arch;
     size = (Nx, Ny, Nz),
     southernmost_latitude = -80,
@@ -56,6 +56,7 @@ underlying_tripolar = OC.TripolarGrid(
     z = (-100.0, 0.0),
     halo = (4, 4, 4),
 )
+underlying_tripolar = tripolar_grid_on(arch)
 
 # Fully wet grid: bottom below the deepest z everywhere.
 wet_grid = OC.ImmersedBoundaryGrid(
@@ -65,12 +66,16 @@ wet_grid = OC.ImmersedBoundaryGrid(
 )
 
 # Half-dry grid: an idealized land hemisphere. TripolarGrid longitudes are
-# not restricted to [-180, 180), so wrap before comparing.
-coastal_grid = OC.ImmersedBoundaryGrid(
-    underlying_tripolar,
-    OC.GridFittedBottom((x, y) -> mod(x, 360) < 180 ? 100.0 : -200.0);
+# not restricted to [-180, 180), so wrap before comparing. Built per
+# architecture so a test that mixes ocean fields with coupler fields can put
+# both in the same memory space.
+coastal_bottom(x, y) = mod(x, 360) < 180 ? 100.0 : -200.0
+coastal_grid_on(arch) = OC.ImmersedBoundaryGrid(
+    tripolar_grid_on(arch),
+    OC.GridFittedBottom(coastal_bottom);
     active_cells_map = false,
 )
+coastal_grid = coastal_grid_on(arch)
 uv_basis = CMIPExt.uv_basis_coefficients(boundary_space)
 
 # Ground-truth wet area of an immersed grid: the sum of the cell areas of
@@ -439,7 +444,7 @@ end
 import SurfaceFluxes as SF
 import Thermodynamics.Parameters as TDP
 import ClimaParams as CP
-import ClimaCoupler: FluxCalculator, Utilities
+import ClimaCoupler: FieldExchanger, FluxCalculator, Utilities
 
 @testset "Per-polygon ocean fluxes" begin
     eg = CMIPExt.build_exchange_grid(boundary_space, coastal_grid)
@@ -626,8 +631,8 @@ end
     fs.sic[1:2:end] .= FT(0.8)
     is.R .= FT(1.0) / FT(2.0) # 1 m of ice at conductivity 2 W/m/K
     is.T_i .= FT(271.2)
-    is.SW_d .= FT(50)
-    is.LW_d .= FT(200)
+    fs.SW_d .= FT(50)
+    fs.LW_d .= FT(200)
     is.T_sfc_new .= 0
 
     CMIPExt.compute_ice_polygon_fluxes!(
@@ -774,4 +779,98 @@ end
         @test allocated < 100_000
     end
     @test all(isfinite, to_cpu(parent(flux_scratch.F_sh)))
+end
+
+# Stand-in for an Oceananigans model in the `update_sim!` radiation path, which
+# reads only the grid, the tracers (and their top flux BCs) and the float type.
+struct FakeOceanModel{G, T}
+    grid::G
+    tracers::T
+end
+Base.eltype(::FakeOceanModel) = FT
+
+@testset "Exchange-grid radiation and precipitation" begin
+    # Make sure both the boundary space and the ocean grid are on the same device
+    ocean_arch = exchange_arch()
+    grid = coastal_grid_on(ocean_arch)
+    eg_cpu = CMIPExt.build_exchange_grid(boundary_space, grid)
+    eg = on_exchange_device(eg_cpu)
+
+    # Only the tracers, their top flux BCs, the grid and `eltype` are read, so
+    # a full `HydrostaticFreeSurfaceModel` is unnecessary.
+    tracer(flux) = OC.CenterField(
+        grid,
+        boundary_conditions = OC.FieldBoundaryConditions(
+            grid,
+            (OC.Center(), OC.Center(), OC.Center());
+            top = OC.FluxBoundaryCondition(flux),
+        ),
+    )
+    surface_field() = OC.Field{OC.Center, OC.Center, Nothing}(grid)
+    T_flux, S_flux = surface_field(), surface_field()
+    model = FakeOceanModel(grid, (; T = tracer(T_flux), S = tracer(S_flux)))
+    T_sfc, S_sfc = FT(12), FT(35) # [°C], [psu]
+    OC.set!(model.tracers.T, T_sfc)
+    OC.set!(model.tracers.S, S_sfc)
+
+    ocean_properties = (;
+        reference_density = FT(1020),
+        heat_capacity = FT(3995),
+        σ = FT(5.67e-8),
+        C_to_K = FT(273.15),
+    )
+    remapping = (;
+        use_exchange_grid = true,
+        exchange_grid = eg,
+        ocean_flux_state = CMIPExt.ExchangeFluxState{FT}(ocean_arch, eg_cpu.n_poly),
+        scratch_field_oc3 = surface_field(),
+    )
+    sim = CMIPExt.OceananigansSimulation(
+        (; model),
+        nothing,
+        ocean_properties,
+        remapping,
+        surface_field(), # ice concentration: ice-free
+        nothing,
+    )
+
+    # Uniform forcing: the node gather preserves constants exactly and the cell
+    # scatter conserves the area integral, so every wet cell must reproduce the
+    # single-column answer to roundoff.
+    uniform(v) = (f = CC.Fields.zeros(boundary_space); f .= FT(v); f)
+    SW_d, LW_d, P_liq, P_snow = FT(300), FT(350), FT(-1e-5), FT(-2e-6)
+    csf = (;
+        SW_d = uniform(SW_d),
+        LW_d = uniform(LW_d),
+        P_liq = uniform(P_liq),
+        P_snow = uniform(P_snow),
+    )
+    FieldExchanger.update_sim!(sim, csf)
+
+    (; reference_density, heat_capacity, σ, C_to_K) = ocean_properties
+    α = FT(0.011) # `Val(:surface_direct_albedo)`
+    ϵ = FT(0.97)  # `Val(:emissivity)`
+    expected_T =
+        (-(1 - α) * SW_d - ϵ * (LW_d - σ * (T_sfc + C_to_K)^4)) /
+        (reference_density * heat_capacity)
+    expected_S = -S_sfc * (P_liq + P_snow) / reference_density
+
+    cell_values(f) = vec(OC.interior(OC.on_architecture(OC.CPU(), f), :, :, 1))
+    flux_T = cell_values(CMIPExt.surface_flux(model.tracers.T))
+    flux_S = cell_values(CMIPExt.surface_flux(model.tracers.S))
+    n_wet = 0
+    # Skip the fold row, whose shadow cells are filled by mirroring rather than
+    # by the scatter.
+    for c in 1:((Ny - 1) * Nx)
+        if eg_cpu.oc_wet_area[c] > 0
+            n_wet += 1
+            @test flux_T[c] ≈ expected_T rtol = 1e-12
+            @test flux_S[c] ≈ expected_S rtol = 1e-12
+        else
+            # Dry cells receive nothing: the property this path exists for.
+            @test flux_T[c] == 0
+            @test flux_S[c] == 0
+        end
+    end
+    @test n_wet > 0
 end

--- a/ext/ClimaCouplerCMIPExt/clima_seaice.jl
+++ b/ext/ClimaCouplerCMIPExt/clima_seaice.jl
@@ -533,8 +533,8 @@ NVTX.@annotate function compute_ice_exchange_fluxes!(
     # Atmospheric state, including the downwelling radiation entering the
     # skin-temperature balance.
     gather_atmos_state_to_polys!(fs, eg, csf, remapping.temp_uv_vec, remapping.uv_basis)
-    gather_nodes_to_polys!(is.SW_d, eg, se_nodal_vec(csf.SW_d))
-    gather_nodes_to_polys!(is.LW_d, eg, se_nodal_vec(csf.LW_d))
+    gather_nodes_to_polys!(fs.SW_d, eg, se_nodal_vec(csf.SW_d))
+    gather_nodes_to_polys!(fs.LW_d, eg, se_nodal_vec(csf.LW_d))
 
     # Ice state from the owning cells. Conductive resistance
     # R = h_ice/k_ice + h_snow/k_snow (series; reduces to h_ice/k_ice with no
@@ -709,6 +709,10 @@ by the coupler.
 Update the portion of the surface_fluxes for T that is due to radiation, and the snow
 precipitation that drives snow accumulation. The rest will be updated in `update_turbulent_fluxes!`.
 
+When the exchange grid is active, the work is done per polygon in
+[`push_exchange_radiation_to_ice!`](@ref); the fallback below remaps with
+`sim.remapping`, whose regridder is unaware of the immersed mask.
+
 A note on sign conventions:
 ClimaAtmos and ClimaSeaIce both use the convention that a positive flux is an upward flux.
 No sign change is needed during the exchange for radiation. Precipitation is the exception:
@@ -716,6 +720,9 @@ ClimaAtmos provides snowfall as a negative (downward) mass flux at the surface, 
 ClimaSeaIce expects `snowfall` as a positive accumulation rate, so the sign is flipped.
 """
 function FieldExchanger.update_sim!(sim::ClimaSeaIceSimulation, csf)
+    if sim.remapping.use_exchange_grid
+        return push_exchange_radiation_to_ice!(sim, csf)
+    end
     ice_concentration = sim.ice.model.ice_concentration
 
     # Absorbed radiative part of Jᵃ (upward positive): −(1−α)SW↓ − ϵLW↓.
@@ -747,6 +754,60 @@ function FieldExchanger.update_sim!(sim::ClimaSeaIceSimulation, csf)
         remapped_P_snow = OC.interior(sim.remapping.scratch_field_oc1, :, :, 1)
         OC.interior(snowfall, :, :, 1) .=
             (OC.interior(ice_concentration, :, :, 1) .> 0) .* (.-remapped_P_snow)
+    end
+    return nothing
+end
+
+"""
+    push_exchange_radiation_to_ice!(sim::ClimaSeaIceSimulation, csf)
+
+Exchange-grid form of the radiative and snowfall part of
+[`FieldExchanger.update_sim!`](@ref): gather the downwelling radiation and
+snowfall onto the polygons and scatter them onto the ClimaSeaIce forcing
+fields, so only wet polygons contribute and dry cells receive exactly
+nothing. Fluxes are per unit ice area, matching the boundary-space path: the
+absorbed radiation written here is completed into the full skin balance
+`Jᵃ = σϵTₛ⁴ − (1−α)SW↓ − ϵLW↓ + F_sh + F_lh` by
+[`compute_ice_top_heat_flux!`](@ref).
+"""
+NVTX.@annotate function push_exchange_radiation_to_ice!(sim::ClimaSeaIceSimulation, csf)
+    remapping = sim.remapping
+    eg = remapping.exchange_grid
+    fs = remapping.ice_flux_state.fluxes
+    grid = sim.ice.model.grid
+    FT = eltype(fs.T_sfc)
+    α = FT(Interfacer.get_field(sim, Val(:surface_direct_albedo))) # scalar
+    ϵ = FT(Interfacer.get_field(sim, Val(:emissivity))) # scalar
+
+    gather_cells_to_polys!(
+        fs.sic,
+        eg,
+        vec(OC.interior(sim.ice.model.ice_concentration, :, :, 1)),
+    )
+
+    # Absorbed radiative part of Jᵃ (upward positive): −(1−α)SW↓ − ϵLW↓.
+    si_flux_heat = sim.ice.model.external_heat_fluxes.top
+    if si_flux_heat isa OC.Field
+        gather_nodes_to_polys!(fs.SW_d, eg, se_nodal_vec(csf.SW_d))
+        gather_nodes_to_polys!(fs.LW_d, eg, se_nodal_vec(csf.LW_d))
+        @. fs.scratch1 = (fs.sic > 0) * (-(1 - α) * fs.SW_d - ϵ * fs.LW_d)
+        heat_cells = vec(OC.interior(remapping.scratch_field_oc1, :, :, 1))
+        scatter_polys_to_cells!(heat_cells, eg, fs.scratch1)
+        mirror_fold_partners!(heat_cells, grid)
+        OC.interior(si_flux_heat, :, :, 1) .=
+            OC.interior(remapping.scratch_field_oc1, :, :, 1)
+    end
+
+    # Snow precipitation drives snow accumulation (sign flip: downward
+    # atmospheric mass flux to positive `snowfall`).
+    snowfall = sim.ice.model.snowfall
+    if snowfall isa OC.Field
+        gather_nodes_to_polys!(fs.P_snow, eg, se_nodal_vec(csf.P_snow))
+        @. fs.scratch1 = -(fs.sic > 0) * fs.P_snow
+        snow_cells = vec(OC.interior(remapping.scratch_field_oc1, :, :, 1))
+        scatter_polys_to_cells!(snow_cells, eg, fs.scratch1)
+        mirror_fold_partners!(snow_cells, grid)
+        OC.interior(snowfall, :, :, 1) .= OC.interior(remapping.scratch_field_oc1, :, :, 1)
     end
     return nothing
 end

--- a/ext/ClimaCouplerCMIPExt/exchange_fluxes.jl
+++ b/ext/ClimaCouplerCMIPExt/exchange_fluxes.jl
@@ -25,8 +25,9 @@ import ClimaComms
 
 Device-resident per-polygon scratch for the exchange-grid flux computation of
 one surface model (one instance for the ocean, one for sea ice): the gathered
-atmospheric and surface state (momentum in the UV basis; `T_sfc` in [K]), the
-flux outputs (`F_*`), running time accumulators for the slow-surface path
+atmospheric and surface state (momentum in the UV basis; downwelling
+radiation `SW_d`/`LW_d` and precipitation `P_liq`/`P_snow`; `T_sfc` in [K]),
+the flux outputs (`F_*`), running time accumulators for the slow-surface path
 (`acc_*`, with `n_acc` counting contributions), and two generic scratch
 vectors.
 """
@@ -40,6 +41,10 @@ struct ExchangeFluxState{FT, VF <: AbstractVector{FT}}
     v_atmos::VF
     height_int::VF
     height_sfc::VF
+    SW_d::VF
+    LW_d::VF
+    P_liq::VF
+    P_snow::VF
     T_sfc::VF
     sic::VF
     F_sh::VF
@@ -79,15 +84,13 @@ ExchangeFluxState{FT}(arch, n_poly::Int) where {FT} =
 Per-polygon scratch for the sea-ice exchange-grid flux computation: the
 common [`ExchangeFluxState`](@ref) plus the ice-specific inputs of the
 skin-temperature flux balance (`R` — conductive resistance, `T_i` — ice
-internal/interface temperature [K], downwelling `SW_d`/`LW_d`) and the
-diagnosed surface temperature output `T_sfc_new` [K].
+internal/interface temperature [K]; the downwelling radiation comes from
+`fluxes`) and the diagnosed surface temperature output `T_sfc_new` [K].
 """
 struct IceExchangeState{FT, VF <: AbstractVector{FT}}
     fluxes::ExchangeFluxState{FT, VF}
     R::VF
     T_i::VF
-    SW_d::VF
-    LW_d::VF
     T_sfc_new::VF
 end
 
@@ -303,8 +306,10 @@ NVTX.@annotate function compute_ocean_polygon_fluxes!(
     return nothing
 end
 
-@inline _kernel_state(is::IceExchangeState) =
-    merge(_kernel_state(is.fluxes), (; is.R, is.T_i, is.SW_d, is.LW_d, is.T_sfc_new))
+@inline _kernel_state(is::IceExchangeState) = merge(
+    _kernel_state(is.fluxes),
+    (; is.R, is.T_i, is.fluxes.SW_d, is.fluxes.LW_d, is.T_sfc_new),
+)
 
 # SurfaceFluxes evaluation with skin-temperature diagnosis for one sea-ice
 # polygon. Polygons without ice short-circuit to zero flux. Mirrors the nodal

--- a/ext/ClimaCouplerCMIPExt/oceananigans.jl
+++ b/ext/ClimaCouplerCMIPExt/oceananigans.jl
@@ -878,6 +878,10 @@ precipitation. The rest will be updated in `update_turbulent_fluxes!`.
 This function sets the surface fluxes directly, overwriting any previous values.
 Additional contributions will be made in `update_turbulent_fluxes!` and `ocean_seaice_fluxes!`.
 
+When the exchange grid is active, the work is done per polygon in
+[`push_exchange_radiation_to_ocean!`](@ref); the fallback below remaps with
+`sim.remapping`, whose regridder is unaware of the immersed mask.
+
 A note on sign conventions:
 ClimaAtmos and Oceananigans both use the convention that a positive flux is an upward flux.
 No sign change is needed during the exchange, except for precipitation/salinity fluxes.
@@ -896,6 +900,10 @@ function FieldExchanger.update_sim!(sim::OceananigansSimulation, csf)
     OC.interior(oc_flux_T, :, :, 1) .= 0
     oc_flux_S = surface_flux(sim.ocean.model.tracers.S)
     OC.interior(oc_flux_S, :, :, 1) .= 0
+
+    if sim.remapping.use_exchange_grid
+        return push_exchange_radiation_to_ocean!(sim, csf)
+    end
 
     # Remap shortwave and longwave onto separate scratch fields
     Interfacer.remap!(sim.remapping.scratch_field_oc3, csf.SW_d, sim.remapping)
@@ -936,6 +944,68 @@ function FieldExchanger.update_sim!(sim::OceananigansSimulation, csf)
     OC.interior(oc_flux_S, :, :, 1) .-=
         OC.interior(sim.ocean.model.tracers.S, :, :, Nz) .* ocean_precipitation ./
         reference_density
+    return nothing
+end
+
+"""
+    push_exchange_radiation_to_ocean!(sim::OceananigansSimulation, csf)
+
+Exchange-grid form of the radiative and freshwater part of
+[`FieldExchanger.update_sim!`](@ref): gather the downwelling radiation and
+precipitation onto the polygons, weight them by the open-water fraction
+`(1 - SIC)` *per polygon*, and scatter the result onto the tracer flux BCs.
+Only wet polygons exist, so dry cells receive exactly nothing. Assumes the 
+tracer flux BCs have just been zeroed.
+"""
+NVTX.@annotate function push_exchange_radiation_to_ocean!(sim::OceananigansSimulation, csf)
+    remapping = sim.remapping
+    eg = remapping.exchange_grid
+    fs = remapping.ocean_flux_state
+    grid = sim.ocean.model.grid
+    Nz = grid.Nz
+    FT = eltype(fs.T_sfc)
+    ρ_ref = FT(sim.ocean_properties.reference_density)
+    c_p = FT(sim.ocean_properties.heat_capacity)
+    σ = FT(sim.ocean_properties.σ)
+    C_to_K = FT(sim.ocean_properties.C_to_K)
+    α = FT(Interfacer.get_field(sim, Val(:surface_direct_albedo))) # scalar
+    ϵ = FT(Interfacer.get_field(sim, Val(:emissivity))) # scalar
+
+    # `update_sim!` runs before `compute_surface_fluxes!` in a coupling step,
+    # so the surface state gathered there is one step stale here: re-gather.
+    gather_cells_to_polys!(
+        fs.T_sfc,
+        eg,
+        vec(OC.interior(sim.ocean.model.tracers.T, :, :, Nz)),
+    )
+    fs.T_sfc .+= C_to_K
+    gather_cells_to_polys!(fs.sic, eg, vec(OC.interior(sim.ice_concentration, :, :, 1)))
+    gather_nodes_to_polys!(fs.SW_d, eg, se_nodal_vec(csf.SW_d))
+    gather_nodes_to_polys!(fs.LW_d, eg, se_nodal_vec(csf.LW_d))
+    gather_nodes_to_polys!(fs.P_liq, eg, se_nodal_vec(csf.P_liq))
+    gather_nodes_to_polys!(fs.P_snow, eg, se_nodal_vec(csf.P_snow))
+
+    # TODO: Note, SW radiation penetrates the surface. Right now, we just put
+    # everything on the surface, but later we will need to account for this.
+    @. fs.scratch1 =
+        (1 - fs.sic) * (-(1 - α) * fs.SW_d - ϵ * (fs.LW_d - σ * fs.T_sfc^4)) / (ρ_ref * c_p)
+    rad_cells = vec(OC.interior(remapping.scratch_field_oc3, :, :, 1))
+    scatter_polys_to_cells!(rad_cells, eg, fs.scratch1)
+    mirror_fold_partners!(rad_cells, grid)
+    oc_flux_T = surface_flux(sim.ocean.model.tracers.T)
+    OC.interior(oc_flux_T, :, :, 1) .+= OC.interior(remapping.scratch_field_oc3, :, :, 1)
+
+    # Rain drains through ice while snow can accumulate there (see the sea-ice
+    # `update_sim!`). Note the negative sign below to account for the sign
+    # change from precipitation to salinity flux.
+    @. fs.scratch1 = (fs.P_liq + (1 - fs.sic) * fs.P_snow) / ρ_ref
+    precip_cells = vec(OC.interior(remapping.scratch_field_oc3, :, :, 1))
+    scatter_polys_to_cells!(precip_cells, eg, fs.scratch1)
+    mirror_fold_partners!(precip_cells, grid)
+    oc_flux_S = surface_flux(sim.ocean.model.tracers.S)
+    OC.interior(oc_flux_S, :, :, 1) .-=
+        OC.interior(sim.ocean.model.tracers.S, :, :, Nz) .*
+        OC.interior(remapping.scratch_field_oc3, :, :, 1)
     return nothing
 end
 


### PR DESCRIPTION
Currently, turbulent fluxes are exchanged on the intersection grid in the CMIP setup, but we missed radiation and precipitation.