### PR TITLE
Replace DataLayouts.AbstractData, removed in ClimaCore v0.16

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ ClimaCoupler.jl Release Notes
 `main`
 -------
 
+#### Replace `DataLayouts.AbstractData`, removed in ClimaCore v0.16
+`ClimaCore.DataLayouts.AbstractData` was an alias for `DataLayout` kept for
+backwards compatibility, and ClimaCore v0.16 removes it. The nine uses here —
+in `Checkpointer.restore!`, `Checkpointer.is_leaf`, and the `_compare` helpers
+of the AMIP and CMIP experiment tests — now spell it `DataLayout`. The two are
+the same type, so this is a spelling change only.
+
 #### Exchange (intersection) grid for CMIP surface fractions and fluxes. PR [#2051](https://github.com/CliMA/ClimaCoupler.jl/pull/2051)
 When coupling to an Oceananigans ocean, ClimaCoupler now builds the exchange
 grid — the polygons where the cubed-sphere spectral elements intersect the

--- a/experiments/test/compare_amip.jl
+++ b/experiments/test/compare_amip.jl
@@ -174,11 +174,11 @@ function _compare(
     v2::T;
     name,
     ignore,
-) where {T <: CC.Fields.Field{<:CC.DataLayouts.AbstractData{<:Real}}}
+) where {T <: CC.Fields.Field{<:CC.DataLayouts.DataLayout{<:Real}}}
     return _compare(parent(v1), parent(v2); name, ignore)
 end
 
-function _compare(pass, v1::T, v2::T; name, ignore) where {T <: CC.DataLayouts.AbstractData}
+function _compare(pass, v1::T, v2::T; name, ignore) where {T <: CC.DataLayouts.DataLayout}
     return pass && _compare(parent(v1), parent(v2); name, ignore)
 end
 

--- a/experiments/test/compare_cmip.jl
+++ b/experiments/test/compare_cmip.jl
@@ -224,11 +224,11 @@ function _compare(
     v2::T;
     name,
     ignore,
-) where {T <: CC.Fields.Field{<:CC.DataLayouts.AbstractData{<:Real}}}
+) where {T <: CC.Fields.Field{<:CC.DataLayouts.DataLayout{<:Real}}}
     return _compare(parent(v1), parent(v2); name, ignore)
 end
 
-function _compare(pass, v1::T, v2::T; name, ignore) where {T <: CC.DataLayouts.AbstractData}
+function _compare(pass, v1::T, v2::T; name, ignore) where {T <: CC.DataLayouts.DataLayout}
     return pass && _compare(parent(v1), parent(v2); name, ignore)
 end
 

--- a/src/Checkpointer.jl
+++ b/src/Checkpointer.jl
@@ -554,8 +554,8 @@ end
 
 """
     restore!(
-        v1::Union{CC.DataLayouts.AbstractData, AbstractArray},
-        v2::Union{CC.DataLayouts.AbstractData, AbstractArray},
+        v1::Union{CC.DataLayouts.DataLayout, AbstractArray},
+        v2::Union{CC.DataLayouts.DataLayout, AbstractArray},
         comms_ctx;
         name = "",
         ignore = Set(),
@@ -566,8 +566,8 @@ device of the new data (v1). Then we copy the original data to
 the new object.
 """
 function restore!(
-    v1::Union{CC.DataLayouts.AbstractData, AbstractArray},
-    v2::Union{CC.DataLayouts.AbstractData, AbstractArray},
+    v1::Union{CC.DataLayouts.DataLayout, AbstractArray},
+    v2::Union{CC.DataLayouts.DataLayout, AbstractArray},
     comms_ctx;
     name = "",
     ignore = Set(),
@@ -778,7 +778,7 @@ Returns `true` if the object should be saved and `false` otherwise.
 
 This function is used by `CacheIterator`.
 """
-is_leaf(::Union{CC.DataLayouts.AbstractData, AbstractArray}) = true # Needed for saving data
+is_leaf(::Union{CC.DataLayouts.DataLayout, AbstractArray}) = true # Needed for saving data
 
 # Needed for error handling
 is_leaf(


### PR DESCRIPTION
note: I had claude do this update



`ClimaCore.DataLayouts.AbstractData` was an alias for `DataLayout`, kept for backwards compatibility when the DataLayouts module was rewritten in ClimaCore v0.15.0. ClimaCore v0.16 removes it (CliMA/ClimaCore.jl#2633), so this spells it `DataLayout`. The two are the same type — a spelling change only.

This is the fix for the `downstream ClimaCoupler.jl` failure on CliMA/ClimaCore.jl#2633, which currently errors with `UndefVarError: AbstractData not defined in ClimaCore.DataLayouts`.

## Changes

Nine uses across three files:

- `src/Checkpointer.jl` (5) — `restore!`'s signature and docstring, and `is_leaf`
- `experiments/test/compare_amip.jl` (2) — the `_compare` helpers
- `experiments/test/compare_cmip.jl` (2) — the `_compare` helpers

A full sweep of the repo for every name ClimaCore v0.16 removes found nothing else: no Geometry aliases (`AxisTensor`, `AxisVector`, `Axis2Tensor`, the generic `*Axis{I}`, `Geometry.components` on tensors), no `IJFH`/`IJHF`, no `ColumnField`, no single-argument `level(field)`, no `WeakDivergence`/`WeakGradient`/`WeakCurl`, no `LeftBiased*`/`RightBiased*`, no `{First,Third}OrderOneSided`, no `PointCloud*`/`PointColumnEnsemble*`, no `MatrixFields.⋅`, and no `RecursiveApply`.

(`src/CalibrationTools.jl` matches a substring search for "AbstractData", but those are this repo's own `AbstractDataLoader` and are unrelated.)

